### PR TITLE
New UI asset 404

### DIFF
--- a/cypress/e2e/assets.cy.ts
+++ b/cypress/e2e/assets.cy.ts
@@ -29,6 +29,7 @@ describe("GOV.UK Assets", () => {
   })
 
   it("should provide favicon icon that loads correctly", () => {
+    cy.visit("/bichard")
     cy.get("link[rel='shortcut icon']")
       .should("have.attr", "href")
       .then((iconHref) => {

--- a/cypress/e2e/assets.cy.ts
+++ b/cypress/e2e/assets.cy.ts
@@ -28,20 +28,18 @@ describe("GOV.UK Assets", () => {
       .should("have.attr", "image", "[object Object]")
   })
 
-  it("should provide favicon icon that loads correctly", () => {
+  it.only("should provide favicon icon that loads correctly", () => {
     cy.visit("/bichard")
     cy.get("link[rel='shortcut icon']")
       .should("have.attr", "href")
       .then((iconHref) => {
-        // cy.request automatically uses Cypress' defined baseUrl, which
-        // includes /users already - so we need to strip it out here to get it
-        // to work
-        const iconUrl = (iconHref as unknown as string).replace("/bichard", "")
+        const iconUrl = iconHref as unknown as string
         cy.request({
           url: iconUrl,
           failOnStatusCode: false
         }).then((resp) => {
           expect(resp.status).not.to.equal(404)
+          expect(resp.status).to.equal(200)
           expect(resp.body).not.to.equal(undefined)
         })
       })

--- a/scripts/copy-govuk-frontend-assets.sh
+++ b/scripts/copy-govuk-frontend-assets.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPTS_DIR=$(dirname "$0")
 REPO_ROOT=$(dirname "$SCRIPTS_DIR")
 
-ASSETS_SOURCE="${REPO_ROOT}/node_modules/govuk-frontend/govuk/assets"
+ASSETS_SOURCE="${REPO_ROOT}/node_modules/govuk-frontend/govuk/assets/*"
 ASSETS_DESTINATION="${REPO_ROOT}/public/govuk_assets"
 
 if [ ! -d $ASSETS_SOURCE ]; then

--- a/scripts/copy-moj-frontend-assets.sh
+++ b/scripts/copy-moj-frontend-assets.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPTS_DIR=$(dirname "$0")
 REPO_ROOT=$(dirname "$SCRIPTS_DIR")
 
-MOJ_ASSETS_SOURCE="${REPO_ROOT}/node_modules/@ministryofjustice/frontend/moj/assets"
+MOJ_ASSETS_SOURCE="${REPO_ROOT}/node_modules/@ministryofjustice/frontend/moj/assets/*"
 MOJ_ASSETS_DESTINATION="${REPO_ROOT}/public/moj_assets"
 
 if [ ! -d $MOJ_ASSETS_SOURCE ]; then

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,6 +2,7 @@ import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitia
 import React from "react"
 import generateCsp from "utils/generateCsp"
 import generateNonce from "utils/generateNonce"
+import { basePath } from "../../next.config"
 
 const GovUkMetadata = () => {
   return (
@@ -15,28 +16,28 @@ const GovUkMetadata = () => {
       <link
         rel="shortcut icon"
         sizes="16x16 32x32 48x48"
-        href={`bichard/govuk_assets/images/favicon.ico`}
+        href={`${basePath}/govuk_assets/images/favicon.ico`}
         type="image/x-icon"
       />
-      <link rel="mask-icon" href={`bichard/govuk_assets/images/govuk-mask-icon.svg`} color="#0b0c0c" />
+      <link rel="mask-icon" href={`${basePath}/govuk_assets/images/govuk-mask-icon.svg`} color="#0b0c0c" />
       <link
         rel="apple-touch-icon"
         sizes="180x180"
-        href={`bichard/govuk_assets/images/govuk-apple-touch-icon-180x180.png`}
+        href={`${basePath}/govuk_assets/images/govuk-apple-touch-icon-180x180.png`}
       />
       <link
         rel="apple-touch-icon"
         sizes="167x167"
-        href={`bichard/govuk_assets/images/govuk-apple-touch-icon-167x167.png`}
+        href={`${basePath}/govuk_assets/images/govuk-apple-touch-icon-167x167.png`}
       />
       <link
         rel="apple-touch-icon"
         sizes="152x152"
-        href={`bichard/govuk_assets/images/govuk-apple-touch-icon-152x152.png`}
+        href={`${basePath}/govuk_assets/images/govuk-apple-touch-icon-152x152.png`}
       />
-      <link rel="apple-touch-icon" href={`bichard/govuk_assets/images/govuk-apple-touch-icon.png`} />
+      <link rel="apple-touch-icon" href={`${basePath}/govuk_assets/images/govuk-apple-touch-icon.png`} />
 
-      <meta property="og:image" content={`bichard/govuk_assets/images/govuk-opengraph-image.png`} />
+      <meta property="og:image" content={`${basePath}/govuk_assets/images/govuk-opengraph-image.png`} />
     </>
   )
 }

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -146,7 +146,6 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
         <Heading as="h1" size="LARGE" aria-label="Case details">
           <title>{"Case Details | Bichard7"}</title>
           <meta name="description" content="Case Details | Bichard7" />
-          <link rel="icon" href="/favicon.ico" />
         </Heading>
         <BackLink href={`${basePath}`} onClick={function noRefCheck() {}}>
           {"Cases"}

--- a/src/pages/court-cases/[courtCaseId]/notes/add.tsx
+++ b/src/pages/court-cases/[courtCaseId]/notes/add.tsx
@@ -82,7 +82,6 @@ const CourtCaseDetailsPage: NextPage<Props> = ({ courtCase, user, lockedByAnothe
         <Heading as="h1" size="LARGE" aria-label="Add Note">
           <title>{"Add Note | Bichard7"}</title>
           <meta name="description" content="Add Note | Bichard7" />
-          <link rel="icon" href="/favicon.ico" />
         </Heading>
         <BackLink href={`${basePath}/court-cases/${courtCase.errorId}`} onClick={function noRefCheck() {}}>
           {"Case Details"}


### PR DESCRIPTION
This PR fixes the broken path links for `govuk_assets` and `moj_assets` assets.

- updated asset copy scripts to only copy over assets and not folder.
- updated cypress test newUI assets (was on userService). 
- used `basePath` for asset links, rather than hard coding. 