### PR TITLE
Fix build script to not fail if $AWS_ACCOUNT_ID is not set

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -26,7 +26,7 @@ function pull_and_build_from_aws() {
 
   echo "Building ui docker image on `date`"
 
-  if [[ -z "${AWS_ACCOUNT_ID}" ]]; then
+  if [[ -z ${AWS_ACCOUNT_ID+""} ]]; then
       AWS_ACCOUNT_ID=$FETCHED_AWS_ACCOUNT_ID
   fi
 


### PR DESCRIPTION
CI was breaking on other repos because it couldn't find the `AWS_ACCOUNT_ID` envvar

https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash