### PR TITLE
Stop installing devDependencies for production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src/ui
 
 COPY . ./
 
-RUN npm ci && \
+RUN npm ci --production && \
     npm run install:assets
 
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
Changed `npm ci` to `npm ci --production` to stop installing dev dependencies.

This will hopefully 🤞 fix the failing codebuild job which is running out of memory due to the size of our node_modules I think