### PR TITLE
Add urgent marker to case listing and details screen

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,9 +53,12 @@
           "error",
           {
             "selector": "variableLike",
-            "format": ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"]
+            "format": ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"],
+            "argsIgnorePattern": "^_+$",
+            "varsIgnorePattern": "^_+$"
           }
-        ]
+        ],
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_+$", "varsIgnorePattern": "^_+$" }]
       }
     },
     {
@@ -77,7 +80,6 @@
         "import/no-extraneous-dependencies": "off",
         "import/prefer-default-export": "off",
         "@typescript-eslint/no-non-null-assertion": "off"
-
       }
     },
     {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,8 @@ import {
   insertCourtCasesWithDefendantNames,
   insertCourtCasesWithOrgCodes,
   insertMultipleDummyCourtCases,
-  insertDummyCourtCaseWithLock
+  insertDummyCourtCaseWithLock,
+  insertDummyCourtCasesWithUrgencies
 } from "./test/util/insertCourtCases"
 import { insertTriggers } from "./test/util/manageTriggers"
 import insertException from "./test/util/manageExceptions"
@@ -75,6 +76,10 @@ export default defineConfig({
             params.triggerLockedByUsername,
             params.orgCodes
           )
+        },
+
+        insertCourtCasesWithUrgencies(params: { urgencies: boolean[]; force: string }) {
+          return insertDummyCourtCasesWithUrgencies(params.urgencies, params.force)
         },
 
         insertCourtCases(params: { courtCases: CourtCase[] }) {

--- a/cypress/e2e/court-cases/caseDetails.cy.ts
+++ b/cypress/e2e/court-cases/caseDetails.cy.ts
@@ -108,6 +108,13 @@ describe("Case details", () => {
       // Notes
       cy.get("H3").contains("Notes")
       cy.get("p").contains("Case has no notes.")
+
+      // Urgency
+      cy.get("th")
+        .contains("Urgency")
+        .then(($cell) => {
+          expect($cell.parent().find("td").text()).to.equal("Urgent")
+        })
     })
 
     it("should return 404 for a case that this user can not see", () => {

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -297,6 +297,19 @@ describe("Home", () => {
         cy.url().should("match", /\/bichard/)
         cy.findByText("Court cases").should("exist")
       })
+
+      it("Should display the urgent badge on cases marked as urgent", () => {
+        cy.task("insertUsers", users)
+        cy.task("insertCourtCasesWithUrgencies", { urgencies: [true, false, true], force: "01" })
+
+        cy.login("bichard01@example.com", "password")
+        cy.visit("/bichard")
+
+        cy.get("tr").not(":first").eq(0).get("td:nth-child(2)").contains(`Case00000`)
+        cy.get("tr").not(":first").eq(0).contains(`Urgent`).should("exist")
+        cy.get("tr").not(":first").eq(1).contains(`Urgent`).should("not.exist")
+        cy.get("tr").not(":first").eq(2).contains(`Urgent`).should("exist")
+      })
     })
   })
 })

--- a/src/features/CourtCaseDetails/CourtCaseDetails.stories.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.stories.tsx
@@ -25,7 +25,8 @@ const courtCase = {
   ptiurn: "42CY0300107",
   triggerReason: "TRPR0006",
   triggers: [{ triggerCode: "TRPR0001", triggerId: 0 } as unknown as Trigger],
-  courtDate: new Date("2008-09-26")
+  courtDate: new Date("2008-09-26"),
+  isUrgent: false
 } as unknown as CourtCase
 
 const aho = parseAhoXml(CourtCaseAho.hearingOutcomeXml) as AnnotatedHearingOutcome
@@ -46,6 +47,7 @@ DetailsNotLockedByAnotherUser.play = ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).toBeInTheDocument()
   expect(canvas.getByText("Add Note")).toBeInTheDocument()
+  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
 }
 
 export const DetailsLockedByAnotherUser: ComponentStory<typeof CourtCaseDetails> = () => (
@@ -64,6 +66,7 @@ DetailsLockedByAnotherUser.play = ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).toBeInTheDocument()
   expect(canvas.queryByText("Add Note")).not.toBeInTheDocument()
+  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
 }
 
 export const TriggersNotVisibleToUser: ComponentStory<typeof CourtCaseDetails> = () => (
@@ -82,4 +85,5 @@ TriggersNotVisibleToUser.play = async ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).not.toBeInTheDocument()
   expect(canvas.getByText("Add Note")).toBeInTheDocument()
