### PR TITLE
Add white-space to banner text

### DIFF
--- a/src/components/PhaseBanner/PhaseBanner.tsx
+++ b/src/components/PhaseBanner/PhaseBanner.tsx
@@ -8,7 +8,7 @@ const PhaseBanner: React.FC<PhaseBannerProps> = ({ phase }: PhaseBannerProps) =>
       <p className="govuk-phase-banner__content">
         <strong className="govuk-tag govuk-phase-banner__content__tag">{phase}</strong>
         <span className="govuk-phase-banner__text">
-          {"This is a prototype. Content is likely to change rapidly –"}
+          {"This is a prototype. Content is likely to change rapidly – "}
           {/* TODO: add feedback page link */}
           <a className="govuk-link" href="/">
             {"help us to improve it"}


### PR DESCRIPTION
Simple white-space fix to the prototype banner in the new UI