### PR TITLE
Fix build script 2: Unbound envvar boogaloo

### DIFF
--- a/.circleci/scripts/build-ui.sh
+++ b/.circleci/scripts/build-ui.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Building UI ..."
 
 # Build UI

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -50,7 +50,7 @@ else
     docker build --build-arg "BUILD_IMAGE=${DOCKER_IMAGE_HASH}" -t ui .
 fi
 
-  if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
+  if [[ -n ${CODEBUILD_RESOLVED_SOURCE_VERSION+""} && -n ${CODEBUILD_START_TIME+""} ]]; then
 
       ## Install goss/trivy
       curl -L https://github.com/aelsabbahy/goss/releases/latest/download/goss-linux-amd64 -o /usr/local/bin/goss


### PR DESCRIPTION
Fix another unbound environment variable in a bash if. This wasn't caught in the last PR due to `set -e` not being set, so the Makefile build failed silently