### PR TITLE
Enable filtering cases work without JS

### DIFF
--- a/src/components/CourtCaseFilter.tsx
+++ b/src/components/CourtCaseFilter.tsx
@@ -1,41 +1,29 @@
-import { Button, GridCol, GridRow, Link, Select } from "govuk-react"
-import { useState } from "react"
+import { Button, Select } from "govuk-react"
 import { Filter } from "types/CaseListQueryParams"
 
 const queryParamToFilterState = (value: string) =>
   (value === "triggers" || value === "exceptions" ? value : undefined) as Filter
 
 const CourtCaseFilter = (props: { initialSelection: Filter }) => {
-  const [currentSelection, setCurrentSelection] = useState(props.initialSelection)
-
   return (
-    <GridRow>
-      <GridCol>
-        <Select
-          label={"Filter cases"}
-          input={{
-            value: currentSelection,
-            onChange: (e) => setCurrentSelection(queryParamToFilterState(e.target.value)),
-            id: "case-filter-select"
-          }}
-        >
-          <option value={""} selected={!currentSelection}>
-            {"Show all cases"}
-          </option>
-          <option value={"triggers"} selected={currentSelection === "triggers"}>
-            {"Show only cases with triggers"}
-          </option>
-          <option value={"exceptions"} selected={currentSelection === "exceptions"}>
-            {"Show only cases with exceptions"}
-          </option>
-        </Select>
-      </GridCol>
-      <GridCol>
-        <Link href={`/bichard?filter=${currentSelection}`}>
-          <Button id={"case-filter-button"}>{"Filter"}</Button>
-        </Link>
-      </GridCol>
-    </GridRow>
+    <form method={"get"}>
+      <Select
+        label={"Filter cases"}
+        input={{
+          id: "case-filter-select",
+          name: "filter",
+          defaultValue: props.initialSelection,
+          className: "form-control"
+        }}
+      >
+        <option value={""}>{"Show all cases"}</option>
+        <option value={"triggers"}>{"Show only cases with triggers"}</option>
+        <option value={"exceptions"}>{"Show only cases with exceptions"}</option>
+      </Select>
+      <Button type={"submit"} id={"case-filter-button"}>
+        {"Filter"}
+      </Button>
+    </form>
   )
 }
 


### PR DESCRIPTION
This PR changes the filter to use a form with a GET submission instead of changing the destination of the button link. The form submits to the case listing page and sets the `filter` query parameter