### PR TITLE
Refactor: make wait for images script generic and reuse in cypress test build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,8 +207,8 @@ jobs:
           name: Retrying installing Cypress
           command: ./.circleci/scripts/install-cypress.sh
       - run:
-          name: Wait for UI build to finish
-          command: until [ -f uiBuilt ]; do sleep 1; done
+          name: Wait for docker images
+          command: IMAGES=(ui user-service nginx-auth-proxy) && bash ./scripts/wait_for_images.sh "${IMAGES[@]}"
           no_output_timeout: 15m
       - run:
           name: Run MQ
@@ -262,7 +262,8 @@ jobs:
           image: beanconnect
       - run:
           name: Wait for docker images
-          command: bash ./scripts/wait_for_images.sh
+          command: IMAGES=(ui user-service nginx-auth-proxy e2etests pncemulator beanconnect) && bash ./scripts/wait_for_images.sh "${IMAGES[@]}"
+          no_output_timeout: 15m
       - run:
           name: Run full stack (excluding beanconnect and PNC emulator)
           working_directory: ~/bichard7-next

--- a/.circleci/scripts/build-ui.sh
+++ b/.circleci/scripts/build-ui.sh
@@ -6,5 +6,3 @@ echo "Building UI ..."
 
 # Build UI
 make build
-
-touch uiBuilt

--- a/scripts/wait_for_images.sh
+++ b/scripts/wait_for_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-array=( ui user-service nginx-auth-proxy e2etests pncemulator beanconnect )
+array=("$@")
 for i in "${array[@]}"
 do
   image=`docker image ls | grep -w -c $i`;


### PR DESCRIPTION
The `build_and_cypress_test ` pipeline pulls images in the background but only waits for the UI build, this could fail the pipeline if the UI build is faster. Made the `wait_for_images` script generic and reused in the build.