+  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
 }

--- a/src/features/CourtCaseDetails/CourtCaseDetails.stories.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.stories.tsx
@@ -26,7 +26,7 @@ const courtCase = {
   triggerReason: "TRPR0006",
   triggers: [{ triggerCode: "TRPR0001", triggerId: 0 } as unknown as Trigger],
   courtDate: new Date("2008-09-26"),
-  isUrgent: false
+  isUrgent: true
 } as unknown as CourtCase
 
 const aho = parseAhoXml(CourtCaseAho.hearingOutcomeXml) as AnnotatedHearingOutcome
@@ -47,7 +47,7 @@ DetailsNotLockedByAnotherUser.play = ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).toBeInTheDocument()
   expect(canvas.getByText("Add Note")).toBeInTheDocument()
-  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
+  expect(canvas.getByText("Urgent")).toBeInTheDocument()
 }
 
 export const DetailsLockedByAnotherUser: ComponentStory<typeof CourtCaseDetails> = () => (
@@ -66,7 +66,7 @@ DetailsLockedByAnotherUser.play = ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).toBeInTheDocument()
   expect(canvas.queryByText("Add Note")).not.toBeInTheDocument()
-  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
+  expect(canvas.getByText("Urgent")).toBeInTheDocument()
 }
 
 export const TriggersNotVisibleToUser: ComponentStory<typeof CourtCaseDetails> = () => (
@@ -85,5 +85,5 @@ TriggersNotVisibleToUser.play = async ({ canvasElement }) => {
   ).toHaveLength(2)
   expect(canvas.queryByText("Resolve trigger")).not.toBeInTheDocument()
   expect(canvas.getByText("Add Note")).toBeInTheDocument()
-  expect(canvas.getByText("Non-urgent")).toBeInTheDocument()
+  expect(canvas.getByText("Urgent")).toBeInTheDocument()
 }

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -4,7 +4,7 @@ import If from "components/If"
 import HearingOutcome from "components/HearingOutcome"
 import ResolveTrigger from "components/ResolveTrigger"
 import LinkButton from "components/LinkButton"
