### PR TITLE
Add support for IE11

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,2 @@
+defaults
+ie 7-11

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,12 @@
 {
-  "presets": ["next/babel"],
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-env": {}
+      }
+    ]
+  ],
   "plugins": [
     "babel-plugin-transform-typescript-metadata",
     ["@babel/plugin-proposal-decorators", { "legacy": true }]

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
+// Transpile some modules which use modern syntax to make them compatible with legacy browsers
+const withTM = require("next-transpile-modules")(["hex-rgb", "is-plain-obj"])
+
 const nextConfig = {
   basePath: "/bichard",
   reactStrictMode: true
 }
 
-module.exports = nextConfig
+module.exports = withTM(nextConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "babel-plugin-transform-typescript-metadata": "^0.3.2",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.5",
+        "date-time-format-timezone": "^1.0.22",
         "govuk-frontend": "^4.2.0",
         "govuk-react": "^0.10.1",
         "next": "12.1.6",
@@ -63,8 +64,10 @@
         "jest": "^27.5.1",
         "jsonwebtoken": "^8.5.1",
         "lint-staged": "^13.0.3",
+        "next-transpile-modules": "^9.0.0",
         "npm-check-updates": "^15.0.1",
         "prettier": "^2.7.1",
+        "react-app-polyfill": "^3.0.0",
         "sass": "^1.53.0",
         "storybook-addon-designs": "^6.3.1",
         "ts-jest": "^27.0.4",
@@ -11918,6 +11921,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -15563,6 +15572,11 @@
       "peerDependencies": {
         "date-fns": ">=2.0.0"
       }
+    },
+    "node_modules/date-time-format-timezone": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/date-time-format-timezone/-/date-time-format-timezone-1.0.22.tgz",
+      "integrity": "sha512-4hEeKPpNlbFO05ldht9FwJEy2g1xL7kU3dTPY5hNSd1AyMjrrIeUS54kSWgt/KdttYshhjDMIonU+vCmL4NjVw=="
     },
     "node_modules/dayjs": {
       "version": "1.11.3",
@@ -26637,6 +26651,38 @@
         }
       }
     },
+    "node_modules/next-transpile-modules": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz",
+      "integrity": "sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==",
+      "dev": true,
+      "dependencies": {
+        "enhanced-resolve": "^5.7.0",
+        "escalade": "^3.1.1"
+      }
+    },
+    "node_modules/next-transpile-modules/node_modules/enhanced-resolve": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/next-transpile-modules/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -28991,6 +29037,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -29277,6 +29332,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -29434,6 +29498,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-app-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
+      "integrity": "sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.19.2",
+        "object-assign": "^4.1.1",
+        "promise": "^8.1.0",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.9",
+        "whatwg-fetch": "^3.6.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/react-docgen": {
@@ -35169,6 +35250,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
@@ -44387,6 +44474,12 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -47288,6 +47381,11 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.5.tgz",
       "integrity": "sha512-SNhl/fWe7i2HoIB9ejLZhEEJ6ZtRRpOBbzizFrq11K2/iceS9Nk7fPN2VTYVOMgFB9u0f3eidSC4n1xaRONW2A==",
       "requires": {}
+    },
+    "date-time-format-timezone": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/date-time-format-timezone/-/date-time-format-timezone-1.0.22.tgz",
+      "integrity": "sha512-4hEeKPpNlbFO05ldht9FwJEy2g1xL7kU3dTPY5hNSd1AyMjrrIeUS54kSWgt/KdttYshhjDMIonU+vCmL4NjVw=="
     },
     "dayjs": {
       "version": "1.11.3",
@@ -55954,6 +56052,34 @@
         "styled-jsx": "5.0.2"
       }
     },
+    "next-transpile-modules": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz",
+      "integrity": "sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==",
+      "dev": true,
+      "requires": {
+        "enhanced-resolve": "^5.7.0",
+        "escalade": "^3.1.1"
+      },
+      "dependencies": {
+        "enhanced-resolve": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+          "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.2.0"
+          }
+        },
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "dev": true
+        }
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -57766,6 +57892,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.6"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -57988,6 +58123,15 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -58110,6 +58254,20 @@
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "react-app-polyfill": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
+      "integrity": "sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.19.2",
+        "object-assign": "^4.1.1",
+        "promise": "^8.1.0",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.9",
+        "whatwg-fetch": "^3.6.2"
       }
     },
     "react-docgen": {
@@ -62558,6 +62716,12 @@
           }
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "govuk-frontend": "^4.2.0",
     "govuk-react": "^0.10.1",
     "next": "12.1.6",
+    "next-transpile-modules": "^9.0.0",
     "pg": "^8.7.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.5",
+    "date-time-format-timezone": "^1.0.22",
     "govuk-frontend": "^4.2.0",
     "govuk-react": "^0.10.1",
     "next": "12.1.6",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import "date-time-format-timezone"
 import type { AppProps } from "next/app"
 
 function MyApp({ Component, pageProps }: AppProps) {


### PR DESCRIPTION
This PR:
* sets babel options to transpile the built client-side JS to be IE11-compatible using the `preset-env` plugin and a browsers list
* transpiles client-side modules using syntax too new for IE11
* adds polyfills for JS features we use which are missing from IE11

I've tested this on a local windows 7 VM for now, but plan to write automated tests using BrowserStack to run as part of the CI shortly

![image](https://user-images.githubusercontent.com/7249529/180782811-8e26dbd4-1655-4020-ac0e-e88d9a1c2693.png)
