### PR TITLE
Add cypress tests for case listing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,11 +72,14 @@
       }
     },
     {
-      "files": ["cypress/**/*.js"],
+      "files": ["cypress/**/*.ts"],
       "extends": ["plugin:cypress/recommended"],
       "rules": {
         "no-console": "off",
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        "@typescript-eslint/naming-convention": "off",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-non-null-assertion": "off"
       }
     }
   ]

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,23 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/naming-convention */
 import { defineConfig } from "cypress"
+import CourtCase from "entities/CourtCase"
+import deleteFromTable from "./test/testFixtures/database/deleteFromTable"
+import { insertCourtCasesWithOrgCodes } from "./test/testFixtures/database/insertCourtCases"
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:4080/bichard"
+    baseUrl: "http://localhost:4080/bichard",
+    setupNodeEvents(on, _config) {
+      on("task", {
+        insertCourtCasesWithOrgCodes(orgCodes: string[]) {
+          return insertCourtCasesWithOrgCodes(orgCodes)
+        },
+
+        clearCourtCases() {
+          return deleteFromTable(CourtCase)
+        }
+      })
+    }
   }
 })

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "cypress"
 import CourtCase from "entities/CourtCase"
 import deleteFromTable from "./test/testFixtures/database/deleteFromTable"
 import { insertCourtCasesWithOrgCodes } from "./test/testFixtures/database/insertCourtCases"
