### PR TITLE
Filter cases by locked status

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -87,9 +87,9 @@ export default defineConfig({
 
         insertMultipleDummyCourtCasesWithLock(params: {
           lockHolders: { errorLockedByUsername?: string; triggerLockedByUsername?: string }[]
-          orgCodes: string[]
+          orgCode: string
         }) {
-          return insertMultipleDummyCourtCasesWithLock(params.lockHolders, params.orgCodes)
+          return insertMultipleDummyCourtCasesWithLock(params.lockHolders, params.orgCode)
         },
 
         insertCourtCasesWithUrgencies(params: { urgencies: boolean[]; force: string }) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,7 +10,8 @@ import {
   insertDummyCourtCaseWithLock,
   insertDummyCourtCasesWithUrgencies,
   insertDummyCourtCasesWithNotes,
-  insertCourtCasesWithCourtDates
+  insertCourtCasesWithCourtDates,
+  insertMultipleDummyCourtCasesWithLock
 } from "./test/utils/insertCourtCases"
 import { insertTriggers } from "./test/utils/manageTriggers"
 import insertException from "./test/utils/manageExceptions"
@@ -82,6 +83,13 @@ export default defineConfig({
             params.triggerLockedByUsername,
             params.orgCodes
           )
+        },
+
+        insertMultipleDummyCourtCasesWithLock(params: {
+          lockHolders: { errorLockedByUsername?: string; triggerLockedByUsername?: string }[]
+          orgCodes: string[]
+        }) {
+          return insertMultipleDummyCourtCasesWithLock(params.lockHolders, params.orgCodes)
         },
 
         insertCourtCasesWithUrgencies(params: { urgencies: boolean[]; force: string }) {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -351,6 +351,7 @@ describe("Case list", () => {
 
       cy.visit("/bichard")
 
+      // Filter for locked cases
       cy.get("button[id=filter-button]").click()
       cy.get("#locked").click()
       cy.get("button[id=search]").click()
@@ -358,21 +359,21 @@ describe("Case list", () => {
       cy.get("tr").not(":first").should("have.length", 1)
       cy.get("tr").not(":first").contains("Case00000").should("exist")
 
-      // Removing urgent filter tag all case should be shown with the filter disabled
-      // cy.get('*[class^="moj-filter-tags"]').contains("Urgent").click()
-      // cy.get("tr").not(":first").should("have.length", 4)
+      // Removing locked filter tag all case should be shown with the filter disabled
+      cy.get('*[class^="moj-filter-tags"]').contains("Locked").click()
+      cy.get("tr").not(":first").should("have.length", 2)
 
-      // // Filter for non-urgent cases
-      // cy.get("button[id=filter-button]").click()
-      // cy.get("#non-urgent").click()
-      // cy.get("button[id=search]").click()
+      // Filter for unlocked cases
+      cy.get("button[id=filter-button]").click()
+      cy.get("#unlocked").click()
+      cy.get("button[id=search]").click()
 
-      // cy.get("tr").not(":first").should("have.length", 1)
-      // cy.get("tr").contains("Case00001").should("exist")
+      cy.get("tr").not(":first").should("have.length", 1)
+      cy.get("tr").contains("Case00001").should("exist")
 
-      // // Removing non-urgent filter tag all case should be shown with the filter disabled
-      // cy.get('*[class^="moj-filter-tags"]').contains("Non-urgent").click()
-      // cy.get("tr").not(":first").should("have.length", 4)
+      // Removing unlocked filter tag all case should be shown with the filter disabled
+      cy.get('*[class^="moj-filter-tags"]').contains("Unlocked").click()
+      cy.get("tr").not(":first").should("have.length", 2)
     })
 
     it("Should clear filters", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -337,6 +337,44 @@ describe("Case list", () => {
       cy.get("tr").not(":first").should("have.length", 4)
     })
 
+    it.only("Should filter cases by locked state", () => {
+      cy.task("insertMultipleDummyCourtCasesWithLock", {
+        lockHolders: [
+          {
+            errorLockedByUsername: "Bichard01",
+            triggerLockedByUsername: "Bichard01"
+          },
+          {}
+        ],
+        orgCodes: ["011111"]
+      })
+
+      cy.visit("/bichard")
+
+      cy.get("button[id=filter-button]").click()
+      cy.get("#locked").click()
+      cy.get("button[id=search]").click()
+
+      cy.get("tr").not(":first").should("have.length", 1)
+      cy.get("tr").not(":first").contains("Case00000").should("exist")
+
+      // Removing urgent filter tag all case should be shown with the filter disabled
+      // cy.get('*[class^="moj-filter-tags"]').contains("Urgent").click()
+      // cy.get("tr").not(":first").should("have.length", 4)
+
+      // // Filter for non-urgent cases
+      // cy.get("button[id=filter-button]").click()
+      // cy.get("#non-urgent").click()
+      // cy.get("button[id=search]").click()
+
+      // cy.get("tr").not(":first").should("have.length", 1)
+      // cy.get("tr").contains("Case00001").should("exist")
+
+      // // Removing non-urgent filter tag all case should be shown with the filter disabled
+      // cy.get('*[class^="moj-filter-tags"]').contains("Non-urgent").click()
+      // cy.get("tr").not(":first").should("have.length", 4)
+    })
+
     it("Should clear filters", () => {
       cy.visit("/bichard")
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -346,7 +346,7 @@ describe("Case list", () => {
           },
           {}
         ],
-        orgCodes: ["011111"]
+        orgCode: "011111"
       })
 
       cy.visit("/bichard")

--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -1,7 +1,7 @@
-import { Filter } from "types/CaseListQueryParams"
+import { TriggerExceptionFilter } from "types/CaseListQueryParams"
 
 interface Props {
-  courtCaseTypes?: Filter[]
+  courtCaseTypes?: TriggerExceptionFilter[]
 }
 
 const courtCaseTypeOptions = ["Exceptions", "Triggers"]
@@ -19,7 +19,7 @@ const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes }: Props) => {
               name="type"
               type="checkbox"
               value={caseType}
-              defaultChecked={courtCaseTypes && courtCaseTypes.includes(caseType as Filter)}
+              defaultChecked={courtCaseTypes && courtCaseTypes.includes(caseType as TriggerExceptionFilter)}
             ></input>
             <label className="govuk-label govuk-checkboxes__label" htmlFor={`${caseType.toLowerCase()}-type`}>
               {caseType}

--- a/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
+++ b/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
@@ -20,7 +20,7 @@ const labelForDateRange = (namedDateRange: string): string =>
 const CourtDateFilterOptions: React.FC<Props> = ({ dateRange }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
-      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Court Date"}</legend>
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Court date"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
         <RadioButton
           name={"courtDate"}

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -18,7 +18,7 @@ const UrgencyFilterOptions: React.FC<Props> = ({ urgency }: Props) => {
             id={urgencyFilter.toLowerCase()}
             defaultChecked={urgency === urgencyFilter}
             value={urgencyFilter}
-            label={urgencyFilter}
+            label={urgencyFilter + " cases only"}
           />
         ))}
       </div>

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -1,0 +1,29 @@
+import RadioButton from "components/RadioButton/RadioButton"
+
+interface Props {
+  locked?: string | null
+}
+
+const LockedOptions = ["Locked", "Unlocked"]
+
+const LockedFilterOptions: React.FC<Props> = ({ locked }: Props) => {
+  return (
+    <fieldset className="govuk-fieldset">
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Locked state"}</legend>
+      <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
+        {LockedOptions.map((lockedFilter) => (
+          <RadioButton
+            name={"locked"}
+            key={lockedFilter.toLowerCase()}
+            id={lockedFilter.toLowerCase()}
+            defaultChecked={locked === lockedFilter}
+            value={lockedFilter}
+            label={lockedFilter + " cases only"}
+          />
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+export default LockedFilterOptions

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -1,12 +1,12 @@
 import FilterTag from "components/FilterTag/FilterTag"
 import If from "components/If"
 import { useRouter } from "next/router"
-import { Filter } from "types/CaseListQueryParams"
+import { TriggerExceptionFilter } from "types/CaseListQueryParams"
 import { deleteQueryParam, deleteQueryParamsByName } from "utils/deleteQueryParam"
 
 interface Props {
   filters: {
-    courtCaseTypes?: Filter[]
+    courtCaseTypes?: TriggerExceptionFilter[]
     keywords?: string[]
     dateRange?: string | null
     urgency?: string | null

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -10,6 +10,7 @@ interface Props {
     keywords?: string[]
     dateRange?: string | null
     urgency?: string | null
+    locked?: string | null
   }
 }
 
@@ -20,7 +21,8 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
     (filters.courtCaseTypes && filters.courtCaseTypes.length > 0) ||
     (filters.keywords && filters.keywords.length > 0) ||
     !!filters.urgency ||
-    !!filters.dateRange
+    !!filters.dateRange ||
+    !!filters.locked
 
   const removeQueryParamFromPath = (paramToRemove: { [key: string]: string }): string => {
     deleteQueryParamsByName(["pageNum"], query)
@@ -66,6 +68,11 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
                 tag={filters.urgency ?? ""}
                 href={removeQueryParamFromPath({ urgency: filters.urgency ?? "" })}
               />
+            </li>
+          </If>
+          <If condition={!!filters.locked}>
+            <li>
+              <FilterTag tag={filters.locked ?? ""} href={removeQueryParamFromPath({ locked: filters.locked ?? "" })} />
             </li>
           </If>
           <li>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,11 +1,11 @@
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
 import { HintText } from "govuk-react"
-import { Filter } from "types/CaseListQueryParams"
+import { TriggerExceptionFilter } from "types/CaseListQueryParams"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 
 interface Props {
-  courtCaseTypes?: Filter[]
+  courtCaseTypes?: TriggerExceptionFilter[]
   dateRange?: string | null
   urgency?: string | null
 }

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,5 +1,6 @@
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
+import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { TriggerExceptionFilter } from "types/CaseListQueryParams"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
@@ -8,9 +9,10 @@ interface Props {
   courtCaseTypes?: TriggerExceptionFilter[]
   dateRange?: string | null
   urgency?: string | null
+  locked?: string | null
 }
 
-const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency }: Props) => {
+const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
   return (
     <form method={"get"}>
       <div className="moj-filter__header">
@@ -46,6 +48,9 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency }
           </div>
           <div className="govuk-form-group">
             <UrgencyFilterOptions urgency={urgency} />
+          </div>
+          <div>
+            <LockedFilterOptions locked={locked} />
           </div>
         </div>
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import CourtCaseFilter from "features/CourtCaseFilters/CourtCaseFilter"
 import AppliedFilters from "features/CourtCaseFilters/AppliedFilters"
 import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
-import { Filter, QueryOrder, Urgency } from "types/CaseListQueryParams"
+import { TriggerExceptionFilter, QueryOrder, Urgency } from "types/CaseListQueryParams"
 import { isError } from "types/Result"
 import CourtCaseList from "features/CourtCaseList/CourtCaseList"
 import Layout from "components/Layout"
@@ -23,7 +23,7 @@ interface Props {
   user: User
   courtCases: CourtCase[]
   order: QueryOrder
-  courtCaseTypes: Filter[]
+  courtCaseTypes: TriggerExceptionFilter[]
   keywords: string[]
   urgentFilter: string | null
   totalPages: number
@@ -39,7 +39,9 @@ export const getServerSideProps = withMultipleServerSideProps(
   async (context: GetServerSidePropsContext<ParsedUrlQuery>): Promise<GetServerSidePropsResult<Props>> => {
     const { currentUser, query } = context as AuthenticationServerSidePropsContext
     const { orderBy, pageNum, type, keywords, maxPageItems, order, urgency, dateRange } = query
-    const courtCaseTypes = [type].flat().filter((t) => validCourtCaseTypes.includes(String(t))) as Filter[]
+    const courtCaseTypes = [type]
+      .flat()
+      .filter((t) => validCourtCaseTypes.includes(String(t))) as TriggerExceptionFilter[]
     const validatedMaxPageItems = validateQueryParams(maxPageItems) ? maxPageItems : "5"
     const validatedPageNum = validateQueryParams(pageNum) ? pageNum : "1"
     const validatedOrderBy = validateQueryParams(orderBy) ? orderBy : "ptiurn"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { Heading } from "govuk-react"
 import CourtCaseWrapper from "features/CourtCaseFilters/CourtCaseFilterWrapper"
 import { mapDateRange, validateNamedDateRange } from "utils/validators/validateDateRanges"
 import { validateQueryParams } from "utils/validators/validateQueryParams"
+import { mapLockFilter } from "utils/validators/validateLockFilter"
 
 interface Props {
   user: User
@@ -52,6 +53,7 @@ export const getServerSideProps = withMultipleServerSideProps(
     const validatedUrgentFilter = validateQueryParams(urgency) ? (urgency as Urgency) : undefined
     const validatedLockedFilter = validateQueryParams(locked) ? locked : undefined
 
+    const lockedFilter = mapLockFilter(locked)
     const dataSource = await getDataSource()
     const courtCases = await listCourtCases(dataSource, {
       forces: currentUser.visibleForces,
@@ -62,7 +64,8 @@ export const getServerSideProps = withMultipleServerSideProps(
       pageNum: validatedPageNum,
       orderBy: validatedOrderBy,
       order: validatedOrder,
-      courtDateRange: validatedDateRange
+      courtDateRange: validatedDateRange,
+      lockedFilter: lockedFilter
     })
 
     const oppositeOrder: QueryOrder = validatedOrder === "asc" ? "desc" : "asc"

--- a/src/services/getDataSource.ts
+++ b/src/services/getDataSource.ts
@@ -31,7 +31,7 @@ const getDataSource = async (): Promise<DataSource> => {
     migrations: [],
     schema: databaseConfig.schema,
     ssl: databaseConfig.ssl ? { rejectUnauthorized: false } : false,
-    logging: false, // Set to true to see what queries are being sent to Postgres
+    logging: true, // Set to true to see what queries are being sent to Postgres
     extra: {
       max: 1
     }

--- a/src/services/getDataSource.ts
+++ b/src/services/getDataSource.ts
@@ -31,7 +31,7 @@ const getDataSource = async (): Promise<DataSource> => {
     migrations: [],
     schema: databaseConfig.schema,
     ssl: databaseConfig.ssl ? { rejectUnauthorized: false } : false,
-    logging: true, // Set to true to see what queries are being sent to Postgres
+    logging: false, // Set to true to see what queries are being sent to Postgres
     extra: {
       max: 1
     }

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -18,7 +18,8 @@ const listCourtCases = async (
     defendantName,
     resultFilter,
     urgentFilter,
-    courtDateRange
+    courtDateRange,
+    lockedFilter
   }: CaseListQueryParams
 ): PromiseResult<ListCourtCaseResult> => {
   const pageNumValidated = (pageNum ? parseInt(pageNum, 10) : 1) - 1 // -1 because the db index starts at 0
@@ -56,7 +57,7 @@ const listCourtCases = async (
   }
 
   const result = await query.getManyAndCount().catch((error: Error) => error)
-
+  console.log(lockedFilter)
   return isError(result)
     ? result
     : {

--- a/src/types/CaseListQueryParams.ts
+++ b/src/types/CaseListQueryParams.ts
@@ -1,6 +1,6 @@
 export type QueryOrder = "asc" | "desc" | undefined
 
-export type Filter = "Triggers" | "Exceptions"
+export type TriggerExceptionFilter = "Triggers" | "Exceptions"
 
 export type NamedCourtDateRanges = "Today" | undefined
 
@@ -14,11 +14,12 @@ export type Urgency = "Urgent" | "Non-urgent" | undefined
 export type CaseListQueryParams = {
   orderBy?: string
   order?: QueryOrder
-  resultFilter?: Filter[]
+  resultFilter?: TriggerExceptionFilter[]
   defendantName?: string
   urgentFilter?: Urgency
   forces: string[]
   pageNum?: string
   maxPageItems: string
   courtDateRange?: CourtDateRange
+  lockedFilter?: boolean
 }

--- a/src/utils/validators/validateLockFilter.test.ts
+++ b/src/utils/validators/validateLockFilter.test.ts
@@ -1,0 +1,11 @@
+import { mapLockFilter } from "./validateLockFilter"
+
+describe("mapLockFilter", () => {
+  it.each([
+    { input: "Locked", expected: true },
+    { input: "Unlocked", expected: false },
+    { input: "Invalid Lock Filter", expected: undefined }
+  ])("check lock filter for '$input'", ({ input, expected }) => {
+    expect(mapLockFilter(input)).toBe(expected)
+  })
+})

--- a/src/utils/validators/validateLockFilter.ts
+++ b/src/utils/validators/validateLockFilter.ts
@@ -1,0 +1,9 @@
+import { validateQueryParams } from "./validateQueryParams"
+
+const lockedFilterOptions = ["Locked", "Unlocked"]
+
+export const validateLockFilter = (lockFilter: string | string[] | undefined): boolean =>
+  validateQueryParams(lockFilter) && lockedFilterOptions.includes(lockFilter)
+
+export const mapLockFilter = (lockFilter: string | string[] | undefined): boolean | undefined =>
+  validateLockFilter(lockFilter) ? lockFilter === "Locked" : undefined

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -727,5 +727,49 @@ describe("listCourtCases", () => {
       expect(cases).toHaveLength(1)
       expect(cases.map((c) => c.errorId)).toStrictEqual([1])
     })
+
+    it("Should treat cases with only one lock as locked.  ", async () => {
+      const orgCode = "36FP"
+      const errorLockedCase = await getDummyCourtCase({
+        errorId: 0,
+        errorLockedByUsername: "bichard01",
+        messageId: "0"
+      })
+      const triggerLockedCase = await getDummyCourtCase({
+        errorId: 1,
+        triggerLockedByUsername: "bichard01",
+        messageId: "1"
+      })
+      const unlockedCase = await getDummyCourtCase({
+        errorId: 2,
+        messageId: "2"
+      })
+
+      await insertCourtCases([errorLockedCase, triggerLockedCase, unlockedCase])
+
+      const lockedResult = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        lockedFilter: true
+      })
+
+      expect(isError(lockedResult)).toBeFalsy()
+      const { result: lockedCases } = lockedResult as ListCourtCaseResult
+
+      expect(lockedCases).toHaveLength(2)
+      expect(lockedCases.map((c) => c.errorId)).toStrictEqual([0, 1])
+
+      const unlockedResult = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        lockedFilter: false
+      })
+
+      expect(isError(unlockedResult)).toBeFalsy()
+      const { result: unlockedCases } = unlockedResult as ListCourtCaseResult
+
+      expect(unlockedCases).toHaveLength(1)
+      expect(unlockedCases.map((c) => c.errorId)).toStrictEqual([2])
+    })
   })
 })

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -13,7 +13,9 @@ import {
   insertDummyCourtCasesWithTriggers,
   insertDummyCourtCasesWithUrgencies,
   getDummyCourtCase,
-  insertCourtCases
+  insertCourtCases,
+  insertMultipleDummyCourtCases,
+  insertMultipleDummyCourtCasesWithLock
 } from "../utils/insertCourtCases"
 import insertException from "../utils/manageExceptions"
 import { isError } from "../../src/types/Result"
@@ -674,18 +676,10 @@ describe("listCourtCases", () => {
   describe("Filter cases by locked status", () => {
     it("Should filter cases that are locked ", async () => {
       const orgCode = "36FP"
-      const lockedCase = await getDummyCourtCase({
-        errorId: 0,
-        errorLockedByUsername: "bichard01",
-        triggerLockedByUsername: "bichard01",
-        messageId: "0"
-      })
-      const unlockedCase = await getDummyCourtCase({
-        errorId: 1,
-        messageId: "1"
-      })
-
-      await insertCourtCases([lockedCase, unlockedCase])
+      await insertMultipleDummyCourtCasesWithLock(
+        [{ errorLockedByUsername: "bichard01", triggerLockedByUsername: "bichard01" }, {}],
+        orgCode
+      )
 
       const result = await listCourtCases(dataSource, {
         forces: [orgCode],

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -11,7 +11,9 @@ import {
   insertCourtCasesWithDefendantNames,
   insertDummyCourtCasesWithNotes,
   insertDummyCourtCasesWithTriggers,
-  insertDummyCourtCasesWithUrgencies
+  insertDummyCourtCasesWithUrgencies,
+  getDummyCourtCase,
+  insertCourtCases
 } from "../utils/insertCourtCases"
 import insertException from "../utils/manageExceptions"
 import { isError } from "../../src/types/Result"
@@ -666,6 +668,36 @@ describe("listCourtCases", () => {
 
       expect(cases).toHaveLength(1)
       expect(cases.map((c) => c.errorId)).toStrictEqual([1])
+    })
+  })
+
+  describe("Filter cases by locked status", () => {
+    it.only("Should filter cases that are locked ", async () => {
+      const orgCode = "36FP"
+      const lockedCase = await getDummyCourtCase({
+        errorId: 0,
+        errorLockedByUsername: "bichard01",
+        triggerLockedByUsername: "bichard01",
+        messageId: "0"
+      })
+      const unlockedCase = await getDummyCourtCase({
+        errorId: 1,
+        messageId: "1"
+      })
+
+      await insertCourtCases([lockedCase, unlockedCase])
+
+      const result = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        lockedFilter: true
+      })
+
+      expect(isError(result)).toBeFalsy()
+      const { result: cases } = result as ListCourtCaseResult
+
+      expect(cases).toHaveLength(1)
+      expect(cases.map((c) => c.errorId)).toStrictEqual([0])
     })
   })
 })

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -672,7 +672,7 @@ describe("listCourtCases", () => {
   })
 
   describe("Filter cases by locked status", () => {
-    it.only("Should filter cases that are locked ", async () => {
+    it("Should filter cases that are locked ", async () => {
       const orgCode = "36FP"
       const lockedCase = await getDummyCourtCase({
         errorId: 0,
@@ -698,6 +698,34 @@ describe("listCourtCases", () => {
 
       expect(cases).toHaveLength(1)
       expect(cases.map((c) => c.errorId)).toStrictEqual([0])
+    })
+
+    it("Should filter cases that are unlocked ", async () => {
+      const orgCode = "36FP"
+      const lockedCase = await getDummyCourtCase({
+        errorId: 0,
+        errorLockedByUsername: "bichard01",
+        triggerLockedByUsername: "bichard01",
+        messageId: "0"
+      })
+      const unlockedCase = await getDummyCourtCase({
+        errorId: 1,
+        messageId: "1"
+      })
+
+      await insertCourtCases([lockedCase, unlockedCase])
+
+      const result = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        lockedFilter: false
+      })
+
+      expect(isError(result)).toBeFalsy()
+      const { result: cases } = result as ListCourtCaseResult
+
+      expect(cases).toHaveLength(1)
+      expect(cases.map((c) => c.errorId)).toStrictEqual([1])
     })
   })
 })

--- a/test/utils/insertCourtCases.ts
+++ b/test/utils/insertCourtCases.ts
@@ -133,25 +133,22 @@ const insertDummyCourtCaseWithLock = async (
 
 const insertMultipleDummyCourtCasesWithLock = async (
   lockHolders: { errorLockedByUsername?: string; triggerLockedByUsername?: string }[],
-  orgCodes: string[]
+  orgCode: string
 ) => {
   const existingCourtCases: CourtCase[] = []
-  for (let lockIndex = 0; lockIndex < lockHolders.length; lockIndex++) {
-    for (let orgCodeIndex = 0; orgCodeIndex < orgCodes.length; orgCodeIndex++) {
-      const index = lockIndex * lockHolders.length + orgCodeIndex
-      existingCourtCases.push(
-        await getDummyCourtCase({
-          orgForPoliceFilter: orgCodes[orgCodeIndex].padEnd(6, " "),
-          errorId: index,
-          messageId: String(index).padStart(5, "x"),
-          ptiurn: "Case" + String(index).padStart(5, "0"),
-          errorLockedByUsername: lockHolders[lockIndex].errorLockedByUsername ?? null,
-          triggerLockedByUsername: lockHolders[lockIndex].triggerLockedByUsername ?? null,
-          errorCount: 1,
-          triggerCount: 1
-        })
-      )
-    }
+  for (let index = 0; index < lockHolders.length; index++) {
+    existingCourtCases.push(
+      await getDummyCourtCase({
+        orgForPoliceFilter: orgCode.padEnd(6, " "),
+        errorId: index,
+        messageId: String(index).padStart(5, "x"),
+        ptiurn: "Case" + String(index).padStart(5, "0"),
+        errorLockedByUsername: lockHolders[index].errorLockedByUsername ?? null,
+        triggerLockedByUsername: lockHolders[index].triggerLockedByUsername ?? null,
+        errorCount: 1,
+        triggerCount: 1
+      })
+    )
   }
 
   return insertCourtCases(existingCourtCases)

--- a/test/utils/insertCourtCases.ts
+++ b/test/utils/insertCourtCases.ts
@@ -108,8 +108,8 @@ const insertMultipleDummyCourtCases = async (numToInsert: number, orgCode: strin
 }
 
 const insertDummyCourtCaseWithLock = async (
-  errorLockedByUsername: string,
-  triggerLockedByUsername: string,
+  errorLockedByUsername: string | null,
+  triggerLockedByUsername: string | null,
   orgsCodes: string[]
 ) => {
   const existingCourtCases: CourtCase[] = []
@@ -126,6 +126,32 @@ const insertDummyCourtCaseWithLock = async (
         triggerCount: 1
       })
     )
+  }
+
+  return insertCourtCases(existingCourtCases)
+}
+
+const insertMultipleDummyCourtCasesWithLock = async (
+  lockHolders: { errorLockedByUsername?: string; triggerLockedByUsername?: string }[],
+  orgCodes: string[]
+) => {
+  const existingCourtCases: CourtCase[] = []
+  for (let lockIndex = 0; lockIndex < lockHolders.length; lockIndex++) {
+    for (let orgCodeIndex = 0; orgCodeIndex < orgCodes.length; orgCodeIndex++) {
+      const index = lockIndex * lockHolders.length + orgCodeIndex
+      existingCourtCases.push(
+        await getDummyCourtCase({
+          orgForPoliceFilter: orgCodes[orgCodeIndex].padEnd(6, " "),
+          errorId: index,
+          messageId: String(index).padStart(5, "x"),
+          ptiurn: "Case" + String(index).padStart(5, "0"),
+          errorLockedByUsername: lockHolders[lockIndex].errorLockedByUsername ?? null,
+          triggerLockedByUsername: lockHolders[lockIndex].triggerLockedByUsername ?? null,
+          errorCount: 1,
+          triggerCount: 1
+        })
+      )
+    }
   }
 
   return insertCourtCases(existingCourtCases)
@@ -209,5 +235,6 @@ export {
   insertDummyCourtCaseWithLock,
   insertDummyCourtCasesWithUrgencies,
   insertDummyCourtCasesWithNotes,
-  insertDummyCourtCasesWithTriggers
+  insertDummyCourtCasesWithTriggers,
+  insertMultipleDummyCourtCasesWithLock
 }


### PR DESCRIPTION
In this PR:
* Added UI to select a locked status filter
* Added cypress tests for filtering cases in the case listing screen by their locked status
* Added ability for `listCourtCases` to take an optional locked filter
* Add unit tests for new `listCourtCases` filtering
* Added `insertMultipleDummyCourtCasesWithLock` helper for use in tests
* Made case filter labels more consistent