### PR TITLE
Added prototype phase banner to newUI

### DIFF
--- a/cypress/e2e/court-cases/notes/add.cy.ts
+++ b/cypress/e2e/court-cases/notes/add.cy.ts
@@ -130,7 +130,7 @@ describe("Case details", () => {
 
       cy.url().should("match", /.*\/court-cases\/0\/notes\/add\?#/)
       cy.get("H2").should("have.text", "Add Note")
-      cy.get("span").eq(1).should("have.text", "Required")
+      cy.get("span").eq(2).should("have.text", "Required")
     })
 
     it("Adding an empty note doesn't add a note, when the case is visible to the user and not locked by another user", () => {

--- a/cypress/e2e/header.cy.ts
+++ b/cypress/e2e/header.cy.ts
@@ -59,7 +59,7 @@ describe("Home", () => {
       })
     })
     context("phase banner", () => {
-      it.only("displays a pahse banner", () => {
+      it("displays a phase banner", () => {
         cy.task("insertUsers", {
           users: [
             {

--- a/cypress/e2e/header.cy.ts
+++ b/cypress/e2e/header.cy.ts
@@ -58,6 +58,28 @@ describe("Home", () => {
         cy.contains("nav a", "Sign out").should("have.attr", "href", "/users/logout/")
       })
     })
+    context("phase banner", () => {
+      it.only("displays a pahse banner", () => {
+        cy.task("insertUsers", {
+          users: [
+            {
+              username: `generalhandler2`,
+              visibleForces: [`01`],
+              forenames: "Bichard Test User",
+              surname: `01`,
+              email: `generalhandler2@example.com`,
+              password:
+                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
+            }
+          ],
+          userGroups: ["B7NewUI_grp"]
+        })
+        cy.login("generalhandler2@example.com", "password")
+        cy.visit("/bichard")
+
+        cy.contains("prototype")
+      })
+    })
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-storybook": "^0.6.6",
         "http-server": "^14.1.1",
-        "husky": "^8.0.1",
+        "husky": "^8.0.2",
         "jest": "^29.2.0",
         "jest-axe": "^6.0.0",
         "jsonwebtoken": "^8.5.1",
@@ -39897,9 +39897,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -89288,9 +89288,9 @@
       }
     },
     "husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
       "dev": true
     },
     "hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-storybook": "^0.6.6",
     "http-server": "^14.1.1",
-    "husky": "^8.0.1",
+    "husky": "^8.0.2",
     "jest": "^29.2.0",
     "jest-axe": "^6.0.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import User from "../services/entities/User"
 import { useRouter } from "next/router"
 import Header from "./Header"
 import NavBar from "./NavBar"
+import PhaseBanner from "./PhaseBanner"
 
 interface Props {
   children: ReactNode
@@ -16,6 +17,7 @@ const Layout = ({ children, user }: Props) => {
     <>
       <Header serviceName={"Bichard7"} organisationName={"Minsitry of Justice"} userName={user.username} />
       <NavBar groups={user.groups} />
+      <PhaseBanner phase={"prototype"} />
     </>
   )
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,13 +17,15 @@ const Layout = ({ children, user }: Props) => {
     <>
       <Header serviceName={"Bichard7"} organisationName={"Minsitry of Justice"} userName={user.username} />
       <NavBar groups={user.groups} />
-      <PhaseBanner phase={"prototype"} />
     </>
   )
 
   return (
     <>
-      <Page header={header}>{children}</Page>
+      <Page header={header}>
+        <PhaseBanner phase={"prototype"} />
+        {children}
+      </Page>
       <Footer
         copyright={{
           image: {

--- a/src/components/PhaseBanner/PhaseBanner.tsx
+++ b/src/components/PhaseBanner/PhaseBanner.tsx
@@ -1,0 +1,22 @@
+interface PhaseBannerProps {
+  phase: string
+}
+
+const PhaseBanner: React.FC<PhaseBannerProps> = ({ phase }: PhaseBannerProps) => {
+  return (
+    <div className="govuk-phase-banner">
+      <p className="govuk-phase-banner__content">
+        <strong className="govuk-tag govuk-phase-banner__content__tag">{phase}</strong>
+        <span className="govuk-phase-banner__text">
+          {"This is a prototype. Content is likely to change rapidly –"}
+          {/* TODO: add feedback page link */}
+          <a className="govuk-link" href="/">
+            {"help us to improve it"}
+          </a>
+        </span>
+      </p>
+    </div>
+  )
+}
+
+export default PhaseBanner

--- a/src/components/PhaseBanner/index.ts
+++ b/src/components/PhaseBanner/index.ts
@@ -1,0 +1,2 @@
+import PhaseBanner from "./PhaseBanner"
+export default PhaseBanner

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,16 +1,15 @@
 interface Props {
   name: string
   id: string
-  key?: string
   dataAriaControls?: string
   defaultChecked: boolean
   value?: string
   label: string
 }
 
-const RadioButton: React.FC<Props> = ({ name, id, key, dataAriaControls, defaultChecked, value, label }: Props) => {
+const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultChecked, value, label }: Props) => {
   return (
-    <div className="govuk-radios__item" key={key}>
+    <div className="govuk-radios__item">
       <input
         className="govuk-radios__input"
         name={name}


### PR DESCRIPTION
This PR is to add a "prototype" phase banner onto the newUI. 
Component aligns with figma template.
https://www.figma.com/file/LHxGJpfSjuTczcqrFzUQNc/06_B7_22-Handover-hifi-case-list-screens?node-id=327%3A2603&t=aLBs0PmL0KxC0bB0-0