+import { deleteUsers, insertUsers, TestUser } from "./test/testFixtures/database/manageUsers"
 
 export default defineConfig({
   e2e: {
@@ -16,6 +17,14 @@ export default defineConfig({
 
         clearCourtCases() {
           return deleteFromTable(CourtCase)
+        },
+
+        insertUsers(users: TestUser[]) {
+          return insertUsers(users)
+        },
+
+        clearUsers() {
+          return deleteUsers()
         }
       })
     }

--- a/cypress/e2e/assets.cy.ts
+++ b/cypress/e2e/assets.cy.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 describe("GOV.UK Assets", () => {
   it("should provide copyright logo", () => {
     cy.setAuthCookie("Bichard01")

--- a/cypress/e2e/assets.cy.ts
+++ b/cypress/e2e/assets.cy.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 describe("GOV.UK Assets", () => {
   it("should provide copyright logo", () => {
     cy.setAuthCookie("Bichard01")
@@ -17,7 +19,7 @@ describe("GOV.UK Assets", () => {
         // cy.request automatically uses Cypress' defined baseUrl, which
         // includes /users already - so we need to strip it out here to get it
         // to work
-        const iconUrl = iconHref.replace("/bichard/", "/")
+        const iconUrl = (iconHref as unknown as string).replace("/bichard", "")
         cy.request({
           url: iconUrl,
           failOnStatusCode: false
@@ -28,3 +30,5 @@ describe("GOV.UK Assets", () => {
       })
   })
 })
+
+export {}

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,19 +1,36 @@
+import type { TestUser } from "../../test/testFixtures/database/manageUsers"
+
 describe("Home", () => {
   context("720p resolution", () => {
     beforeEach(() => {
       cy.task("clearCourtCases")
+      cy.task("clearUsers")
       cy.clearCookies()
     })
 
+    const users: TestUser[] = [
+      {
+        id: 1,
+        username: "Bichard01",
+        visibleForces: ["001"],
+        forenames: "Bichard Test User",
+        surname: "01",
+        email: "bichard01@example.com"
+      }
+    ]
+
     it("should display 0 cases and the user's username when no cases are added", () => {
       cy.setAuthCookie("Bichard01")
+      cy.task("insertUsers", users)
       cy.visit("/")
       cy.get("caption").should("have.text", "0 court cases for Bichard01")
     })
 
     it("should display a case for the user's org", () => {
       cy.setAuthCookie("Bichard01")
+      cy.task("insertUsers", users)
       cy.task("insertCourtCasesWithOrgCodes", ["01"])
+
       cy.visit("/")
       cy.get("caption").should("have.text", "1 court cases for Bichard01")
     })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,8 +1,22 @@
 describe("Home", () => {
-  it("should display 0 cases and the user's username when no cases are added", () => {
-    cy.setAuthCookie("Bichard01")
-    cy.visit("/")
-    cy.get("caption").should("have.text", "0 court cases for Bichard01")
+  context("720p resolution", () => {
+    beforeEach(() => {
+      cy.task("clearCourtCases")
+      cy.clearCookies()
+    })
+
+    it("should display 0 cases and the user's username when no cases are added", () => {
+      cy.setAuthCookie("Bichard01")
+      cy.visit("/")
+      cy.get("caption").should("have.text", "0 court cases for Bichard01")
+    })
+
+    it("should display a case for the user's org", () => {
+      cy.setAuthCookie("Bichard01")
+      cy.task("insertCourtCasesWithOrgCodes", ["01"])
+      cy.visit("/")
+      cy.get("caption").should("have.text", "1 court cases for Bichard01")
+    })
   })
 })
 

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -19,37 +19,69 @@ describe("Home", () => {
     })
 
     it("should display 0 cases and the user's username when no cases are added", () => {
-      cy.setAuthCookie("Bichard01")
       cy.task("insertUsers", users)
+      cy.setAuthCookie("Bichard01")
+
       cy.visit("/")
       cy.get("caption").should("have.text", "0 court cases for Bichard01")
     })
 
     it("should display a case for the user's org", () => {
-      cy.setAuthCookie("Bichard01")
       cy.task("insertUsers", users)
       cy.task("insertCourtCasesWithOrgCodes", ["01"])
+      cy.setAuthCookie("Bichard01")
 
       cy.visit("/")
       cy.get("caption").should("have.text", "1 court cases for Bichard01")
+      cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00000`)
     })
 
     it("should only display cases visible to users forces", () => {
-      cy.setAuthCookie("Bichard02")
       cy.task("insertUsers", users)
       cy.task("insertCourtCasesWithOrgCodes", ["01", "02", "03", "04"])
+      cy.setAuthCookie("Bichard02")
 
       cy.visit("/")
       cy.get("caption").should("have.text", "1 court cases for Bichard02")
+      cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00001`)
     })
 
     it("should display cases for sub-forces", () => {
-      cy.setAuthCookie("Bichard01")
       cy.task("insertUsers", users)
       cy.task("insertCourtCasesWithOrgCodes", ["01", "011", "012A", "013A1"])
+      cy.setAuthCookie("Bichard01")
 
       cy.visit("/")
       cy.get("caption").should("have.text", "4 court cases for Bichard01")
+      cy.get("tr")
+        .not(":first")
+        .each((row, index) => {
+          cy.wrap(row).get("td:nth-child(2)").contains(`Case0000${index}`)
+      })
+    })
+
+    it("should display cases for parent forces up to the second-level force", () => {
+      cy.task("insertUsers", [
+        {
+          username: "Bichard01",
+          visibleForces: ["0011111"],
+          forenames: "Bichard Test User",
+          surname: "01",
+          email: "bichard01@example.com"
+        }
+      ])
+      cy.task("insertCourtCasesWithOrgCodes", ["01", "011", "0111", "01111", "011111"])
+      cy.setAuthCookie("Bichard01")
+
+      cy.visit("/")
+      cy.get("caption").should("have.text", "3 court cases for Bichard01")
+      cy.get("tr")
+        .not(":first")
+        .each((row, index) => {
+          cy.wrap(row)
+            .get("td:nth-child(2)")
+            .contains(`Case0000${index + 2}`)
+        })
     })
   })
 })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -11,7 +11,7 @@ describe("Home", () => {
     const users: TestUser[] = Array.from(Array(5)).map((_value, idx) => {
       return {
         username: `Bichard0${idx}`,
-        visibleForces: [`00${idx}`],
+        visibleForces: [`0${idx}`],
         forenames: "Bichard Test User",
         surname: `0${idx}`,
         email: `bichard0${idx}@example.com`
@@ -64,7 +64,7 @@ describe("Home", () => {
       cy.task("insertUsers", [
         {
           username: "Bichard01",
-          visibleForces: ["0011111"],
+          visibleForces: ["011111"],
           forenames: "Bichard Test User",
           surname: "01",
           email: "bichard01@example.com"

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -5,3 +5,5 @@ describe("Home", () => {
     cy.get("caption").should("have.text", "0 court cases for Bichard01")
   })
 })
+
+export {}

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -8,16 +8,15 @@ describe("Home", () => {
       cy.clearCookies()
     })
 
-    const users: TestUser[] = [
-      {
-        id: 1,
-        username: "Bichard01",
-        visibleForces: ["001"],
+    const users: TestUser[] = Array.from(Array(5)).map((_value, idx) => {
+      return {
+        username: `Bichard0${idx}`,
+        visibleForces: [`00${idx}`],
         forenames: "Bichard Test User",
-        surname: "01",
-        email: "bichard01@example.com"
+        surname: `0${idx}`,
+        email: `bichard0${idx}@example.com`
       }
-    ]
+    })
 
     it("should display 0 cases and the user's username when no cases are added", () => {
       cy.setAuthCookie("Bichard01")
@@ -33,6 +32,24 @@ describe("Home", () => {
 
       cy.visit("/")
       cy.get("caption").should("have.text", "1 court cases for Bichard01")
+    })
+
+    it("should only display cases visible to users forces", () => {
+      cy.setAuthCookie("Bichard02")
+      cy.task("insertUsers", users)
+      cy.task("insertCourtCasesWithOrgCodes", ["01", "02", "03", "04"])
+
+      cy.visit("/")
+      cy.get("caption").should("have.text", "1 court cases for Bichard02")
+    })
+
+    it("should display cases for sub-forces", () => {
+      cy.setAuthCookie("Bichard01")
+      cy.task("insertUsers", users)
+      cy.task("insertCourtCasesWithOrgCodes", ["01", "011", "012A", "013A1"])
+
+      cy.visit("/")
+      cy.get("caption").should("have.text", "4 court cases for Bichard01")
     })
   })
 })

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "types": ["cypress"]
+    "types": ["node", "cypress"]
   },
   "include": ["**/*.*"]
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -8,6 +8,9 @@ export default class User extends BaseEntity {
   username!: string
 
   @Column()
+  email!: string
+
+  @Column()
   forenames?: string
 
   @Column()

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, PrimaryColumn } from "typeorm"
 import BaseEntity from "./BaseEntity"
-import delimeterStringTransfomer from "./transformers/delimeterStringTransfomer"
+import delimitedPrefixedString from "./transformers/delimitedPrefixedString"
 
 @Entity({ name: "users" })
 export default class User extends BaseEntity {
@@ -16,6 +16,6 @@ export default class User extends BaseEntity {
   @Column()
   surname?: string
 
-  @Column({ name: "visible_forces", transformer: delimeterStringTransfomer(","), type: "varchar" })
+  @Column({ name: "visible_forces", transformer: delimitedPrefixedString(",", "0"), type: "varchar" })
   visibleForces!: string[]
 }

--- a/src/entities/transformers/delimeterStringTransfomer.ts
+++ b/src/entities/transformers/delimeterStringTransfomer.ts
@@ -1,8 +1,0 @@
-import { ValueTransformer } from "typeorm"
-
-const delimeterStringTransfomer = (delimeter: string): ValueTransformer => ({
-  to: (value: string[]) => value.join(delimeter),
-  from: (value?: string) => value?.split(delimeter) ?? []
-})
-
-export default delimeterStringTransfomer

--- a/src/entities/transformers/delimitedPrefixedString.ts
+++ b/src/entities/transformers/delimitedPrefixedString.ts
@@ -1,0 +1,8 @@
+import { ValueTransformer } from "typeorm"
+
+const delimitedPrefixedString = (delimeter: string, prefix: string): ValueTransformer => ({
+  to: (value: string[]) => value.map((f) => prefix + f).join(delimeter),
+  from: (value?: string) => value?.split(delimeter).map((f) => f.substring(prefix.length)) ?? []
+})
+
+export default delimitedPrefixedString

--- a/src/useCases/listCourtCases.ts
+++ b/src/useCases/listCourtCases.ts
@@ -16,8 +16,7 @@ const listCourtCases = async (dataSource: DataSource, forces: string[], limit: n
     return query.getMany().catch((error: Error) => error)
   }
 
-  forces.forEach((f, i) => {
-    const force = f.substring(1)
+  forces.forEach((force, i) => {
     const args: KeyValuePair<string, string> = {}
     args[`force${i}`] = force
     // use different named parameters for each force

--- a/src/useCases/listCourtCases.ts
+++ b/src/useCases/listCourtCases.ts
@@ -4,8 +4,8 @@ import PromiseResult from "../types/PromiseResult"
 import KeyValuePair from "../types/KeyValuePair"
 import getColumnName from "../lib/getColumnName"
 
-const listCourtCases = async (connection: DataSource, forces: string[], limit: number): PromiseResult<CourtCase[]> => {
-  const courtCaseRepository = connection.getRepository(CourtCase)
+const listCourtCases = async (dataSource: DataSource, forces: string[], limit: number): PromiseResult<CourtCase[]> => {
+  const courtCaseRepository = dataSource.getRepository(CourtCase)
   const query = courtCaseRepository
     .createQueryBuilder("courtCase")
     .orderBy(getColumnName(courtCaseRepository, "errorId"), "ASC")

--- a/test/UseCases/listCourtCases.integration.test.ts
+++ b/test/UseCases/listCourtCases.integration.test.ts
@@ -27,7 +27,7 @@ describe("listCourtCases", () => {
   it("shouldn't return more cases than the specified limit", async () => {
     await insertCourtCasesWithOrgCodes(Array.from(Array(100)).map(() => "36FPA1"))
 
-    const result = await listCourtCases(dataSource, ["036FPA1"], 10)
+    const result = await listCourtCases(dataSource, ["36FPA1"], 10)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -57,7 +57,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(dataSource, ["03"], 100)
+    const result = await listCourtCases(dataSource, ["3"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -91,7 +91,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(dataSource, ["036"], 100)
+    const result = await listCourtCases(dataSource, ["36"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -123,7 +123,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(dataSource, ["036F"], 100)
+    const result = await listCourtCases(dataSource, ["36F"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -148,7 +148,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(dataSource, ["036FP"], 100)
+    const result = await listCourtCases(dataSource, ["36FP"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -160,7 +160,7 @@ describe("listCourtCases", () => {
   it("a user with a visible force of length 5 can see cases for the 4-long prefix, and the exact match, and 6-long suffixes of the visible force", async () => {
     await insertCourtCasesWithOrgCodes(["12GH", "12LK", "12G", "12GHB", "12GHA", "12GHAB", "12GHAC", "13BR", "14AT"])
 
-    const result = await listCourtCases(dataSource, ["012GHA"], 100)
+    const result = await listCourtCases(dataSource, ["12GHA"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -189,7 +189,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(dataSource, ["036FPA1"], 100)
+    const result = await listCourtCases(dataSource, ["36FPA1"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -221,7 +221,7 @@ describe("listCourtCases", () => {
       "13GHBA"
     ])
 
-    const result = await listCourtCases(dataSource, ["036FPA1", "013GH"], 100)
+    const result = await listCourtCases(dataSource, ["36FPA1", "13GH"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 

--- a/test/UseCases/listCourtCases.integration.test.ts
+++ b/test/UseCases/listCourtCases.integration.test.ts
@@ -3,31 +3,17 @@ import "reflect-metadata"
 import { expect } from "@jest/globals"
 import listCourtCases from "../../src/useCases/listCourtCases"
 import deleteFromTable from "../testFixtures/database/deleteFromTable"
-import CourtCaseCase from "../testFixtures/database/data/error_list.json"
-import insertCourtCases from "../testFixtures/database/insertCourtCases"
+import { insertCourtCasesWithOrgCodes } from "../testFixtures/database/insertCourtCases"
 import { isError } from "../../src/types/Result"
 import CourtCase from "../../src/entities/CourtCase"
 import { DataSource } from "typeorm"
 import getDataSource from "../../src/lib/getDataSource"
 
-const insertRecords = (orgsCodes: string[]) => {
-  const existingCourtCases = orgsCodes.map((code, i) => {
-    return {
-      ...CourtCaseCase,
-      org_for_police_filter: code.padEnd(6, " "),
-      error_id: i,
-      message_id: String(i).padStart(5, "x")
-    }
-  })
-
-  return insertCourtCases(existingCourtCases)
-}
-
 describe("listCourtCases", () => {
-  let connection: DataSource
+  let dataSource: DataSource
 
   beforeAll(async () => {
-    connection = await getDataSource()
+    dataSource = await getDataSource()
   })
 
   beforeEach(async () => {
@@ -35,13 +21,13 @@ describe("listCourtCases", () => {
   })
 
   afterAll(async () => {
-    await connection.destroy()
+    await dataSource.destroy()
   })
 
   it("shouldn't return more cases than the specified limit", async () => {
-    await insertRecords(Array.from(Array(100)).map(() => "36FPA1"))
+    await insertCourtCasesWithOrgCodes(Array.from(Array(100)).map(() => "36FPA1"))
 
-    const result = await listCourtCases(connection, ["036FPA1"], 10)
+    const result = await listCourtCases(dataSource, ["036FPA1"], 10)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -54,7 +40,7 @@ describe("listCourtCases", () => {
   })
 
   it("should return a list of cases when the force code length is 1", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "3",
       "36",
       "36F",
@@ -71,7 +57,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(connection, ["03"], 100)
+    const result = await listCourtCases(dataSource, ["03"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -90,7 +76,7 @@ describe("listCourtCases", () => {
   })
 
   it("should return a list of cases when the force code length is 2", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -105,7 +91,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(connection, ["036"], 100)
+    const result = await listCourtCases(dataSource, ["036"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -122,7 +108,7 @@ describe("listCourtCases", () => {
   })
 
   it("should return a list of cases when the force code length is 3", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -137,7 +123,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(connection, ["036F"], 100)
+    const result = await listCourtCases(dataSource, ["036F"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -147,7 +133,7 @@ describe("listCourtCases", () => {
   })
 
   it("should return a list of cases when the force code length is 4", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -162,7 +148,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(connection, ["036FP"], 100)
+    const result = await listCourtCases(dataSource, ["036FP"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -172,9 +158,9 @@ describe("listCourtCases", () => {
   })
 
   it("a user with a visible force of length 5 can see cases for the 4-long prefix, and the exact match, and 6-long suffixes of the visible force", async () => {
-    await insertRecords(["12GH", "12LK", "12G", "12GHB", "12GHA", "12GHAB", "12GHAC", "13BR", "14AT"])
+    await insertCourtCasesWithOrgCodes(["12GH", "12LK", "12G", "12GHB", "12GHA", "12GHAB", "12GHAC", "13BR", "14AT"])
 
-    const result = await listCourtCases(connection, ["012GHA"], 100)
+    const result = await listCourtCases(dataSource, ["012GHA"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -187,7 +173,7 @@ describe("listCourtCases", () => {
   })
 
   it("shouldn't return non-visible cases when the force code length is 6", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -203,7 +189,7 @@ describe("listCourtCases", () => {
       "12GHAC"
     ])
 
-    const result = await listCourtCases(connection, ["036FPA1"], 100)
+    const result = await listCourtCases(dataSource, ["036FPA1"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -214,7 +200,7 @@ describe("listCourtCases", () => {
   })
 
   it("should show cases for all forces visible to a user", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -235,7 +221,7 @@ describe("listCourtCases", () => {
       "13GHBA"
     ])
 
-    const result = await listCourtCases(connection, ["036FPA1", "013GH"], 100)
+    const result = await listCourtCases(dataSource, ["036FPA1", "013GH"], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 
@@ -255,7 +241,7 @@ describe("listCourtCases", () => {
   })
 
   it("should show no cases to a user with no visible forces", async () => {
-    await insertRecords([
+    await insertCourtCasesWithOrgCodes([
       "36",
       "36F",
       "36FP",
@@ -276,7 +262,7 @@ describe("listCourtCases", () => {
       "13GHBA"
     ])
 
-    const result = await listCourtCases(connection, [], 100)
+    const result = await listCourtCases(dataSource, [], 100)
     expect(isError(result)).toBe(false)
     const cases = result as CourtCase[]
 

--- a/test/testFixtures/database/deleteFromTable.ts
+++ b/test/testFixtures/database/deleteFromTable.ts
@@ -2,9 +2,9 @@ import getDataSource from "../../../src/lib/getDataSource"
 import { EntityTarget, ObjectLiteral } from "typeorm"
 
 const deleteFromTable = async (entity: EntityTarget<ObjectLiteral>) => {
-  const connection = await getDataSource()
+  const dataSource = await getDataSource()
 
-  return connection.getRepository(entity).createQueryBuilder().delete().execute()
+  return dataSource.getRepository(entity).createQueryBuilder().delete().execute()
 }
 
 export default deleteFromTable

--- a/test/testFixtures/database/insertCourtCases.ts
+++ b/test/testFixtures/database/insertCourtCases.ts
@@ -92,7 +92,8 @@ const insertCourtCasesWithOrgCodes = (orgsCodes: string[]) => {
       ...CourtCaseCase,
       org_for_police_filter: code.padEnd(6, " "),
       error_id: i,
-      message_id: String(i).padStart(5, "x")
+      message_id: String(i).padStart(5, "x"),
+      ptiurn: "Case" + String(i).padStart(5, "0")
     }
   })
 

--- a/test/testFixtures/database/insertCourtCases.ts
+++ b/test/testFixtures/database/insertCourtCases.ts
@@ -1,4 +1,5 @@
 import getDataSource from "../../../src/lib/getDataSource"
+import CourtCaseCase from "./data/error_list.json"
 
 const insertCourtCases = async <T>(data: T[]): Promise<null[]> => {
   const dataSource = await getDataSource()
@@ -85,4 +86,17 @@ const insertCourtCases = async <T>(data: T[]): Promise<null[]> => {
   return Promise.all(data.map((datum) => dataSource.manager.query(insertQuery, Object.values(datum))))
 }
 
-export default insertCourtCases
+const insertCourtCasesWithOrgCodes = (orgsCodes: string[]) => {
+  const existingCourtCases = orgsCodes.map((code, i) => {
+    return {
+      ...CourtCaseCase,
+      org_for_police_filter: code.padEnd(6, " "),
+      error_id: i,
+      message_id: String(i).padStart(5, "x")
+    }
+  })
+
+  return insertCourtCases(existingCourtCases)
+}
+
+export { insertCourtCases, insertCourtCasesWithOrgCodes }

--- a/test/testFixtures/database/manageUsers.ts
+++ b/test/testFixtures/database/manageUsers.ts
@@ -1,0 +1,35 @@
+import User from "entities/User"
+import getDataSource from "lib/getDataSource"
+
+type TestUser = {
+  id: number
+  username: string
+  visibleForces: string[]
+  forenames: string
+  surname: string
+  email: string
+}
+
+const insertUsers = async (users: TestUser[]): Promise<boolean> => {
+  const dataSource = await getDataSource()
+
+  await dataSource.createQueryBuilder().insert().into(User).values(users).execute()
+
+  await dataSource.destroy()
+
+  return true
+}
+
+const deleteUsers = async (): Promise<boolean> => {
+  const dataSource = await getDataSource()
+
+  await dataSource.manager.query(`DELETE FROM br7own.users_groups`)
+  await dataSource.manager.query(`DELETE FROM br7own.users`)
+
+  await dataSource.destroy()
+
+  return true
+}
+
+export type { TestUser }
+export { insertUsers, deleteUsers }

--- a/test/testFixtures/database/manageUsers.ts
+++ b/test/testFixtures/database/manageUsers.ts
@@ -2,7 +2,6 @@ import User from "entities/User"
 import getDataSource from "lib/getDataSource"
 
 type TestUser = {
-  id: number
   username: string
   visibleForces: string[]
   forenames: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "baseUrl": "./src",
     "incremental": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
+    "experimentalDecorators": true
   },
   "include": [
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "baseUrl": "./src",
     "incremental": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
This PR:
* Adds more test cases for listing cases, particularly cases for parent and sub-forces
* Creates the users and cases for a test in the test
* Migrates all cypress code to typescript
* Removes the visible force prefix at ORM-level with a transformer