-import { Heading, Paragraph, Table } from "govuk-react"
+import { Heading, Paragraph, Table, Tag } from "govuk-react"
 import CourtCase from "services/entities/CourtCase"
 
 interface Props {
@@ -32,6 +32,13 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         <Table.CellHeader>{"Court date"}</Table.CellHeader>
         <Table.Cell>
           <DateTime date={courtCase.courtDate} dateFormat="dd/MM/yyyy" />
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.CellHeader>{"Urgency"}</Table.CellHeader>
+        <Table.Cell>
+          {courtCase.isUrgent && <Tag tint="RED">{"Urgent"}</Tag>}
+          {!courtCase.isUrgent && <Tag tint="GREY">{"Non-urgent"}</Tag>}
         </Table.Cell>
       </Table.Row>
       <Table.Row>

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -38,7 +38,6 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         <Table.CellHeader>{"Urgency"}</Table.CellHeader>
         <Table.Cell>
           {courtCase.isUrgent && <Tag tint="RED">{"Urgent"}</Tag>}
-          {!courtCase.isUrgent && <Tag tint="GREY">{"Non-urgent"}</Tag>}
         </Table.Cell>
       </Table.Row>
       <Table.Row>

--- a/src/features/CourtCaseList/CourtCaseList.stories.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.stories.tsx
@@ -34,9 +34,9 @@ EmptyList.play = async ({ canvasElement }) => {
 
 export const OneRecord: ComponentStory<typeof CourtCaseList> = () => <CourtCaseList courtCases={[courtCase]} />
 
-export const ManyRecords: ComponentStory<typeof CourtCaseList> = () => (
-  <CourtCaseList courtCases={new Array(100).fill(courtCase)} />
-)
+const courtCases = new Array(100).fill(courtCase)
+export const ManyRecords: ComponentStory<typeof CourtCaseList> = () => <CourtCaseList courtCases={courtCases} />
+
 ManyRecords.parameters = {
   design: [
     {
@@ -50,4 +50,27 @@ ManyRecords.parameters = {
       url: "https://www.figma.com/file/HwIQgyZQtsCxxDxitpKvvI/B7?node-id=0%3A1"
     }
   ]
+}
+
+ManyRecords.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+
+  const urgentTags = await canvas.findAllByText("Urgent")
+  expect(urgentTags).toHaveLength(courtCases.length)
+}
+
+const mixedUrgencies: CourtCase[] = new Array(10).fill(0).map((_, index) => {
+  const urgencyCourtCase = Object.assign({}, courtCase)
+  if (index % 2 === 0) {
+    urgencyCourtCase.isUrgent = false
+  }
+  return urgencyCourtCase
+})
+export const MixedUrgencies: ComponentStory<typeof CourtCaseList> = () => <CourtCaseList courtCases={mixedUrgencies} />
+
+MixedUrgencies.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+
+  const urgentTags = await canvas.findAllByText("Urgent")
+  expect(urgentTags).toHaveLength(mixedUrgencies.filter((c) => c.isUrgent).length)
 }

--- a/src/features/CourtCaseList/CourtCaseList.stories.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.stories.tsx
@@ -21,7 +21,8 @@ const courtCase = {
   ptiurn: "42CY0300107",
   triggerReason: "TRPR0006",
   triggers: [{ triggerCode: "TRPR0001" } as unknown as Trigger],
-  courtDate: new Date("2008-09-26")
+  courtDate: new Date("2008-09-26"),
+  isUrgent: true
 } as unknown as CourtCase
 
 export const EmptyList: ComponentStory<typeof CourtCaseList> = () => <CourtCaseList courtCases={[]} />

--- a/src/features/CourtCaseList/CourtCaseList.stories.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.stories.tsx
@@ -56,7 +56,7 @@ ManyRecords.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
 
   const urgentTags = await canvas.findAllByText("Urgent")
-  expect(urgentTags).toHaveLength(courtCases.length)
+  expect(urgentTags).toHaveLength(courtCases.length + 1) // The column header also matches this
 }
 
 const mixedUrgencies: CourtCase[] = new Array(10).fill(0).map((_, index) => {
@@ -72,5 +72,5 @@ MixedUrgencies.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
 
   const urgentTags = await canvas.findAllByText("Urgent")
-  expect(urgentTags).toHaveLength(mixedUrgencies.filter((c) => c.isUrgent).length)
+  expect(urgentTags).toHaveLength(mixedUrgencies.filter((c) => c.isUrgent).length + 1) // The column header also matches this
 }

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router"
 import CourtCase from "services/entities/CourtCase"
-import { Paragraph, Table, Link } from "govuk-react"
+import { Paragraph, Table, Link, Tag } from "govuk-react"
 import DateTime from "components/DateTime"
 import type { QueryOrder } from "types/CaseListQueryParams"
 
@@ -38,6 +38,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
           {"Court Name"}
         </Link>
       </Table.CellHeader>
+      <Table.CellHeader>{"Urgent"}</Table.CellHeader>
       <Table.CellHeader>{"Triggers"}</Table.CellHeader>
       <Table.CellHeader>
         <Link href={orderByParams("errorReason")} id="exceptions">
@@ -46,24 +47,27 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
       </Table.CellHeader>
     </Table.Row>
   )
