### PR TITLE
Turn off cypress video processing for large test speedup

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -76,5 +76,6 @@ export default defineConfig({
       })
     }
   },
-  chromeWebSecurity: false
+  chromeWebSecurity: false,
+  video: false
 })


### PR DESCRIPTION
Cypress currently records, compresses, and saves videos of all the tests it runs. This takes a good while, and isn't really that useful.