### PR TITLE
fix: 🐛 remove unneeded goss tests

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -114,9 +114,3 @@ process:
     running: true
   supervisord:
     running: true
-http:
-  https://localhost/bichard:
-    request-headers:
-      - "X-Origin: http://localhost:4080"
-    status: 200
-    allow-insecure: true


### PR DESCRIPTION
We are testing this logic in cypress so we don't need to test it in goss too, it's failing because we have to authenticate (jwt) before reaching the site.