-  const tableBody = courtCases.map(({ courtDate, ptiurn, defendantName, courtName, triggers, errorReason }, idx) => {
-    return (
-      <Table.Row key={idx}>
-        <Table.Cell>
-          <DateTime date={courtDate} />
-        </Table.Cell>
-        <Table.Cell>{ptiurn}</Table.Cell>
-        <Table.Cell>
-          <Link href={caseDetailsPath(courtCases[idx].errorId)} id={`Case details for ${defendantName}`}>
-            {defendantName}
-          </Link>
-        </Table.Cell>
-        <Table.Cell>{courtName}</Table.Cell>
-        <Table.Cell>{triggers?.map((trigger) => trigger.triggerCode).join(", ")}</Table.Cell>
-        <Table.Cell>{errorReason}</Table.Cell>
-      </Table.Row>
-    )
-  })
+  const tableBody = courtCases.map(
+    ({ courtDate, ptiurn, defendantName, courtName, triggers, errorReason, isUrgent }, idx) => {
+      return (
+        <Table.Row key={idx}>
+          <Table.Cell>
+            <DateTime date={courtDate} />
+          </Table.Cell>
+          <Table.Cell>{ptiurn}</Table.Cell>
+          <Table.Cell>
+            <Link href={caseDetailsPath(courtCases[idx].errorId)} id={`Case details for ${defendantName}`}>
+              {defendantName}
+            </Link>
+          </Table.Cell>
+          <Table.Cell>{courtName}</Table.Cell>
+          <Table.Cell>{isUrgent && <Tag tint="RED">{"Urgent"}</Tag>}</Table.Cell>
+          <Table.Cell>{triggers?.map((trigger) => trigger.triggerCode).join(", ")}</Table.Cell>
+          <Table.Cell>{errorReason}</Table.Cell>
+        </Table.Row>
+      )
+    }
+  )
 
   if (courtCases.length === 0) {
     return <Paragraph>{"There are no court cases to show"}</Paragraph>

--- a/src/services/entities/CourtCase.ts
+++ b/src/services/entities/CourtCase.ts
@@ -7,6 +7,7 @@ import Note from "./Note"
 import Trigger from "./Trigger"
 import resolutionStatusTransformer from "./transformers/resolutionStatusTransformer"
 import type { ResolutionStatus } from "types/ResolutionStatus"
+import booleanIntTransformer from "./transformers/booleanIntTransformer"
 
 @Entity({ name: "error_list" })
 export default class CourtCase extends BaseEntity {
@@ -34,8 +35,8 @@ export default class CourtCase extends BaseEntity {
   @Column({ name: "trigger_count" })
   triggerCount!: number
 
-  @Column({ name: "is_urgent", type: "int2" })
-  urgency!: number
+  @Column({ name: "is_urgent", type: "int2", transformer: booleanIntTransformer })
+  isUrgent!: boolean
 
   @Column({ name: "asn", type: "varchar", nullable: true })
   asn!: string | null

--- a/src/services/entities/transformers/booleanIntTransformer.ts
+++ b/src/services/entities/transformers/booleanIntTransformer.ts
@@ -1,0 +1,8 @@
+import { ValueTransformer } from "typeorm"
+
+const booleanIntTransformer: ValueTransformer = {
+  to: (value) => (value ? 1 : 0),
+  from: (value) => value !== 0
+}
+
+export default booleanIntTransformer

--- a/test/util/DummyCourtCase.ts
+++ b/test/util/DummyCourtCase.ts
@@ -17,7 +17,7 @@ const DummyCourtCase: Partial<CourtCase> = {
   triggerCount: 0,
   errorLockedByUsername: null,
   triggerLockedByUsername: null,
-  urgency: 1,
+  isUrgent: true,
   asn: "0836FP0100000377244A",
   courtCode: "B42AZ01",
   updatedHearingOutcome: null,

--- a/test/util/insertCourtCases.ts
+++ b/test/util/insertCourtCases.ts
@@ -131,6 +131,22 @@ const insertDummyCourtCaseWithLock = async (
   return insertCourtCases(existingCourtCases)
 }
 
+const insertDummyCourtCasesWithUrgencies = async (urgencies: boolean[], orgCode: string) => {
+  const existingCourtCases: CourtCase[] = await Promise.all(
+    urgencies.map((urgency, index) =>
+      getDummyCourtCase({
+        orgForPoliceFilter: orgCode,
+        errorId: index,
+        messageId: String(index).padStart(5, "x"),
+        ptiurn: "Case" + String(index).padStart(5, "0"),
+        isUrgent: urgency
+      })
+    )
+  )
+
+  return insertCourtCases(existingCourtCases)
+}
+
 export {
   getDummyCourtCase,
   insertCourtCases,
@@ -139,5 +155,6 @@ export {
   insertCourtCasesWithCourtDates,
   insertCourtCasesWithDefendantNames,
   insertMultipleDummyCourtCases,
-  insertDummyCourtCaseWithLock
+  insertDummyCourtCaseWithLock,
+  insertDummyCourtCasesWithUrgencies
 }


### PR DESCRIPTION
This is implemented using a [GDS Tag component](https://design-system.service.gov.uk/components/tag/), and is shown for cases marked urgent in the database (`is_urgent` column being non-zero).

This functionality is tested with storybook and cypress end-to-end tests.

## Screenshots

#### Case listing screen
![Screenshot 2022-10-17 at 13 47 44](https://user-images.githubusercontent.com/7249529/196180905-7ac6847c-a0e4-4c55-b79a-f6da1c582995.png)

#### Case detail screen
![Screenshot 2022-10-17 at 13 48 29](https://user-images.githubusercontent.com/7249529/196181081-89ae3c8a-7886-4038-acfd-b70bcc5c8d0e.png)