### PR TITLE
BICAWS-2483: Selected filters panel

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -62,10 +62,10 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(3)").contains("Barbara Gordon").should("not.exist")
       cy.get("tr").not(":first").get("td:nth-child(3)").contains("Alfred Pennyworth").should("not.exist")
       cy.get("tr").should("have.length", 2)
-      cy.get('*[class^="moj-filter-tags"]').contains("Bruce Wayne")
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Bruce Wayne")
 
       // Removing filter tag
-      cy.get('*[class^="moj-filter-tags"]').contains("Bruce Wayne").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Bruce Wayne").click({ force: true })
       cy.get("tr").not(":first").get("td:nth-child(3)").contains("Bruce Wayne")
       cy.get("tr").not(":first").get("td:nth-child(3)").contains("Barbara Gordon")
       cy.get("tr").not(":first").get("td:nth-child(3)").contains("Alfred Pennyworth")
@@ -125,7 +125,7 @@ describe("Case list", () => {
           cy.wrap(row).contains("Case00000").should("exist")
         })
 
-      cy.get(".moj-filter-tags").contains("Today").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Today").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 5)
 
       // Tests for "yesterday"
@@ -142,7 +142,7 @@ describe("Case list", () => {
           cy.wrap(row).contains("Case00001").should("exist")
         })
 
-      cy.get(".moj-filter-tags").contains("Yesterday").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Yesterday").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 5)
 
       // Tests for "This week"
@@ -160,7 +160,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").contains("Case00001").should("exist")
       cy.get("tr").not(":first").contains("Case00003").should("exist")
 
-      cy.get(".moj-filter-tags").contains("This week").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("This week").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 5)
 
       // Tests for "Last week"
@@ -178,7 +178,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").contains("Case00004").should("exist")
       cy.get("tr").not(":first").contains("Case00005").should("exist")
 
-      cy.get(".moj-filter-tags").contains("Last week").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Last week").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 5)
 
       // Tests for "This month"
@@ -208,7 +208,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").contains(oneMonthAgoDateString).should("exist")
       cy.get("tr").not(":first").contains("Case00006").should("exist")
 
-      cy.get(".moj-filter-tags").contains("This month").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("This month").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 5)
     })
 
@@ -260,7 +260,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00003`).should("not.exist")
 
       // Filtering by having exceptions
-      cy.get('*[class^="moj-filter-tags"]').contains("Triggers").click() // Removing triggers filter tag
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Triggers").click({ force: true })
       cy.get("button[id=filter-button]").click()
       cy.get('[id="exceptions-type"]').check()
       cy.get("button[id=search]").click()
@@ -285,7 +285,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00001`)
 
       // Removing exceptions filter tag
-      cy.get('*[class^="moj-filter-tags"]').contains("Exceptions").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Exceptions").click({ force: true })
 
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00000`)
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00001`)
@@ -293,7 +293,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00003`).should("not.exist")
 
       // Removing triggers filter tag
-      cy.get('*[class^="moj-filter-tags"]').contains("Triggers").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Triggers").click({ force: true })
 
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00000`)
       cy.get("tr").not(":first").get("td:nth-child(2)").contains(`Case00001`)
@@ -321,7 +321,7 @@ describe("Case list", () => {
         })
 
       // Removing urgent filter tag all case should be shown with the filter disabled
-      cy.get('*[class^="moj-filter-tags"]').contains("Urgent").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Urgent").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 4)
 
       // Filter for non-urgent cases
@@ -333,11 +333,11 @@ describe("Case list", () => {
       cy.get("tr").contains("Case00001").should("exist")
 
       // Removing non-urgent filter tag all case should be shown with the filter disabled
-      cy.get('*[class^="moj-filter-tags"]').contains("Non-urgent").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Non-urgent").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 4)
     })
 
-    it.only("Should filter cases by locked state", () => {
+    it("Should filter cases by locked state", () => {
       cy.task("insertMultipleDummyCourtCasesWithLock", {
         lockHolders: [
           {
@@ -360,7 +360,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").contains("Case00000").should("exist")
 
       // Removing locked filter tag all case should be shown with the filter disabled
-      cy.get('*[class^="moj-filter-tags"]').contains("Locked").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Locked").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 2)
 
       // Filter for unlocked cases
@@ -372,7 +372,7 @@ describe("Case list", () => {
       cy.get("tr").contains("Case00001").should("exist")
 
       // Removing unlocked filter tag all case should be shown with the filter disabled
-      cy.get('*[class^="moj-filter-tags"]').contains("Unlocked").click()
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Unlocked").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 2)
     })
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -337,7 +337,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").should("have.length", 4)
     })
 
-    it("Should filter cases by locked state", () => {
+    it.only("Should filter cases by locked state", () => {
       cy.task("insertMultipleDummyCourtCasesWithLock", {
         lockHolders: [
           {

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -83,6 +83,21 @@ describe("Case list", () => {
         cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
       })
     })
+
+    describe("Date range", () => {
+      it.only("Should allow you to add 'today' as the date range filter chip", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#date-range").click()
+        cy.get("#date-range-today").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Date range").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Today").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Last week").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+      })
+    })
   })
 })
 

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -64,7 +64,7 @@ describe("Case list", () => {
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
-        cy.get('ul[class^="moj-filter-tags"]').contains("Reason").should("exist")
+        cy.get("h3.govuk-heading-s").contains("Reason").should("exist")
         cy.get('*[class^="moj-filter__selected"]').contains("Trigger").should("exist")
         cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
       })
@@ -76,10 +76,10 @@ describe("Case list", () => {
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
-        cy.get('*[class^="moj-filter-tags"').contains("Reason").should("exist")
+        cy.get("h3.govuk-heading-s").contains("Reason").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
-        cy.get('*[class^="moj-filter-tags"]').children().should("have.length", 3)
+        cy.get(".moj-filter-tags").children().should("have.length", 2)
 
         // Removes the two filter chips
         cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
@@ -205,7 +205,7 @@ describe("Case list", () => {
         cy.get('.moj-filter *[class^="moj-filter__tag"').contains("Non-urgent").should("not.exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("exist")
         cy.get('*[class^="moj-filter__tag"').contains("Urgent").should("exist")
-        cy.get('*[class^="moj-filter__tag"')
+        cy.get(".moj-filter__tag")
           .contains("Urgent")
           .parent()
           .parent()

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -26,7 +26,9 @@ describe("Case list", () => {
 
     it("Should display no filters chips as the default state", () => {
       cy.get('[class^="moj-action-bar"]').click()
-      cy.get('ui [class^="moj-filter-tags"]').should("have.length", 0)
+      cy.get('*[class^="moj-filter-tag"]').should("not.be.visible")
+      cy.get('*[class^="govuk-checkboxes__item"]').should("not.be.checked")
+      cy.get('*[class^="govuk-radios__input"]').should("not.be.checked")
     })
 
     describe("Case type", () => {
@@ -37,6 +39,7 @@ describe("Case list", () => {
         // Check if the correct heading and filter label are applied
         cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
       })
 
       it("Should remove the Trigger filter chip when the chip is clicked and remove the selected option in the filter panel", () => {
@@ -46,10 +49,11 @@ describe("Case list", () => {
         // Check if the correct heading and filter label are applied
         cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
         cy.get('*[class^="moj-filter-tag"]').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
 
         // Removes the filter chip
         cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
-        cy.get('ui [class^="moj-filter-tags"]').should("have.length", 0)
+        cy.get('*[class^="moj-filter-tag"]').contains("Trigger").should("not.exist")
       })
 
       it("Should display Trigger and Exception filter chips when selected", () => {
@@ -59,28 +63,39 @@ describe("Case list", () => {
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Trigger").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
-        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+        cy.get('ul[class^="moj-filter-tags"]').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected"]').contains("Trigger").should("exist")
+        cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
       })
 
-      it("Should remove the Trigger and Exception filter chip when both chips are clicked and remove the selected option in the filter panel", () => {
+      it("Should display Trigger and Exception filter chips when selected", () => {
         // Shows filters and clicks both options
         cy.get('[class^="moj-action-bar"]').click()
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('ul[class^="moj-filter-tags"]').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected"]').contains("Trigger").should("exist")
+        cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
+      })
+
+      it("Should remove the Trigger and Exception filter chips when both chips are clicked and remove the selected option in the filter panel", () => {
+        // Shows filters and clicks both options
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+
+        // Check if the correct heading for chips and filter labels are applied
+        cy.get('*[class^="moj-filter-tags"').contains("Reason").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
-        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+        cy.get('*[class^="moj-filter-tags"]').children().should("have.length", 3)
 
         // Removes the two filter chips
         cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
         cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
-        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+        cy.get('*[class^="moj-filter-tag"]').should("not.contain", "Trigger").and("not.contain", "Exception")
       })
     })
 
@@ -100,7 +115,7 @@ describe("Case list", () => {
     })
 
     describe("Urgency", () => {
-      it.only("Should apply the 'Urgent cases only' radio button", () => {
+      it("Should apply the 'Urgent cases only' radio button", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#urgent").click()
 
@@ -116,6 +131,20 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
+      })
+
+      it("Should remove the 'Urgent cases only' filter chip when the correct chip is 'X' is clicked", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#urgent").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("not.exist")
+        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 1)
+
+        // Removes the urgent filter chips
+        cy.get('li button[class ^="moj-filter__tag"]').contains("Urgent").trigger("click")
+        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
       })
     })
   })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -175,7 +175,7 @@ describe("Case list", () => {
         cy.get('*[class^="moj-button-menu__wrapper"').contains("Last week").should("exist")
       })
 
-      it.only("Should allow a user to apply 'Trigger' and 'Urgent cases only' filter, under the Applied filters section. Then selecting 'Non urgent cases only' and see the previous urgent filter removed", () => {
+      it("Should allow a user to apply 'Trigger' and 'Urgent cases only' filter, under the Applied filters section. Then selecting 'Non urgent cases only' and see the previous urgent filter removed", () => {
         cy.get(".moj-action-bar button").click()
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
         cy.get("#non-urgent").click()

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -147,6 +147,38 @@ describe("Case list", () => {
         cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
       })
     })
+
+    describe("Locked status", () => {
+      it("", () => {})
+    })
+
+    describe("Selecting multiple filter chips", () => {
+      it.only("should allow you to select 'Trigger', 'Last week', 'non-urgent'. This should display relevant header for each filter chip", () => {
+        // Open filters and build filter chip query
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get("#date-range").click()
+        cy.get("#date-range-last-week").click()
+        cy.get("#non-urgent").click()
+
+        // Check that relevant chips and headers are present on screen
+        // Reasons
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
+        // Urgency
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
+        // Date Range
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Date range").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Last week").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Today").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+      })
+    })
   })
 })
 

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -24,49 +24,64 @@ describe("Case list", () => {
       cy.login("bichard01@example.com", "password")
     })
 
-    it("Should display the Trigger filter chip when selected", () => {
+    it("Should display no filters chips as the default state", () => {
       cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
-    })
-
-    it("Should remove the Trigger filter chip when the chip is clicked and remove the selected option in the filter panel", () => {
-      cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-      cy.get('*[class^="moj-filter-tag"]').contains("Triggers").should("exist")
-
-      cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
       cy.get('ui [class^="moj-filter-tags"]').should("have.length", 0)
     })
 
-    it("Should display Trigger and Exception filter chips when selected", () => {
-      cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+    describe("Case type", () => {
+      it("Should display the Trigger filter chip when selected", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
 
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Trigger").should("exist")
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
-    })
+        // Check if the correct heading and filter label are applied
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+      })
 
-    it.only("Should remove the Trigger and Exception filter chip when both chips are clicked and remove the selected option in the filter panel", () => {
-      cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-      cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+      it("Should remove the Trigger filter chip when the chip is clicked and remove the selected option in the filter panel", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
 
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
-      cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
-      cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+        // Check if the correct heading and filter label are applied
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter-tag"]').contains("Triggers").should("exist")
 
-      cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
-      cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
+        // Removes the filter chip
+        cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
+        cy.get('ui [class^="moj-filter-tags"]').should("have.length", 0)
+      })
 
-      cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+      it("Should display Trigger and Exception filter chips when selected", () => {
+        // Shows filters and clicks both options
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+
+        // Check if the correct heading for chips and filter labels are applied
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Trigger").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
+        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+      })
+
+      it("Should remove the Trigger and Exception filter chip when both chips are clicked and remove the selected option in the filter panel", () => {
+        // Shows filters and clicks both options
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+
+        // Check if the correct heading for chips and filter labels are applied
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
+        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+
+        // Removes the two filter chips
+        cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
+        cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
+        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+      })
     })
   })
 })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -210,6 +210,7 @@ describe("Case list", () => {
           .parent()
           .parent()
           .prev()
+          .prev()
           .contains("Selected filters")
           .should("exist")
       })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -26,7 +26,8 @@ describe("Case list", () => {
 
     it("Should display no filters chips as the default state", () => {
       cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="moj-filter-tag"]').should("not.be.visible")
+      cy.get('*[class^="moj-filter-tag"]').should("not.exist")
+      cy.get('*[class^="moj-filter__selected"]').should("not.exist")
       cy.get('*[class^="govuk-checkboxes__item"]').should("not.be.checked")
       cy.get('*[class^="govuk-radios__input"]').should("not.be.checked")
     })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -1,0 +1,74 @@
+import hashedPassword from "../../fixtures/hashedPassword"
+
+describe("Case list", () => {
+  context("When filters applied", () => {
+    before(() => {
+      cy.task("clearUsers")
+      cy.task("insertUsers", {
+        users: [
+          {
+            username: "Bichard01",
+            visibleForces: ["011111"],
+            forenames: "Bichard Test User",
+            surname: "01",
+            email: "bichard01@example.com",
+            password: hashedPassword
+          }
+        ],
+        userGroups: ["B7NewUI_grp"]
+      })
+    })
+
+    beforeEach(() => {
+      cy.viewport(1280, 720)
+      cy.login("bichard01@example.com", "password")
+    })
+
+    it("Should display the Trigger filter chip when selected", () => {
+      cy.get('[class^="moj-action-bar"]').click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+    })
+
+    it("Should remove the Trigger filter chip when the chip is clicked and remove the selected option in the filter panel", () => {
+      cy.get('[class^="moj-action-bar"]').click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+      cy.get('*[class^="moj-filter-tag"]').contains("Triggers").should("exist")
+
+      cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
+      cy.get('ui [class^="moj-filter-tags"]').should("have.length", 0)
+    })
+
+    it("Should display Trigger and Exception filter chips when selected", () => {
+      cy.get('[class^="moj-action-bar"]').click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Trigger").should("exist")
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
+    })
+
+    it.only("Should remove the Trigger and Exception filter chip when both chips are clicked and remove the selected option in the filter panel", () => {
+      cy.get('[class^="moj-action-bar"]').click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+      cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+      cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
+      cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 2)
+
+      cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
+      cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
+
+      cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+    })
+  })
+})
+
+export {}

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -54,7 +54,7 @@ describe("Case list", () => {
 
         // Removes the filter chip
         cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').contains("Trigger").should("not.exist")
+        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
       })
 
       it("Should display Trigger and Exception filter chips when selected", () => {
@@ -84,7 +84,7 @@ describe("Case list", () => {
         // Removes the two filter chips
         cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
         cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').should("not.contain", "Trigger").and("not.contain", "Exception")
+        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
       })
     })
 
@@ -125,7 +125,7 @@ describe("Case list", () => {
 
         // Removes the urgent filter chips
         cy.get('li button[class ^="moj-filter__tag"]').contains("Urgent").trigger("click")
-        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
       })
     })
 
@@ -139,7 +139,7 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected-heading"').contains("Unlocked").should("not.exist")
 
         cy.get('li button[class ^="moj-filter__tag"]').contains("Locked").trigger("click")
-        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
       })
     })
 

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -68,18 +68,6 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
       })
 
-      it("Should display Trigger and Exception filter chips when selected", () => {
-        // Shows filters and clicks both options
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
-
-        // Check if the correct heading for chips and filter labels are applied
-        cy.get('ul[class^="moj-filter-tags"]').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected"]').contains("Trigger").should("exist")
-        cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
-      })
-
       it("Should remove the Trigger and Exception filter chips when both chips are clicked and remove the selected option in the filter panel", () => {
         // Shows filters and clicks both options
         cy.get('[class^="moj-action-bar"]').click()
@@ -101,10 +89,12 @@ describe("Case list", () => {
 
     describe("Date range", () => {
       it("Should allow you to add 'today' as the date range filter chip", () => {
+        // Shows filters and clicks date range followed by today's date
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#date-range").click()
         cy.get("#date-range-today").click()
 
+        // Shows the correct heading 'Today' and checks that the others are not visible
         cy.get('*[class^="moj-filter__selected-heading"').contains("Date range").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Today").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
@@ -115,15 +105,6 @@ describe("Case list", () => {
     })
 
     describe("Urgency", () => {
-      it("Should apply the 'Urgent cases only' radio button", () => {
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get("#urgent").click()
-
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("not.exist")
-      })
-
       it("Should apply the 'Non-urgent cases only' radio button", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#non-urgent").click()
@@ -133,14 +114,13 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
       })
 
-      it("Should remove the 'Urgent cases only' filter chip when the correct chip is 'X' is clicked", () => {
+      it("Should apply the 'Urgent cases only' radio button and cancel it when the 'X' is clicked", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#urgent").click()
 
         cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("not.exist")
-        cy.get('li button[class^="moj-filter__tag"]').children().should("have.length", 1)
 
         // Removes the urgent filter chips
         cy.get('li button[class ^="moj-filter__tag"]').contains("Urgent").trigger("click")
@@ -153,7 +133,7 @@ describe("Case list", () => {
     })
 
     describe("Selecting multiple filter chips", () => {
-      it.only("should allow you to select 'Trigger', 'Last week', 'non-urgent'. This should display relevant header for each filter chip", () => {
+      it("should allow you to select 'Trigger', 'Last week', 'non-urgent'. This should display relevant header for each filter chip", () => {
         // Open filters and build filter chip query
         cy.get('[class^="moj-action-bar"]').click()
         cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
@@ -177,6 +157,12 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+
+        // submit query and display filter chips in filters applied section
+        cy.get("#search").contains("Apply filters").click()
+        cy.get('*[class^="moj-button-menu__wrapper"').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-button-menu__wrapper"').contains("Non-urgent").should("exist")
+        cy.get('*[class^="moj-button-menu__wrapper"').contains("Last week").should("exist")
       })
     })
   })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -85,7 +85,7 @@ describe("Case list", () => {
     })
 
     describe("Date range", () => {
-      it.only("Should allow you to add 'today' as the date range filter chip", () => {
+      it("Should allow you to add 'today' as the date range filter chip", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#date-range").click()
         cy.get("#date-range-today").click()
@@ -96,6 +96,26 @@ describe("Case list", () => {
         cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("Last week").should("not.exist")
         cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+      })
+    })
+
+    describe("Urgency", () => {
+      it.only("Should apply the 'Urgent cases only' radio button", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#urgent").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("not.exist")
+      })
+
+      it("Should apply the 'Non-urgent cases only' radio button", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#non-urgent").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
       })
     })
   })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -129,7 +129,7 @@ describe("Case list", () => {
     })
 
     describe("Locked status", () => {
-      it.only("Should apply the 'Locked cases only' filter chips then remove this chips to the original state", () => {
+      it("Should apply the 'Locked cases only' filter chips then remove this chips to the original state", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#locked").click()
 
@@ -173,6 +173,44 @@ describe("Case list", () => {
         cy.get('*[class^="moj-button-menu__wrapper"').contains("Triggers").should("exist")
         cy.get('*[class^="moj-button-menu__wrapper"').contains("Non-urgent").should("exist")
         cy.get('*[class^="moj-button-menu__wrapper"').contains("Last week").should("exist")
+      })
+
+      it.only("Should allow a user to apply 'Trigger' and 'Urgent cases only' filter, under the Applied filters section. Then selecting 'Non urgent cases only' and see the previous urgent filter removed", () => {
+        cy.get(".moj-action-bar button").click()
+        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get("#non-urgent").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
+        cy.get("#search").contains("Apply filters").click()
+
+        cy.get(".moj-action-bar button").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
+        cy.get('*[class^="moj-filter__tag"').contains("Triggers").should("exist")
+        cy.get('*[class^="moj-filter__tag"').contains("Non-urgent").should("exist")
+
+        cy.get("#urgent").click()
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
+        cy.get('.moj-filter *[class^="moj-filter__tag"').contains("Non-urgent").should("not.exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("exist")
+        cy.get('*[class^="moj-filter__tag"').contains("Urgent").should("exist")
+        cy.get('*[class^="moj-filter__tag"')
+          .contains("Urgent")
+          .parent()
+          .parent()
+          .prev()
+          .contains("Selected filters")
+          .should("exist")
       })
     })
   })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -105,7 +105,7 @@ describe("Case list", () => {
     })
 
     describe("Urgency", () => {
-      it("Should apply the 'Non-urgent cases only' radio button", () => {
+      it("Should apply the 'Non-urgent cases only' filter chip", () => {
         cy.get('[class^="moj-action-bar"]').click()
         cy.get("#non-urgent").click()
 
@@ -129,7 +129,17 @@ describe("Case list", () => {
     })
 
     describe("Locked status", () => {
-      it("", () => {})
+      it.only("Should apply the 'Locked cases only' filter chips then remove this chips to the original state", () => {
+        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#locked").click()
+
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Locked state").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Locked").should("exist")
+        cy.get('*[class^="moj-filter__selected-heading"').contains("Unlocked").should("not.exist")
+
+        cy.get('li button[class ^="moj-filter__tag"]').contains("Locked").trigger("click")
+        cy.get('h2[class^="govuk-heading-m govuk-!-margin-bottom-0"]').children().should("have.length", 0)
+      })
     })
 
     describe("Selecting multiple filter chips", () => {

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -25,186 +25,186 @@ describe("Case list", () => {
     })
 
     it("Should display no filters chips as the default state", () => {
-      cy.get('[class^="moj-action-bar"]').click()
-      cy.get('*[class^="moj-filter-tag"]').should("not.exist")
-      cy.get('*[class^="moj-filter__selected"]').should("not.exist")
-      cy.get('*[class^="govuk-checkboxes__item"]').should("not.be.checked")
-      cy.get('*[class^="govuk-radios__input"]').should("not.be.checked")
+      cy.get("#filter-button").click()
+      cy.get(".moj-filter__tag").should("not.exist")
+      cy.get(".moj-filter__selected").should("not.exist")
+      cy.get(".govuk-checkboxes__item").should("not.be.checked")
+      cy.get(".govuk-radios__input").should("not.be.checked")
     })
 
     describe("Case type", () => {
       it("Should display the Trigger filter chip when selected", () => {
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get("#filter-button").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
 
         // Check if the correct heading and filter label are applied
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Reason").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-filter__tag").contains("Exceptions").should("not.exist")
       })
 
       it("Should remove the Trigger filter chip when the chip is clicked and remove the selected option in the filter panel", () => {
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get("#filter-button").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
 
         // Check if the correct heading and filter label are applied
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter-tag"]').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Reason").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-filter__tag").contains("Exceptions").should("not.exist")
 
         // Removes the filter chip
-        cy.get('li button[class ^="moj-filter__tag"]').trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
+        cy.get("li button.moj-filter__tag").trigger("click")
+        cy.get(".moj-filter__tag").should("not.exist")
       })
 
       it("Should display Trigger and Exception filter chips when selected", () => {
         // Shows filters and clicks both options
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+        cy.get("#filter-button").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
+        cy.get(".govuk-checkboxes__item").contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
         cy.get("h3.govuk-heading-s").contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected"]').contains("Trigger").should("exist")
-        cy.get('*[class^="moj-filter__selected"]').contains("Exception").should("exist")
+        cy.get(".moj-filter__tag").contains("Trigger").should("exist")
+        cy.get(".moj-filter__tag").contains("Exception").should("exist")
       })
 
       it("Should remove the Trigger and Exception filter chips when both chips are clicked and remove the selected option in the filter panel", () => {
         // Shows filters and clicks both options
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Exception").click()
+        cy.get("#filter-button").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
+        cy.get(".govuk-checkboxes__item").contains("Exception").click()
 
         // Check if the correct heading for chips and filter labels are applied
         cy.get("h3.govuk-heading-s").contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Exception").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-filter__tag").contains("Exception").should("exist")
         cy.get(".moj-filter-tags").children().should("have.length", 2)
 
         // Removes the two filter chips
-        cy.get('li button[class ^="moj-filter__tag"]').contains("Triggers").trigger("click")
-        cy.get('li button[class ^="moj-filter__tag"]').contains("Exception").trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
+        cy.get("li button.moj-filter__tag").contains("Triggers").trigger("click")
+        cy.get("li button.moj-filter__tag").contains("Exception").trigger("click")
+        cy.get(".moj-filter__tag").should("not.exist")
       })
     })
 
     describe("Date range", () => {
       it("Should allow you to add 'today' as the date range filter chip", () => {
         // Shows filters and clicks date range followed by today's date
-        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#filter-button").click()
         cy.get("#date-range").click()
         cy.get("#date-range-today").click()
 
         // Shows the correct heading 'Today' and checks that the others are not visible
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Date range").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Today").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Last week").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Date range").should("exist")
+        cy.get(".moj-filter__tag").contains("Today").should("exist")
+        cy.get(".moj-filter__tag").contains("Yesterday").should("not.exist")
+        cy.get(".moj-filter__tag").contains("This week").should("not.exist")
+        cy.get(".moj-filter__tag").contains("Last week").should("not.exist")
+        cy.get(".moj-filter__tag").contains("This month").should("not.exist")
       })
     })
 
     describe("Urgency", () => {
       it("Should apply the 'Non-urgent cases only' filter chip", () => {
-        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#filter-button").click()
         cy.get("#non-urgent").click()
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get(".moj-filter__tag").contains("Non-urgent").should("exist")
+        cy.get(".moj-filter__tag").contains("Urgent").should("not.exist")
       })
 
       it("Should apply the 'Urgent cases only' radio button and cancel it when the 'X' is clicked", () => {
-        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#filter-button").click()
         cy.get("#urgent").click()
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get(".moj-filter__tag").contains("Urgent").should("exist")
+        cy.get(".moj-filter__tag").contains("Non-urgent").should("not.exist")
 
         // Removes the urgent filter chips
-        cy.get('li button[class ^="moj-filter__tag"]').contains("Urgent").trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
+        cy.get("li button.moj-filter__tag").contains("Urgent").trigger("click")
+        cy.get(".moj-filter__tag").should("not.exist")
       })
     })
 
     describe("Locked status", () => {
       it("Should apply the 'Locked cases only' filter chips then remove this chips to the original state", () => {
-        cy.get('[class^="moj-action-bar"]').click()
+        cy.get("#filter-button").click()
         cy.get("#locked").click()
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Locked state").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Locked").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Unlocked").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Locked state").should("exist")
+        cy.get(".moj-filter__tag").contains("Locked").should("exist")
+        cy.get(".moj-filter__tag").contains("Unlocked").should("not.exist")
 
-        cy.get('li button[class ^="moj-filter__tag"]').contains("Locked").trigger("click")
-        cy.get('*[class^="moj-filter-tag"]').should("not.exist")
+        cy.get("li button.moj-filter__tag").contains("Locked").trigger("click")
+        cy.get(".moj-filter__tag").should("not.exist")
       })
     })
 
     describe("Selecting multiple filter chips", () => {
       it("should allow you to select 'Trigger', 'Last week', 'non-urgent'. This should display relevant header for each filter chip", () => {
         // Open filters and build filter chip query
-        cy.get('[class^="moj-action-bar"]').click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get("#filter-button").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
         cy.get("#date-range").click()
         cy.get("#date-range-last-week").click()
         cy.get("#non-urgent").click()
 
         // Check that relevant chips and headers are present on screen
         // Reasons
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-filter-tag"]').contains("Exceptions").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Reason").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-filter__tag").contains("Exceptions").should("not.exist")
         // Urgency
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgent").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get(".moj-filter__tag").contains("Non-urgent").should("exist")
+        cy.get(".moj-filter__tag").contains("Urgent").should("not.exist")
         // Date Range
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Date range").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Last week").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Today").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Yesterday").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("This week").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("This month").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Date range").should("exist")
+        cy.get(".moj-filter__tag").contains("Last week").should("exist")
+        cy.get(".moj-filter__tag").contains("Today").should("not.exist")
+        cy.get(".moj-filter__tag").contains("Yesterday").should("not.exist")
+        cy.get(".moj-filter__tag").contains("This week").should("not.exist")
+        cy.get(".moj-filter__tag").contains("This month").should("not.exist")
 
         // submit query and display filter chips in filters applied section
         cy.get("#search").contains("Apply filters").click()
-        cy.get('*[class^="moj-button-menu__wrapper"').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-button-menu__wrapper"').contains("Non-urgent").should("exist")
-        cy.get('*[class^="moj-button-menu__wrapper"').contains("Last week").should("exist")
+        cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Non-urgent").should("exist")
+        cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Last week").should("exist")
       })
 
       it("Should allow a user to apply 'Trigger' and 'Urgent cases only' filter, under the Applied filters section. Then selecting 'Non urgent cases only' and see the previous urgent filter removed", () => {
         cy.get(".moj-action-bar button").click()
-        cy.get('*[class^="govuk-checkboxes__item"]').contains("Triggers").click()
+        cy.get(".govuk-checkboxes__item").contains("Triggers").click()
         cy.get("#non-urgent").click()
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Triggers").should("exist")
+        cy.get(".govuk-heading-m").contains("Selected filters").should("exist")
+        cy.get(".govuk-heading-m").contains("Applied filters").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Reason").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Non-urgent").should("exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get(".moj-filter__tag").contains("Non-urgent").should("exist")
         cy.get("#search").contains("Apply filters").click()
 
         cy.get(".moj-action-bar button").click()
 
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Reason").should("exist")
-        cy.get('*[class^="moj-filter__tag"').contains("Triggers").should("exist")
-        cy.get('*[class^="moj-filter__tag"').contains("Non-urgent").should("exist")
+        cy.get(".govuk-heading-m").contains("Selected filters").should("not.exist")
+        cy.get(".govuk-heading-m").contains("Applied filters").should("exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get(".govuk-heading-s").contains("Reason").should("exist")
+        cy.get(".moj-filter__tag").contains("Triggers").should("exist")
+        cy.get(".moj-filter__tag").contains("Non-urgent").should("exist")
 
         cy.get("#urgent").click()
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Applied filters").should("exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Urgency").should("exist")
-        cy.get('.moj-filter *[class^="moj-filter__tag"').contains("Non-urgent").should("not.exist")
-        cy.get('*[class^="moj-filter__selected-heading"').contains("Selected filters").should("exist")
-        cy.get('*[class^="moj-filter__tag"').contains("Urgent").should("exist")
+        cy.get(".govuk-heading-m").contains("Applied filters").should("exist")
+        cy.get(".govuk-heading-s").contains("Urgency").should("exist")
+        cy.get("#filter-panel .moj-filter__tag").contains("Non-urgent").should("not.exist")
+        cy.get(".govuk-heading-m").contains("Selected filters").should("exist")
+        cy.get(".moj-filter__tag").contains("Urgent").should("exist")
         cy.get(".moj-filter__tag")
           .contains("Urgent")
           .parent()

--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -1,5 +1,5 @@
 import { Reason } from "types/CaseListQueryParams"
-import type { MouseEvent, Dispatch } from "react"
+import type { Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
 
 interface Props {

--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -1,12 +1,14 @@
 import { Reason } from "types/CaseListQueryParams"
+import type { MouseEvent } from "react"
 
 interface Props {
   courtCaseTypes?: Reason[]
+  onClick: (option: string) => void
 }
 
 const courtCaseTypeOptions = ["Exceptions", "Triggers"]
 
-const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes }: Props) => {
+const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, onClick }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Case type"}</legend>
@@ -20,6 +22,7 @@ const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes }: Props) => {
               type="checkbox"
               value={caseType}
               defaultChecked={courtCaseTypes && courtCaseTypes.includes(caseType as Reason)}
+              onClick={(event: MouseEvent<HTMLInputElement>) => onClick(event.currentTarget.value)}
             ></input>
             <label className="govuk-label govuk-checkboxes__label" htmlFor={`${caseType.toLowerCase()}-type`}>
               {caseType}

--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -1,14 +1,15 @@
 import { Reason } from "types/CaseListQueryParams"
-import type { MouseEvent } from "react"
+import type { MouseEvent, Dispatch } from "react"
+import type { FilterAction } from "types/CourtCaseFilter"
 
 interface Props {
   courtCaseTypes?: Reason[]
-  onClick: (option: string) => void
+  dispatch: Dispatch<FilterAction>
 }
 
 const courtCaseTypeOptions = ["Exceptions", "Triggers"]
 
-const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, onClick }: Props) => {
+const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Case type"}</legend>
@@ -22,7 +23,10 @@ const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, onClick }: Prop
               type="checkbox"
               value={caseType}
               defaultChecked={courtCaseTypes && courtCaseTypes.includes(caseType as Reason)}
-              onClick={(event: MouseEvent<HTMLInputElement>) => onClick(event.currentTarget.value)}
+              onClick={(event: MouseEvent<HTMLInputElement>) => {
+                const value = event.currentTarget.value === "Triggers" ? "Triggers" : "Exceptions"
+                dispatch({ method: "add", type: "reason", value })
+              }}
             ></input>
             <label className="govuk-label govuk-checkboxes__label" htmlFor={`${caseType.toLowerCase()}-type`}>
               {caseType}

--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -22,8 +22,8 @@ const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, dispatch }: Pro
               name="type"
               type="checkbox"
               value={caseType}
-              defaultChecked={courtCaseTypes && courtCaseTypes.includes(caseType as Reason)}
-              onClick={(event: MouseEvent<HTMLInputElement>) => {
+              checked={courtCaseTypes && courtCaseTypes.includes(caseType as Reason)}
+              onChange={(event) => {
                 const value = event.currentTarget.value === "Triggers" ? "Triggers" : "Exceptions"
                 dispatch({ method: "add", type: "reason", value })
               }}

--- a/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
+++ b/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
@@ -2,10 +2,12 @@ import { format } from "date-fns"
 import { mapDateRange, validateNamedDateRange } from "utils/validators/validateDateRanges"
 import { NamedDateRangeOptions } from "utils/namedDateRange"
 import RadioButton from "components/RadioButton/RadioButton"
+import type { FilterAction } from "types/CourtCaseFilter"
+import type { Dispatch } from "react"
 
 interface Props {
   dateRange?: string | null
-  onClick: (option: string) => void
+  dispatch: Dispatch<FilterAction>
 }
 
 const formatNamedDateRange = (namedDateRange: string): string => {
@@ -18,7 +20,7 @@ const formatNamedDateRange = (namedDateRange: string): string => {
 const labelForDateRange = (namedDateRange: string): string =>
   ["Today", "Yesterday"].includes(namedDateRange) ? namedDateRange : formatNamedDateRange(namedDateRange)
 
-const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, onClick }: Props) => {
+const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Court date"}</legend>
@@ -40,7 +42,7 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, onClick }: Props) 
                 defaultChecked={dateRange === namedDateRange}
                 value={namedDateRange}
                 label={labelForDateRange(namedDateRange)}
-                onClick={(option: string) => onClick(option)}
+                onClick={(option: string) => dispatch({ method: "add", type: "date", value: option })}
               />
             ))}
           </div>

--- a/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
+++ b/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
@@ -39,10 +39,10 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch }: Props)
                 name={"dateRange"}
                 key={namedDateRange.toLowerCase().replace(" ", "-")}
                 id={`date-range-${namedDateRange.toLowerCase().replace(" ", "-")}`}
-                defaultChecked={dateRange === namedDateRange}
+                checked={dateRange === namedDateRange}
                 value={namedDateRange}
                 label={labelForDateRange(namedDateRange)}
-                onClick={(option: string) => dispatch({ method: "add", type: "date", value: option })}
+                onChange={(event) => dispatch({ method: "add", type: "date", value: event.target.value })}
               />
             ))}
           </div>

--- a/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
+++ b/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
@@ -5,6 +5,7 @@ import RadioButton from "components/RadioButton/RadioButton"
 
 interface Props {
   dateRange?: string | null
+  onClick: (option: string) => void
 }
 
 const formatNamedDateRange = (namedDateRange: string): string => {
@@ -17,7 +18,7 @@ const formatNamedDateRange = (namedDateRange: string): string => {
 const labelForDateRange = (namedDateRange: string): string =>
   ["Today", "Yesterday"].includes(namedDateRange) ? namedDateRange : formatNamedDateRange(namedDateRange)
 
-const CourtDateFilterOptions: React.FC<Props> = ({ dateRange }: Props) => {
+const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, onClick }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Court date"}</legend>
@@ -39,6 +40,7 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange }: Props) => {
                 defaultChecked={dateRange === namedDateRange}
                 value={namedDateRange}
                 label={labelForDateRange(namedDateRange)}
+                onClick={(option: string) => onClick(option)}
               />
             ))}
           </div>

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -2,13 +2,12 @@ import RadioButton from "components/RadioButton/RadioButton"
 
 interface Props {
   urgency?: string | null
-  onClick: boolean
-  setLabel: string
+  onClick: (option: string) => void
 }
 
 const UrgencyOptions = ["Urgent", "Non-urgent"]
 
-const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick, setLabel }: Props) => {
+const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Urgency"}</legend>
@@ -21,8 +20,7 @@ const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick, setLabel }: P
             defaultChecked={urgency === urgencyFilter}
             value={urgencyFilter}
             label={urgencyFilter + " cases only"}
-            onClick={onClick}
-            setLabel={setLabel(urgencyFilter)}
+            onClick={(option: string) => onClick(option)}
           />
         ))}
       </div>

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -2,11 +2,13 @@ import RadioButton from "components/RadioButton/RadioButton"
 
 interface Props {
   urgency?: string | null
+  onClick: boolean
+  setLabel: string
 }
 
 const UrgencyOptions = ["Urgent", "Non-urgent"]
 
-const UrgencyFilterOptions: React.FC<Props> = ({ urgency }: Props) => {
+const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick, setLabel }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Urgency"}</legend>
@@ -19,6 +21,8 @@ const UrgencyFilterOptions: React.FC<Props> = ({ urgency }: Props) => {
             defaultChecked={urgency === urgencyFilter}
             value={urgencyFilter}
             label={urgencyFilter + " cases only"}
+            onClick={onClick}
+            setLabel={setLabel(urgencyFilter)}
           />
         ))}
       </div>

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -1,29 +1,33 @@
 import RadioButton from "components/RadioButton/RadioButton"
 import type { Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
+import KeyValuePair from "types/KeyValuePair"
 
 interface Props {
-  urgency?: string | null
+  urgency?: boolean
   dispatch: Dispatch<FilterAction>
 }
 
-const UrgencyOptions = ["Urgent", "Non-urgent"]
+const UrgencyOptions: KeyValuePair<string, boolean> = {
+  Urgent: true,
+  "Non-urgent": false
+}
 
 const UrgencyFilterOptions: React.FC<Props> = ({ urgency, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Urgency"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
-        {UrgencyOptions.map((urgencyFilter) => (
+        {Object.keys(UrgencyOptions).map((optionName) => (
           <RadioButton
             name={"urgency"}
-            key={urgencyFilter.toLowerCase()}
-            id={urgencyFilter.toLowerCase()}
-            defaultChecked={urgency === urgencyFilter}
-            value={urgencyFilter}
-            label={urgencyFilter + " cases only"}
-            onClick={(option: string) => {
-              const filterValue = option === "Urgent"
+            key={optionName.toLowerCase()}
+            id={optionName.toLowerCase()}
+            checked={urgency === UrgencyOptions[optionName]}
+            value={optionName}
+            label={optionName + " cases only"}
+            onChange={(event) => {
+              const filterValue = UrgencyOptions[event.target.value]
               dispatch({ method: "add", type: "urgency", value: filterValue })
             }}
           />

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -1,13 +1,15 @@
 import RadioButton from "components/RadioButton/RadioButton"
+import type { Dispatch } from "react"
+import type { FilterAction } from "types/CourtCaseFilter"
 
 interface Props {
   urgency?: string | null
-  onClick: (option: string) => void
+  dispatch: Dispatch<FilterAction>
 }
 
 const UrgencyOptions = ["Urgent", "Non-urgent"]
 
-const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick }: Props) => {
+const UrgencyFilterOptions: React.FC<Props> = ({ urgency, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Urgency"}</legend>
@@ -20,7 +22,10 @@ const UrgencyFilterOptions: React.FC<Props> = ({ urgency, onClick }: Props) => {
             defaultChecked={urgency === urgencyFilter}
             value={urgencyFilter}
             label={urgencyFilter + " cases only"}
-            onClick={(option: string) => onClick(option)}
+            onClick={(option: string) => {
+              const filterValue = option === "Urgent"
+              dispatch({ method: "add", type: "urgency", value: filterValue })
+            }}
           />
         ))}
       </div>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,6 +1,6 @@
 import type { Dispatch } from "react"
-import type { FilterAction, FilterState } from "types/CourtCaseFilter"
 import { createUseStyles } from "react-jss"
+import type { FilterAction, FilterState } from "types/CourtCaseFilter"
 
 interface Props {
   chipLabel: string
@@ -25,7 +25,7 @@ const useStyles = createUseStyles({
 
 const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction, state }: Props) => {
   const classes = useStyles()
-  const buttonClass = "moj-filter__tag " + (state === "applied" ? classes.appliedFilter : "")
+  const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes.appliedFilter : "")
   return (
     <li>
       <button className={buttonClass} onClick={() => dispatch(removeAction())}>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,24 +1,18 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-
-import { useRouter } from "next/router"
-import { deleteQueryParam } from "utils/deleteQueryParam"
-
 /* eslint-disable jsx-a11y/click-events-have-key-events */
+
+import { MouseEvent } from "react"
 interface Props {
   tag: string
   chipLabel: string
   paramName: string
+  onClick: (option: string) => void
 }
 
-const FilterChip: React.FC<Props> = ({ tag, chipLabel, paramName }: Props) => {
-  const { query, basePath } = useRouter()
-
-  const removeFilterParams = deleteQueryParam({ [paramName]: chipLabel }, query)
-  const removeFilterUrl = `${basePath}/?${removeFilterParams}`
-
+const FilterChip: React.FC<Props> = ({ tag, chipLabel, onClick }: Props) => {
   return (
-    <a className={tag} href={removeFilterUrl}>
+    <a className={tag} onClick={(event: MouseEvent<HTMLInputElement>) => onClick(event.currentTarget.value)}>
       <span className="govuk-visually-hidden">{"Remove this filter"}</span>
       {chipLabel}
     </a>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -13,10 +13,12 @@ interface Props {
 
 const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction }: Props) => {
   return (
-    <a className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
-      <span className="govuk-visually-hidden">{"Remove this filter"}</span>
-      {chipLabel}
-    </a>
+    <li>
+      <a className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
+        <span className="govuk-visually-hidden">{"Remove this filter"}</span>
+        {chipLabel}
+      </a>
+    </li>
   )
 }
 

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,16 +1,27 @@
 import type { Dispatch } from "react"
-import type { FilterAction } from "types/CourtCaseFilter"
+import type { FilterAction, FilterState } from "types/CourtCaseFilter"
+import { createUseStyles } from "react-jss"
 
 interface Props {
   chipLabel: string
   dispatch: Dispatch<FilterAction>
   removeAction: () => FilterAction
+  state: FilterState
 }
 
-const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction }: Props) => {
+const useStyles = createUseStyles({
+  appliedFilter: {
+    backgroundColor: "#62696D",
+    color: "#ffffff"
+  }
+})
+
+const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction, state }: Props) => {
+  const classes = useStyles()
+  const buttonClass = "moj-filter__tag " + (state === "applied" ? classes.appliedFilter : "")
   return (
     <li>
-      <button className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
+      <button className={buttonClass} onClick={() => dispatch(removeAction())}>
         <span className="govuk-visually-hidden">{"Remove this filter"}</span>
         {chipLabel}
       </button>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -2,17 +2,18 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { MouseEvent } from "react"
+import type { Dispatch } from "react"
+import type { FilterAction } from "types/CourtCaseFilter"
+
 interface Props {
-  tag: string
   chipLabel: string
-  paramName: string
-  onClick: (option: string) => void
+  dispatch: Dispatch<FilterAction>
+  removeAction: () => FilterAction
 }
 
-const FilterChip: React.FC<Props> = ({ tag, chipLabel, onClick }: Props) => {
+const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction }: Props) => {
   return (
-    <a className={tag} onClick={(event: MouseEvent<HTMLInputElement>) => onClick(event.currentTarget.value)}>
+    <a className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
       <span className="govuk-visually-hidden">{"Remove this filter"}</span>
       {chipLabel}
     </a>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-
 import type { Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
 
@@ -14,10 +10,10 @@ interface Props {
 const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction }: Props) => {
   return (
     <li>
-      <a className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
+      <button className="moj-filter__tag" onClick={() => dispatch(removeAction())}>
         <span className="govuk-visually-hidden">{"Remove this filter"}</span>
         {chipLabel}
-      </a>
+      </button>
     </li>
   )
 }

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -12,7 +12,14 @@ interface Props {
 const useStyles = createUseStyles({
   appliedFilter: {
     backgroundColor: "#62696D",
-    color: "#ffffff"
+    color: "#ffffff",
+    "&:hover": {
+      backgroundColor: "#62696D",
+      color: "#ffffff"
+    },
+    "&:after": {
+      backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"
+    }
   }
 })
 

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+
+import { useRouter } from "next/router"
+import { deleteQueryParam } from "utils/deleteQueryParam"
+
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+interface Props {
+  tag: string
+  chipLabel: string
+  paramName: string
+}
+
+const FilterChip: React.FC<Props> = ({ tag, chipLabel, paramName }: Props) => {
+  const { query, basePath } = useRouter()
+
+  const removeFilterParams = deleteQueryParam({ [paramName]: chipLabel }, query)
+  const removeFilterUrl = `${basePath}/?${removeFilterParams}`
+
+  return (
+    <a className={tag} href={removeFilterUrl}>
+      <span className="govuk-visually-hidden">{"Remove this filter"}</span>
+      {chipLabel}
+    </a>
+  )
+}
+
+export default FilterChip

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -1,11 +1,17 @@
 import RadioButton from "components/RadioButton/RadioButton"
 import type { ChangeEvent, Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
+import KeyValuePair from "types/KeyValuePair"
 import lockedFilters from "utils/lockedFilters"
 
 interface Props {
-  locked?: string | null
+  locked?: boolean
   dispatch: Dispatch<FilterAction>
+}
+
+const LockedOptions: KeyValuePair<string, boolean> = {
+  Locked: true,
+  Unlocked: false
 }
 
 const LockedFilterOptions: React.FC<Props> = ({ locked, dispatch }: Props) => {
@@ -13,16 +19,16 @@ const LockedFilterOptions: React.FC<Props> = ({ locked, dispatch }: Props) => {
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Locked state"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
-        {lockedFilters.map((lockedFilter) => (
+        {lockedFilters.map((optionName) => (
           <RadioButton
             name={"locked"}
-            key={lockedFilter.toLowerCase()}
-            id={lockedFilter.toLowerCase()}
-            checked={locked === lockedFilter}
-            value={lockedFilter}
-            label={lockedFilter + " cases only"}
+            key={optionName.toLowerCase()}
+            id={optionName.toLowerCase()}
+            checked={locked === LockedOptions[optionName]}
+            value={optionName}
+            label={optionName + " cases only"}
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
-              dispatch({ method: "add", type: "locked", value: event.target.value })
+              dispatch({ method: "add", type: "locked", value: LockedOptions[event.target.value] })
             }}
           />
         ))}

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -1,5 +1,5 @@
 import RadioButton from "components/RadioButton/RadioButton"
-import type { Dispatch } from "react"
+import type { ChangeEvent, Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
 import lockedFilters from "utils/lockedFilters"
 
@@ -18,12 +18,11 @@ const LockedFilterOptions: React.FC<Props> = ({ locked, dispatch }: Props) => {
             name={"locked"}
             key={lockedFilter.toLowerCase()}
             id={lockedFilter.toLowerCase()}
-            defaultChecked={locked === lockedFilter}
+            checked={locked === lockedFilter}
             value={lockedFilter}
             label={lockedFilter + " cases only"}
-            onClick={(option: string) => {
-              const value = option === "Locked"
-              dispatch({ method: "add", type: "locked", value })
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              dispatch({ method: "add", type: "locked", value: event.target.value })
             }}
           />
         ))}

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -3,9 +3,10 @@ import lockedFilters from "utils/lockedFilters"
 
 interface Props {
   locked?: string | null
+  onClick: (option: string) => void
 }
 
-const LockedFilterOptions: React.FC<Props> = ({ locked }: Props) => {
+const LockedFilterOptions: React.FC<Props> = ({ locked, onClick }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Locked state"}</legend>
@@ -18,6 +19,7 @@ const LockedFilterOptions: React.FC<Props> = ({ locked }: Props) => {
             defaultChecked={locked === lockedFilter}
             value={lockedFilter}
             label={lockedFilter + " cases only"}
+            onClick={(option: string) => onClick(option)}
           />
         ))}
       </div>

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -1,12 +1,14 @@
 import RadioButton from "components/RadioButton/RadioButton"
+import type { Dispatch } from "react"
+import type { FilterAction } from "types/CourtCaseFilter"
 import lockedFilters from "utils/lockedFilters"
 
 interface Props {
   locked?: string | null
-  onClick: (option: string) => void
+  dispatch: Dispatch<FilterAction>
 }
 
-const LockedFilterOptions: React.FC<Props> = ({ locked, onClick }: Props) => {
+const LockedFilterOptions: React.FC<Props> = ({ locked, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Locked state"}</legend>
@@ -19,7 +21,10 @@ const LockedFilterOptions: React.FC<Props> = ({ locked, onClick }: Props) => {
             defaultChecked={locked === lockedFilter}
             value={lockedFilter}
             label={lockedFilter + " cases only"}
-            onClick={(option: string) => onClick(option)}
+            onClick={(option: string) => {
+              const value = option === "Locked"
+              dispatch({ method: "add", type: "locked", value })
+            }}
           />
         ))}
       </div>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -25,7 +25,6 @@ const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultCheck
           if (onClick) {
             onClick(event.currentTarget.value)
           }
-          console.log(event.currentTarget.nextSibling)
         }}
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { MouseEvent } from "react"
+
 interface Props {
   name: string
   id: string
@@ -7,7 +7,7 @@ interface Props {
   defaultChecked: boolean
   value?: string
   label: string
-  onClick: boolean
+  onClick?: (option: string) => void
 }
 
 const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultChecked, value, label, onClick }: Props) => {
@@ -21,7 +21,12 @@ const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultCheck
         data-aria-controls={dataAriaControls}
         value={value}
         defaultChecked={defaultChecked}
-        onClick={onClick}
+        onClick={(event: MouseEvent<HTMLInputElement>) => {
+          if (onClick) {
+            onClick(event.currentTarget.value)
+          }
+          console.log(event.currentTarget.nextSibling)
+        }}
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>
         {label}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from "react"
+import type { MouseEvent } from "react"
 
 interface Props {
   name: string

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,16 +1,28 @@
-import type { MouseEvent } from "react"
+import type { ChangeEvent, MouseEvent } from "react"
 
 interface Props {
   name: string
   id: string
   dataAriaControls?: string
-  defaultChecked: boolean
+  defaultChecked?: boolean
+  checked?: boolean
   value?: string
   label: string
   onClick?: (option: string) => void
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }
 
-const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultChecked, value, label, onClick }: Props) => {
+const RadioButton: React.FC<Props> = ({
+  name,
+  id,
+  dataAriaControls,
+  defaultChecked,
+  checked,
+  value,
+  label,
+  onClick,
+  onChange
+}: Props) => {
   return (
     <div className="govuk-radios__item">
       <input
@@ -21,11 +33,13 @@ const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultCheck
         data-aria-controls={dataAriaControls}
         value={value}
         defaultChecked={defaultChecked}
+        checked={checked}
         onClick={(event: MouseEvent<HTMLInputElement>) => {
           if (onClick) {
             onClick(event.currentTarget.value)
           }
         }}
+        onChange={onChange}
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>
         {label}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, MouseEvent } from "react"
+import type { ChangeEvent } from "react"
 
 interface Props {
   name: string
@@ -8,7 +8,6 @@ interface Props {
   checked?: boolean
   value?: string
   label: string
-  onClick?: (option: string) => void
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void
 }
 
@@ -20,7 +19,6 @@ const RadioButton: React.FC<Props> = ({
   checked,
   value,
   label,
-  onClick,
   onChange
 }: Props) => {
   return (
@@ -34,11 +32,6 @@ const RadioButton: React.FC<Props> = ({
         value={value}
         defaultChecked={defaultChecked}
         checked={checked}
-        onClick={(event: MouseEvent<HTMLInputElement>) => {
-          if (onClick) {
-            onClick(event.currentTarget.value)
-          }
-        }}
         onChange={onChange}
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 interface Props {
   name: string
   id: string
@@ -5,9 +7,10 @@ interface Props {
   defaultChecked: boolean
   value?: string
   label: string
+  onClick: boolean
 }
 
-const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultChecked, value, label }: Props) => {
+const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultChecked, value, label, onClick }: Props) => {
   return (
     <div className="govuk-radios__item">
       <input
@@ -18,6 +21,7 @@ const RadioButton: React.FC<Props> = ({ name, id, dataAriaControls, defaultCheck
         data-aria-controls={dataAriaControls}
         value={value}
         defaultChecked={defaultChecked}
+        onClick={onClick}
       />
       <label className="govuk-label govuk-radios__label" htmlFor={id}>
         {label}

--- a/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export const ShouldBeAccessible: ComponentStory<typeof CourtCaseFilter> = () => (
   <div data-testid="filters">
-    <CourtCaseFilter courtCaseTypes={["Exceptions", "Triggers"]} urgency={"Urgent"} />
+    <CourtCaseFilter />
   </div>
 )
 
@@ -22,9 +22,7 @@ ShouldBeAccessible.play = async ({ canvasElement }) => {
   expect(await axe(pagination)).toHaveNoViolations()
 }
 
-export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> = () => (
-  <CourtCaseFilter courtCaseTypes={["Exceptions", "Triggers"]} urgency={"Urgent"} />
-)
+export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> = () => <CourtCaseFilter />
 
 WhenThereAreFiltersApplied.play = ({ canvasElement }) => {
   const canvas = within(canvasElement)

--- a/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export const ShouldBeAccessible: ComponentStory<typeof CourtCaseFilter> = () => (
   <div data-testid="filters">
-    <CourtCaseFilter />
+    <CourtCaseFilter courtCaseTypes={[]} dateRange={null} urgency={null} locked={null} />
   </div>
 )
 
@@ -22,7 +22,9 @@ ShouldBeAccessible.play = async ({ canvasElement }) => {
   expect(await axe(pagination)).toHaveNoViolations()
 }
 
-export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> = () => <CourtCaseFilter />
+export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> = () => (
+  <CourtCaseFilter courtCaseTypes={["Exceptions"]} dateRange={"today"} urgency={"Urgent"} locked={"Locked"} />
+)
 
 WhenThereAreFiltersApplied.play = ({ canvasElement }) => {
   const canvas = within(canvasElement)

--- a/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
@@ -29,9 +29,8 @@ export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> 
 WhenThereAreFiltersApplied.play = ({ canvasElement }) => {
   const canvas = within(canvasElement)
   expect(canvas.queryByText("Filter")).toBeInTheDocument()
-  expect(canvas.queryByText("Selected filters")).toBeInTheDocument()
+  expect(canvas.queryByText("Applied filters")).toBeInTheDocument()
   expect(canvas.queryByText("Apply filters")).toBeInTheDocument()
   expect(canvas.queryByText("Keywords")).toBeInTheDocument()
   expect(canvas.queryByText("Defendent name, Court name, Reason, PTIURN")).toBeInTheDocument()
-  expect(canvas.queryByText("Urgency")).toBeInTheDocument()
 }

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -68,8 +68,6 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
 
   const [state, dispatch] = useReducer(reducer, initialFilterState)
 
-  console.log(state)
-
   return (
     <form method={"get"}>
       <div className="moj-filter__header">

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
-import FilterChip from "components/FilterChip"
-import If from "components/If"
 import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { useReducer } from "react"
 import { Reason } from "types/CaseListQueryParams"
 import type { Filter, FilterAction } from "types/CourtCaseFilter"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
+import FilterChipSection from "./FilterChipSection"
 
 interface Props {
   courtCaseTypes: Reason[]
@@ -23,20 +22,20 @@ const reducer = (state: Filter, action: FilterAction): Filter => {
     if (action.type === "urgency") {
       newState.urgentFilter.value = action.value
       newState.urgentFilter.label = action.value ? "Urgent" : "Non-urgent"
-      newState.urgentFilter.state = "selected"
+      newState.urgentFilter.state = "Selected"
     } else if (action.type === "date") {
       newState.dateFilter.value = action.value
       newState.dateFilter.label = action.value
-      newState.dateFilter.state = "selected"
+      newState.dateFilter.state = "Selected"
     } else if (action.type === "locked") {
       newState.lockedFilter.value = action.value
       newState.lockedFilter.label = action.value ? "Locked" : "Unlocked"
-      newState.lockedFilter.state = "selected"
+      newState.lockedFilter.state = "Selected"
     } else if (action.type === "reason") {
       // React might invoke our reducer more than once for a single event,
       // so avoid duplicating reason filters
       if (newState.reasonFilter.filter((reasonFilter) => reasonFilter.value === action.value).length < 1) {
-        newState.reasonFilter.push({ value: action.value, state: "selected" })
+        newState.reasonFilter.push({ value: action.value, state: "Selected" })
       }
     }
   } else if (action.method === "remove") {
@@ -58,29 +57,15 @@ const reducer = (state: Filter, action: FilterAction): Filter => {
 
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
   const initialFilterState: Filter = {
-    urgentFilter: urgency !== null ? { value: urgency === "Urgent", state: "applied", label: urgency } : {},
-    dateFilter: dateRange !== null ? { value: dateRange, state: "applied", label: dateRange } : {},
-    lockedFilter: locked !== null ? { value: locked === "Locked", state: "applied", label: locked } : {},
+    urgentFilter: urgency !== null ? { value: urgency === "Urgent", state: "Applied", label: urgency } : {},
+    dateFilter: dateRange !== null ? { value: dateRange, state: "Applied", label: dateRange } : {},
+    lockedFilter: locked !== null ? { value: locked === "Locked", state: "Applied", label: locked } : {},
     reasonFilter: courtCaseTypes.map((courtCaseType) => {
-      return { value: courtCaseType, state: "applied" }
+      return { value: courtCaseType, state: "Applied" }
     })
   }
 
   const [state, dispatch] = useReducer(reducer, initialFilterState)
-  const noSelectedFilter =
-    [state.dateFilter, state.lockedFilter, state.urgentFilter]
-      .map((filter): number => {
-        return filter.value !== undefined && filter.state === "selected" ? 1 : 0
-      })
-      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === "selected").length
-
-  const noAppliedFilters =
-    [state.dateFilter, state.lockedFilter, state.urgentFilter]
-      .map((filter): number => {
-        return filter.value !== undefined && filter.state === "applied" ? 1 : 0
-      })
-      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === "applied").length
-
   return (
     <form method={"get"}>
       <div className="moj-filter__header">
@@ -93,158 +78,8 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
         <div className="moj-filter__selected">
           <div className="moj-filter__selected-heading">
             <div className="moj-filter__heading-title">
-              <If condition={noAppliedFilters > 0}>
-                <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Applied filters"}</h2>
-                <ul className="moj-filter-tags">
-                  <If
-                    condition={
-                      state.urgentFilter.value !== undefined &&
-                      state.urgentFilter.label !== undefined &&
-                      state.urgentFilter.state === "applied"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
-                    <FilterChip
-                      chipLabel={state.urgentFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
-                      }}
-                      state={state.urgentFilter.state || "applied"}
-                    />
-                  </If>
-                  <If
-                    condition={
-                      state.dateFilter.value !== undefined &&
-                      state.dateFilter.label !== undefined &&
-                      state.dateFilter.state === "applied"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
-                    <FilterChip
-                      chipLabel={state.dateFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "date", value: state.dateFilter.value! }
-                      }}
-                      state={state.dateFilter.state || "applied"}
-                    />
-                  </If>
-                  <If
-                    condition={
-                      state.lockedFilter.value !== undefined &&
-                      state.lockedFilter.label !== undefined &&
-                      state.lockedFilter.state === "applied"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
-                    <FilterChip
-                      chipLabel={state.lockedFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
-                      }}
-                      state={state.lockedFilter.state || "applied"}
-                    />
-                  </If>
-                  <If
-                    condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === "applied").length > 0}
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
-                  </If>
-
-                  {state.reasonFilter
-                    .filter((reasonFilter) => reasonFilter.state === "applied")
-                    .map((reasonFilter) => (
-                      <FilterChip
-                        key={reasonFilter.value}
-                        chipLabel={reasonFilter.value}
-                        dispatch={dispatch}
-                        removeAction={() => {
-                          return { method: "remove", type: "reason", value: reasonFilter.value }
-                        }}
-                        state={reasonFilter.state}
-                      />
-                    ))}
-                </ul>
-              </If>
-              <If condition={noSelectedFilter > 0}>
-                <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
-                <ul className="moj-filter-tags">
-                  <If
-                    condition={
-                      state.urgentFilter.value !== undefined &&
-                      state.urgentFilter.label !== undefined &&
-                      state.urgentFilter.state === "selected"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
-                    <FilterChip
-                      chipLabel={state.urgentFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
-                      }}
-                      state={state.urgentFilter.state || "selected"}
-                    />
-                  </If>
-                  <If
-                    condition={
-                      state.dateFilter.value !== undefined &&
-                      state.dateFilter.label !== undefined &&
-                      state.dateFilter.state === "selected"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
-                    <FilterChip
-                      chipLabel={state.dateFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "date", value: state.dateFilter.value! }
-                      }}
-                      state={state.dateFilter.state || "selected"}
-                    />
-                  </If>
-                  <If
-                    condition={
-                      state.lockedFilter.value !== undefined &&
-                      state.lockedFilter.label !== undefined &&
-                      state.lockedFilter.state === "selected"
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
-                    <FilterChip
-                      chipLabel={state.lockedFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
-                      }}
-                      state={state.lockedFilter.state || "selected"}
-                    />
-                  </If>
-                  <If
-                    condition={
-                      state.reasonFilter.filter((reasonFilter) => reasonFilter.state === "selected").length > 0
-                    }
-                  >
-                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
-                  </If>
-
-                  {state.reasonFilter
-                    .filter((reasonFilter) => reasonFilter.state === "selected")
-                    .map((reasonFilter) => (
-                      <FilterChip
-                        key={reasonFilter.value}
-                        chipLabel={reasonFilter.value}
-                        dispatch={dispatch}
-                        removeAction={() => {
-                          return { method: "remove", type: "reason", value: reasonFilter.value }
-                        }}
-                        state={reasonFilter.state}
-                      />
-                    ))}
-                </ul>
-              </If>
+              <FilterChipSection state={state} dispatch={dispatch} sectionState={"Applied"} />
+              <FilterChipSection state={state} dispatch={dispatch} sectionState={"Selected"} />
             </div>
           </div>
         </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -68,45 +68,43 @@ const CourtCaseFilter: React.FC = () => {
             <div className="moj-filter__heading-title">
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
-                <li>
-                  <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
-                    <FilterChip
-                      chipLabel={state.urgentFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
-                      }}
-                    />
-                  </If>
-                  <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
-                    <FilterChip
-                      chipLabel={state.dateFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "date", value: state.dateFilter.value! }
-                      }}
-                    />
-                  </If>
-                  <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
-                    <FilterChip
-                      chipLabel={state.lockedFilter.label!}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
-                      }}
-                    />
-                  </If>
-                  {state.reasonFilter.value.map((reason: Reason) => (
-                    <FilterChip
-                      key={reason}
-                      chipLabel={reason}
-                      dispatch={dispatch}
-                      removeAction={() => {
-                        return { method: "remove", type: "reason", value: reason }
-                      }}
-                    />
-                  ))}
-                </li>
+                <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
+                  <FilterChip
+                    chipLabel={state.urgentFilter.label!}
+                    dispatch={dispatch}
+                    removeAction={() => {
+                      return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
+                    }}
+                  />
+                </If>
+                <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
+                  <FilterChip
+                    chipLabel={state.dateFilter.label!}
+                    dispatch={dispatch}
+                    removeAction={() => {
+                      return { method: "remove", type: "date", value: state.dateFilter.value! }
+                    }}
+                  />
+                </If>
+                <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
+                  <FilterChip
+                    chipLabel={state.lockedFilter.label!}
+                    dispatch={dispatch}
+                    removeAction={() => {
+                      return { method: "remove", type: "locked", value: state.lockedFilter.value! }
+                    }}
+                  />
+                </If>
+                {state.reasonFilter.value.map((reason: Reason) => (
+                  <FilterChip
+                    key={reason}
+                    chipLabel={reason}
+                    dispatch={dispatch}
+                    removeAction={() => {
+                      return { method: "remove", type: "reason", value: reason }
+                    }}
+                  />
+                ))}
               </ul>
             </div>
           </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -51,19 +51,28 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     tag={urgentFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
                     chipLabel={urgentFilterState.label[0]}
                     paramName="urgency"
+                    onClick={() => urgentFilterState.filter[1](undefined)}
                   />
                   <FilterChip
                     tag={dateFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
                     chipLabel={dateFilterState.label[0]}
                     paramName="dateRange"
+                    onClick={() => dateFilterState.filter[1](undefined)}
                   />
                   <FilterChip
                     tag={lockedFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
                     chipLabel={lockedFilterState.label[0]}
                     paramName="locked"
+                    onClick={() => lockedFilterState.filter[1](undefined)}
                   />
                   {reasonFilterState.filter[0].map((reason: string) => (
-                    <FilterChip key={reason} tag="moj-filter__tag" chipLabel={reason} paramName="type" />
+                    <FilterChip
+                      key={reason}
+                      tag="moj-filter__tag"
+                      chipLabel={reason}
+                      paramName="type"
+                      onClick={() => reasonFilterState.filter[1]([])}
+                    />
                   ))}
                 </li>
               </ul>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -7,7 +7,7 @@ import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { useReducer } from "react"
 import { Reason } from "types/CaseListQueryParams"
-import type { FilterAction, Filter } from "types/CourtCaseFilter"
+import type { Filter, FilterAction } from "types/CourtCaseFilter"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 
 interface Props {
@@ -67,6 +67,19 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
   }
 
   const [state, dispatch] = useReducer(reducer, initialFilterState)
+  const noSelectedFilter =
+    [state.dateFilter, state.lockedFilter, state.urgentFilter]
+      .map((filter): number => {
+        return filter.value !== undefined && filter.state === "selected" ? 1 : 0
+      })
+      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === "selected").length
+
+  const noAppliedFilters =
+    [state.dateFilter, state.lockedFilter, state.urgentFilter]
+      .map((filter): number => {
+        return filter.value !== undefined && filter.state === "applied" ? 1 : 0
+      })
+      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === "applied").length
 
   return (
     <form method={"get"}>
@@ -80,57 +93,158 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
         <div className="moj-filter__selected">
           <div className="moj-filter__selected-heading">
             <div className="moj-filter__heading-title">
-              <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
-              <ul className="moj-filter-tags">
-                <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
-                  <FilterChip
-                    chipLabel={state.urgentFilter.label!}
-                    dispatch={dispatch}
-                    removeAction={() => {
-                      return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
-                    }}
-                    state={state.urgentFilter.state || "selected"}
-                  />
-                </If>
-                <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
-                  <FilterChip
-                    chipLabel={state.dateFilter.label!}
-                    dispatch={dispatch}
-                    removeAction={() => {
-                      return { method: "remove", type: "date", value: state.dateFilter.value! }
-                    }}
-                    state={state.dateFilter.state || "selected"}
-                  />
-                </If>
-                <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
-                  <FilterChip
-                    chipLabel={state.lockedFilter.label!}
-                    dispatch={dispatch}
-                    removeAction={() => {
-                      return { method: "remove", type: "locked", value: state.lockedFilter.value! }
-                    }}
-                    state={state.lockedFilter.state || "selected"}
-                  />
-                </If>
-                <If condition={state.reasonFilter.length > 0}>
-                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
-                </If>
+              <If condition={noAppliedFilters > 0}>
+                <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Applied filters"}</h2>
+                <ul className="moj-filter-tags">
+                  <If
+                    condition={
+                      state.urgentFilter.value !== undefined &&
+                      state.urgentFilter.label !== undefined &&
+                      state.urgentFilter.state === "applied"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
+                    <FilterChip
+                      chipLabel={state.urgentFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
+                      }}
+                      state={state.urgentFilter.state || "applied"}
+                    />
+                  </If>
+                  <If
+                    condition={
+                      state.dateFilter.value !== undefined &&
+                      state.dateFilter.label !== undefined &&
+                      state.dateFilter.state === "applied"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
+                    <FilterChip
+                      chipLabel={state.dateFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "date", value: state.dateFilter.value! }
+                      }}
+                      state={state.dateFilter.state || "applied"}
+                    />
+                  </If>
+                  <If
+                    condition={
+                      state.lockedFilter.value !== undefined &&
+                      state.lockedFilter.label !== undefined &&
+                      state.lockedFilter.state === "applied"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
+                    <FilterChip
+                      chipLabel={state.lockedFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
+                      }}
+                      state={state.lockedFilter.state || "applied"}
+                    />
+                  </If>
+                  <If
+                    condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === "applied").length > 0}
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
+                  </If>
 
-                {state.reasonFilter.map((reasonFilter) => (
-                  <FilterChip
-                    key={reasonFilter.value}
-                    chipLabel={reasonFilter.value}
-                    dispatch={dispatch}
-                    removeAction={() => {
-                      return { method: "remove", type: "reason", value: reasonFilter.value }
-                    }}
-                    state={reasonFilter.state}
-                  />
-                ))}
-              </ul>
+                  {state.reasonFilter
+                    .filter((reasonFilter) => reasonFilter.state === "applied")
+                    .map((reasonFilter) => (
+                      <FilterChip
+                        key={reasonFilter.value}
+                        chipLabel={reasonFilter.value}
+                        dispatch={dispatch}
+                        removeAction={() => {
+                          return { method: "remove", type: "reason", value: reasonFilter.value }
+                        }}
+                        state={reasonFilter.state}
+                      />
+                    ))}
+                </ul>
+              </If>
+              <If condition={noSelectedFilter > 0}>
+                <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
+                <ul className="moj-filter-tags">
+                  <If
+                    condition={
+                      state.urgentFilter.value !== undefined &&
+                      state.urgentFilter.label !== undefined &&
+                      state.urgentFilter.state === "selected"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
+                    <FilterChip
+                      chipLabel={state.urgentFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
+                      }}
+                      state={state.urgentFilter.state || "selected"}
+                    />
+                  </If>
+                  <If
+                    condition={
+                      state.dateFilter.value !== undefined &&
+                      state.dateFilter.label !== undefined &&
+                      state.dateFilter.state === "selected"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
+                    <FilterChip
+                      chipLabel={state.dateFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "date", value: state.dateFilter.value! }
+                      }}
+                      state={state.dateFilter.state || "selected"}
+                    />
+                  </If>
+                  <If
+                    condition={
+                      state.lockedFilter.value !== undefined &&
+                      state.lockedFilter.label !== undefined &&
+                      state.lockedFilter.state === "selected"
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
+                    <FilterChip
+                      chipLabel={state.lockedFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
+                      }}
+                      state={state.lockedFilter.state || "selected"}
+                    />
+                  </If>
+                  <If
+                    condition={
+                      state.reasonFilter.filter((reasonFilter) => reasonFilter.state === "selected").length > 0
+                    }
+                  >
+                    <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
+                  </If>
+
+                  {state.reasonFilter
+                    .filter((reasonFilter) => reasonFilter.state === "selected")
+                    .map((reasonFilter) => (
+                      <FilterChip
+                        key={reasonFilter.value}
+                        chipLabel={reasonFilter.value}
+                        dispatch={dispatch}
+                        removeAction={() => {
+                          return { method: "remove", type: "reason", value: reasonFilter.value }
+                        }}
+                        state={reasonFilter.state}
+                      />
+                    ))}
+                </ul>
+              </If>
             </div>
           </div>
         </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -20,7 +20,7 @@ const reducer = (state: FilterState, action: FilterAction) => {
       newState.dateFilter.value = action.value
       newState.dateFilter.label = action.value
     } else if (action.type === "locked") {
-      newState.lockedFilter.value = action.value ? "Locked" : "Unlocked"
+      newState.lockedFilter.value = action.value
       newState.lockedFilter.label = action.value ? "Locked" : "Unlocked"
     } else if (action.type === "reason") {
       // React might invoke our reducer more than once for a single event,
@@ -129,11 +129,9 @@ const CourtCaseFilter: React.FC = () => {
             <CourtDateFilterOptions dateRange={state.dateFilter.value} dispatch={dispatch} />
           </div>
           <div>
-            {/* TODO fix state updates */}
-            <UrgencyFilterOptions urgency={"Urgent"} dispatch={dispatch} />
+            <UrgencyFilterOptions urgency={state.urgentFilter.value} dispatch={dispatch} />
           </div>
           <div>
-            {/* TODO selecting "non-urgent" doesn't work */}
             <LockedFilterOptions locked={state.lockedFilter.value} dispatch={dispatch} />
           </div>
         </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
+import If from "components/If"
 import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { useReducer } from "react"
 import { Reason } from "types/CaseListQueryParams"
 import type { Filter, FilterAction } from "types/CourtCaseFilter"
+import { countFilterChips } from "utils/filterChips"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 import FilterChipSection from "./FilterChipSection"
 
@@ -66,6 +68,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
   }
 
   const [state, dispatch] = useReducer(reducer, initialFilterState)
+
   return (
     <form method={"get"}>
       <div className="moj-filter__header">
@@ -75,14 +78,16 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
         <div className="moj-filter__header-action"></div>
       </div>
       <div className="moj-filter__content">
-        <div className="moj-filter__selected">
-          <div className="moj-filter__selected-heading">
-            <div className="moj-filter__heading-title">
-              <FilterChipSection state={state} dispatch={dispatch} sectionState={"Applied"} />
-              <FilterChipSection state={state} dispatch={dispatch} sectionState={"Selected"} />
+        <If condition={countFilterChips(state) > 0}>
+          <div className="moj-filter__selected">
+            <div className="moj-filter__selected-heading">
+              <div className="moj-filter__heading-title">
+                <FilterChipSection state={state} dispatch={dispatch} sectionState={"Applied"} />
+                <FilterChipSection state={state} dispatch={dispatch} sectionState={"Selected"} />
+              </div>
             </div>
           </div>
-        </div>
+        </If>
         <div className="moj-filter__options">
           <button className="govuk-button" data-module="govuk-button" id="search">
             {"Apply filters"}

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -27,6 +27,10 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
     filter: useState<boolean | undefined>(undefined),
     label: useState<string>("")
   }
+  const reasonFilterState = {
+    filter: useState<string[]>([]),
+    label: useState<string>("")
+  }
 
   return (
     <form method={"get"}>
@@ -58,6 +62,9 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     chipLabel={lockedFilterState.label[0]}
                     paramName="locked"
                   />
+                  {reasonFilterState.filter[0].map((reason: string) => (
+                    <FilterChip key={reason} tag="moj-filter__tag" chipLabel={reason} paramName="type" />
+                  ))}
                 </li>
               </ul>
             </div>
@@ -75,7 +82,13 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <input className="govuk-input" id="keywords" name="keywords" type="text"></input>
           </div>
           <div className="govuk-form-group">
-            <CourtCaseTypeOptions courtCaseTypes={courtCaseTypes} />
+            <CourtCaseTypeOptions
+              courtCaseTypes={courtCaseTypes}
+              onClick={(option: string) => {
+                reasonFilterState.filter[1]([...reasonFilterState.filter[0], option])
+                reasonFilterState.label[1](option)
+              }}
+            />
           </div>
           <div className="govuk-form-group">
             <CourtDateFilterOptions

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -15,9 +15,18 @@ interface Props {
 }
 
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
-  const [filter, setFilter] = useState<boolean | undefined>(undefined)
-  const [filterChipLabel, setFilterChipLabel] = useState("")
-  const filterTag = filter !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"
+  const urgentFilterState = {
+    filter: useState<boolean | undefined>(undefined),
+    label: useState<string>("")
+  }
+  const dateFilterState = {
+    filter: useState<string | undefined>(undefined),
+    label: useState<string>("")
+  }
+  const lockedFilterState = {
+    filter: useState<boolean | undefined>(undefined),
+    label: useState<string>("")
+  }
 
   return (
     <form method={"get"}>
@@ -33,7 +42,23 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <div className="moj-filter__heading-title">
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
-                <li>{<FilterChip tag={filterTag} chipLabel={filterChipLabel} paramName="urgency" />}</li>
+                <li>
+                  <FilterChip
+                    tag={urgentFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
+                    chipLabel={urgentFilterState.label[0]}
+                    paramName="urgency"
+                  />
+                  <FilterChip
+                    tag={dateFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
+                    chipLabel={dateFilterState.label[0]}
+                    paramName="dateRange"
+                  />
+                  <FilterChip
+                    tag={lockedFilterState.filter[0] !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
+                    chipLabel={lockedFilterState.label[0]}
+                    paramName="locked"
+                  />
+                </li>
               </ul>
             </div>
           </div>
@@ -53,20 +78,33 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <CourtCaseTypeOptions courtCaseTypes={courtCaseTypes} />
           </div>
           <div className="govuk-form-group">
-            <CourtDateFilterOptions dateRange={dateRange} />
+            <CourtDateFilterOptions
+              dateRange={dateRange}
+              onClick={(option: string) => {
+                dateFilterState.filter[1](option)
+                dateFilterState.label[1](option)
+              }}
+            />
           </div>
           <div>
             <UrgencyFilterOptions
               urgency={urgency}
               onClick={(option: string) => {
                 const filterValue = option === "Urgent" ? true : option === "Non-urgent" ? false : undefined
-                setFilter(filterValue)
-                setFilterChipLabel(option)
+                urgentFilterState.filter[1](filterValue)
+                urgentFilterState.label[1](option)
               }}
             />
           </div>
           <div>
-            <LockedFilterOptions locked={locked} />
+            <LockedFilterOptions
+              locked={locked}
+              onClick={(option: string) => {
+                const filterValue = option === "Locked" ? true : option === "Unlocked" ? false : undefined
+                lockedFilterState.filter[1](filterValue)
+                lockedFilterState.label[1](option)
+              }}
+            />
           </div>
         </div>
       </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -15,10 +15,25 @@ interface Props {
   urgency?: string | null
   locked?: string | null
 }
+
+interface FilterChipProps {
+  tag: string
+  chipLabel: string
+}
+
+const FilterChip: React.FC<FilterChipProps> = ({ tag, chipLabel }: FilterChipProps) => {
+  return (
+    <a className={tag} href="#">
+      <span className="govuk-visually-hidden">{"Remove this filter"}</span>
+      {chipLabel}
+    </a>
+  )
+}
+
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
-  const [isVisible, setVisible] = useState(false)
-  const [isLabel, setLabel] = useState("")
-  console.log(isLabel)
+  const [filter, setFilter] = useState<boolean | undefined>(undefined)
+  const [label, setLabel] = useState("")
+  const filterTag = filter !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"
 
   return (
     <form method={"get"}>
@@ -34,12 +49,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <div className="moj-filter__heading-title">
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
-                <li>
-                  <a className={isVisible ? "moj-filter__tag" : "moj-filter moj-hidden"} href="#">
-                    <span className="govuk-visually-hidden">{"Remove this filter"}</span>
-                    {isLabel}
-                  </a>
-                </li>
+                <li>{<FilterChip tag={filterTag} chipLabel={label} />}</li>
               </ul>
             </div>
           </div>
@@ -64,10 +74,12 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
           <div>
             <UrgencyFilterOptions
               urgency={urgency}
-              onClick={() => {
-                setVisible(!isVisible)
+              onClick={(option: string) => {
+                const filterValue = option === "Urgent" ? true : option === "Non-urgent" ? false : undefined
+                setFilter(filterValue)
+                setLabel(option)
+                console.log(filterValue)
               }}
-              setLabel={setLabel}
             />
           </div>
           <div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -70,7 +70,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
   const [state, dispatch] = useReducer(reducer, initialFilterState)
 
   return (
-    <form method={"get"}>
+    <form method={"get"} id="filter-panel">
       <div className="moj-filter__header">
         <div className="moj-filter__header-title">
           <h2 className="govuk-heading-m">{"Filter"}</h2>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -69,6 +69,7 @@ const CourtCaseFilter: React.FC = () => {
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
                 <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
                   <FilterChip
                     chipLabel={state.urgentFilter.label!}
                     dispatch={dispatch}
@@ -78,6 +79,7 @@ const CourtCaseFilter: React.FC = () => {
                   />
                 </If>
                 <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
                   <FilterChip
                     chipLabel={state.dateFilter.label!}
                     dispatch={dispatch}
@@ -87,6 +89,7 @@ const CourtCaseFilter: React.FC = () => {
                   />
                 </If>
                 <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
                   <FilterChip
                     chipLabel={state.lockedFilter.label!}
                     dispatch={dispatch}
@@ -95,6 +98,10 @@ const CourtCaseFilter: React.FC = () => {
                     }}
                   />
                 </If>
+                <If condition={state.reasonFilter.value.length > 0}>
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
+                </If>
+
                 {state.reasonFilter.value.map((reason: Reason) => (
                   <FilterChip
                     key={reason}

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -82,8 +82,13 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
           <div className="moj-filter__selected">
             <div className="moj-filter__selected-heading">
               <div className="moj-filter__heading-title">
-                <FilterChipSection state={state} dispatch={dispatch} sectionState={"Applied"} />
-                <FilterChipSection state={state} dispatch={dispatch} sectionState={"Selected"} />
+                <FilterChipSection state={state} dispatch={dispatch} sectionState={"Applied"} marginTop={false} />
+                <FilterChipSection
+                  state={state}
+                  dispatch={dispatch}
+                  sectionState={"Selected"}
+                  marginTop={countFilterChips(state, "Applied") > 0}
+                />
               </div>
             </div>
           </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -10,13 +10,6 @@ import { Reason } from "types/CaseListQueryParams"
 import type { FilterAction, FilterState } from "types/CourtCaseFilter"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 
-interface Props {
-  courtCaseTypes?: Reason[]
-  dateRange?: string | null
-  urgency?: string | null
-  locked?: string | null
-}
-
 const reducer = (state: FilterState, action: FilterAction) => {
   const newState = Object.assign({}, state)
   if (action.method === "add") {
@@ -25,8 +18,10 @@ const reducer = (state: FilterState, action: FilterAction) => {
       newState.urgentFilter.label = action.value ? "Urgent" : "Non-urgent"
     } else if (action.type === "date") {
       newState.dateFilter.value = action.value
+      newState.dateFilter.label = action.value
     } else if (action.type === "locked") {
-      newState.lockedFilter.value = action.value
+      newState.lockedFilter.value = action.value ? "Locked" : "Unlocked"
+      newState.lockedFilter.label = action.value ? "Locked" : "Unlocked"
     } else if (action.type === "reason") {
       // React might invoke our reducer more than once for a single event,
       // so avoid duplicating reason filters
@@ -37,10 +32,13 @@ const reducer = (state: FilterState, action: FilterAction) => {
   } else if (action.method === "remove") {
     if (action.type === "urgency") {
       newState.urgentFilter.value = undefined
+      newState.urgentFilter.label = undefined
     } else if (action.type === "date") {
       newState.dateFilter.value = undefined
+      newState.dateFilter.label = undefined
     } else if (action.type === "locked") {
       newState.lockedFilter.value = undefined
+      newState.dateFilter.label = undefined
     } else if (action.type === "reason") {
       newState.reasonFilter.value = newState.reasonFilter.value.filter((reason: string) => reason !== action.value)
     }
@@ -48,12 +46,12 @@ const reducer = (state: FilterState, action: FilterAction) => {
   return newState
 }
 
-const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
+const CourtCaseFilter: React.FC = () => {
   const [state, dispatch] = useReducer(reducer, {
     urgentFilter: {},
     dateFilter: {},
     lockedFilter: {},
-    reasonFilter: { value: courtCaseTypes || [] }
+    reasonFilter: { value: [] }
   })
 
   return (
@@ -128,13 +126,15 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <CourtCaseTypeOptions courtCaseTypes={state.reasonFilter.value} dispatch={dispatch} />
           </div>
           <div className="govuk-form-group">
-            <CourtDateFilterOptions dateRange={dateRange} dispatch={dispatch} />
+            <CourtDateFilterOptions dateRange={state.dateFilter.value} dispatch={dispatch} />
           </div>
           <div>
-            <UrgencyFilterOptions urgency={urgency} dispatch={dispatch} />
+            {/* TODO fix state updates */}
+            <UrgencyFilterOptions urgency={"Urgent"} dispatch={dispatch} />
           </div>
           <div>
-            <LockedFilterOptions locked={locked} dispatch={dispatch} />
+            {/* TODO selecting "non-urgent" doesn't work */}
+            <LockedFilterOptions locked={state.lockedFilter.value} dispatch={dispatch} />
           </div>
         </div>
       </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
+import FilterChip from "components/FilterChip"
 import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { useState } from "react"
@@ -16,23 +14,9 @@ interface Props {
   locked?: string | null
 }
 
-interface FilterChipProps {
-  tag: string
-  chipLabel: string
-}
-
-const FilterChip: React.FC<FilterChipProps> = ({ tag, chipLabel }: FilterChipProps) => {
-  return (
-    <a className={tag} href="#">
-      <span className="govuk-visually-hidden">{"Remove this filter"}</span>
-      {chipLabel}
-    </a>
-  )
-}
-
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
   const [filter, setFilter] = useState<boolean | undefined>(undefined)
-  const [label, setLabel] = useState("")
+  const [filterChipLabel, setFilterChipLabel] = useState("")
   const filterTag = filter !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"
 
   return (
@@ -49,7 +33,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <div className="moj-filter__heading-title">
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
-                <li>{<FilterChip tag={filterTag} chipLabel={label} />}</li>
+                <li>{<FilterChip tag={filterTag} chipLabel={filterChipLabel} paramName="urgency" />}</li>
               </ul>
             </div>
           </div>
@@ -77,8 +61,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
               onClick={(option: string) => {
                 const filterValue = option === "Urgent" ? true : option === "Non-urgent" ? false : undefined
                 setFilter(filterValue)
-                setLabel(option)
-                console.log(filterValue)
+                setFilterChipLabel(option)
               }}
             />
           </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -18,33 +18,34 @@ interface Props {
 }
 
 const reducer = (state: FilterState, action: FilterAction) => {
+  const newState = Object.assign({}, state)
   if (action.method === "add") {
     if (action.type === "urgency") {
-      state.urgentFilter.value = action.value
-      state.urgentFilter.label = action.value ? "Urgent" : "Non-urgent"
+      newState.urgentFilter.value = action.value
+      newState.urgentFilter.label = action.value ? "Urgent" : "Non-urgent"
     } else if (action.type === "date") {
-      state.dateFilter.value = action.value
+      newState.dateFilter.value = action.value
     } else if (action.type === "locked") {
-      state.lockedFilter.value = action.value
+      newState.lockedFilter.value = action.value
     } else if (action.type === "reason") {
       // React might invoke our reducer more than once for a single event,
       // so avoid duplicating reason filters
-      if (!state.reasonFilter.value.includes(action.value)) {
-        state.reasonFilter.value.push(action.value)
+      if (!newState.reasonFilter.value.includes(action.value)) {
+        newState.reasonFilter.value.push(action.value)
       }
     }
   } else if (action.method === "remove") {
     if (action.type === "urgency") {
-      state.urgentFilter.value = undefined
+      newState.urgentFilter.value = undefined
     } else if (action.type === "date") {
-      state.dateFilter.value = undefined
+      newState.dateFilter.value = undefined
     } else if (action.type === "locked") {
-      state.lockedFilter.value = undefined
+      newState.lockedFilter.value = undefined
     } else if (action.type === "reason") {
-      state.reasonFilter.value = state.reasonFilter.value.filter((reason: string) => reason === action.value)
+      newState.reasonFilter.value = newState.reasonFilter.value.filter((reason: string) => reason === action.value)
     }
   }
-  return state
+  return newState
 }
 
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
 import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
+import { useState } from "react"
 import { Reason } from "types/CaseListQueryParams"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 
@@ -11,8 +15,11 @@ interface Props {
   urgency?: string | null
   locked?: string | null
 }
-
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
+  const [isVisible, setVisible] = useState(false)
+  const [isLabel, setLabel] = useState("")
+  console.log(isLabel)
+
   return (
     <form method={"get"}>
       <div className="moj-filter__header">
@@ -25,7 +32,15 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
         <div className="moj-filter__selected">
           <div className="moj-filter__selected-heading">
             <div className="moj-filter__heading-title">
-              <h2 className="govuk-heading-m">{"Selected filters"}</h2>
+              <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
+              <ul className="moj-filter-tags">
+                <li>
+                  <a className={isVisible ? "moj-filter__tag" : "moj-filter moj-hidden"} href="#">
+                    <span className="govuk-visually-hidden">{"Remove this filter"}</span>
+                    {isLabel}
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -46,8 +61,14 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
           <div className="govuk-form-group">
             <CourtDateFilterOptions dateRange={dateRange} />
           </div>
-          <div className="govuk-form-group">
-            <UrgencyFilterOptions urgency={urgency} />
+          <div>
+            <UrgencyFilterOptions
+              urgency={urgency}
+              onClick={() => {
+                setVisible(!isVisible)
+              }}
+              setLabel={setLabel}
+            />
           </div>
           <div>
             <LockedFilterOptions locked={locked} />

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -18,7 +18,6 @@ interface Props {
 }
 
 const reducer = (state: FilterState, action: FilterAction) => {
-  console.log("reducer action dispatched", state, action)
   if (action.method === "add") {
     if (action.type === "urgency") {
       state.urgentFilter.value = action.value
@@ -28,7 +27,11 @@ const reducer = (state: FilterState, action: FilterAction) => {
     } else if (action.type === "locked") {
       state.lockedFilter.value = action.value
     } else if (action.type === "reason") {
-      state.reasonFilter.value.push(action.value)
+      // React might invoke our reducer more than once for a single event,
+      // so avoid duplicating reason filters
+      if (!state.reasonFilter.value.includes(action.value)) {
+        state.reasonFilter.value.push(action.value)
+      }
     }
   } else if (action.method === "remove") {
     if (action.type === "urgency") {
@@ -45,23 +48,6 @@ const reducer = (state: FilterState, action: FilterAction) => {
 }
 
 const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
-  // const urgentFilterState = {
-  //   filter: useState<boolean | undefined>(undefined),
-  //   label: useState<string>("")
-  // }
-  // const dateFilterState = {
-  //   filter: useState<string | undefined>(undefined),
-  //   label: useState<string>("")
-  // }
-  // const lockedFilterState = {
-  //   filter: useState<boolean | undefined>(undefined),
-  //   label: useState<string>("")
-  // }
-  // const reasonFilterState = {
-  //   filter: useState<string[]>([]),
-  //   label: useState<string>("")
-  // }
-
   const [state, dispatch] = useReducer(reducer, {
     urgentFilter: {},
     dateFilter: {},
@@ -84,39 +70,43 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
               <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{"Selected filters"}</h2>
               <ul className="moj-filter-tags">
                 <li>
-                  <>
-                    {console.log("Rendering urgent filter chip, state: ", state)}
-                    <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
-                      <FilterChip
-                        chipLabel={state.urgentFilter.label!}
-                        dispatch={dispatch}
-                        removeAction={() => {
-                          return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
-                        }}
-                      />
-                    </If>
-                  </>
-                  {/* <FilterChip
-                    tag={state.dateFilter !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
-                    chipLabel={state.dateFilter.label}
-                    paramName="dateRange"
-                    onClick={(option: string) => dispatch({ method: "add", type: "date", value: option })}
-                  />
-                  <FilterChip
-                    tag={state.lockedFilter !== undefined ? "moj-filter__tag" : "moj-filter moj-hidden"}
-                    chipLabel={state.lockedFilter.label}
-                    paramName="locked"
-                    onClick={() => dispatch({ method: "add", type: "locked", value: true })}
-                  />
+                  <If condition={state.urgentFilter.value !== undefined && state.urgentFilter.label !== undefined}>
+                    <FilterChip
+                      chipLabel={state.urgentFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
+                      }}
+                    />
+                  </If>
+                  <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
+                    <FilterChip
+                      chipLabel={state.dateFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "date", value: state.dateFilter.value! }
+                      }}
+                    />
+                  </If>
+                  <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
+                    <FilterChip
+                      chipLabel={state.lockedFilter.label!}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "locked", value: state.lockedFilter.value! }
+                      }}
+                    />
+                  </If>
                   {state.reasonFilter.value.map((reason: Reason) => (
                     <FilterChip
                       key={reason}
-                      tag="moj-filter__tag"
                       chipLabel={reason}
-                      paramName="type"
-                      onClick={() => dispatch({ method: "add", type: "reason", value: reason })}
+                      dispatch={dispatch}
+                      removeAction={() => {
+                        return { method: "remove", type: "reason", value: reason }
+                      }}
                     />
-                  ))} */}
+                  ))}
                 </li>
               </ul>
             </div>
@@ -133,37 +123,18 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <HintText>{"Defendent name, Court name, Reason, PTIURN"}</HintText>
             <input className="govuk-input" id="keywords" name="keywords" type="text"></input>
           </div>
-          {/* <div className="govuk-form-group">
-            <CourtCaseTypeOptions
-              courtCaseTypes={courtCaseTypes}
-              onClick={(option: string) => {
-                reasonFilterState.filter[1]([...reasonFilterState.filter[0], option])
-                reasonFilterState.label[1](option)
-              }}
-            />
+          <div className="govuk-form-group">
+            <CourtCaseTypeOptions courtCaseTypes={courtCaseTypes} dispatch={dispatch} />
           </div>
           <div className="govuk-form-group">
-            <CourtDateFilterOptions
-              dateRange={dateRange}
-              onClick={(option: string) => {
-                dateFilterState.filter[1](option)
-                dateFilterState.label[1](option)
-              }}
-            />
-          </div> */}
+            <CourtDateFilterOptions dateRange={dateRange} dispatch={dispatch} />
+          </div>
           <div>
             <UrgencyFilterOptions urgency={urgency} dispatch={dispatch} />
           </div>
-          {/* <div>
-            <LockedFilterOptions
-              locked={locked}
-              onClick={(option: string) => {
-                const filterValue = option === "Locked" ? true : option === "Unlocked" ? false : undefined
-                lockedFilterState.filter[1](filterValue)
-                lockedFilterState.label[1](option)
-              }}
-            />
-          </div> */}
+          <div>
+            <LockedFilterOptions locked={locked} dispatch={dispatch} />
+          </div>
         </div>
       </div>
     </form>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -42,7 +42,7 @@ const reducer = (state: FilterState, action: FilterAction) => {
     } else if (action.type === "locked") {
       newState.lockedFilter.value = undefined
     } else if (action.type === "reason") {
-      newState.reasonFilter.value = newState.reasonFilter.value.filter((reason: string) => reason === action.value)
+      newState.reasonFilter.value = newState.reasonFilter.value.filter((reason: string) => reason !== action.value)
     }
   }
   return newState
@@ -53,7 +53,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
     urgentFilter: {},
     dateFilter: {},
     lockedFilter: {},
-    reasonFilter: { value: [] }
+    reasonFilter: { value: courtCaseTypes || [] }
   })
 
   return (
@@ -125,7 +125,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <input className="govuk-input" id="keywords" name="keywords" type="text"></input>
           </div>
           <div className="govuk-form-group">
-            <CourtCaseTypeOptions courtCaseTypes={courtCaseTypes} dispatch={dispatch} />
+            <CourtCaseTypeOptions courtCaseTypes={state.reasonFilter.value} dispatch={dispatch} />
           </div>
           <div className="govuk-form-group">
             <CourtDateFilterOptions dateRange={dateRange} dispatch={dispatch} />

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -92,6 +92,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     removeAction={() => {
                       return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
                     }}
+                    state={state.urgentFilter.state || "selected"}
                   />
                 </If>
                 <If condition={state.dateFilter.value !== undefined && state.dateFilter.label !== undefined}>
@@ -102,6 +103,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     removeAction={() => {
                       return { method: "remove", type: "date", value: state.dateFilter.value! }
                     }}
+                    state={state.dateFilter.state || "selected"}
                   />
                 </If>
                 <If condition={state.lockedFilter.value !== undefined && state.lockedFilter.label !== undefined}>
@@ -112,6 +114,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     removeAction={() => {
                       return { method: "remove", type: "locked", value: state.lockedFilter.value! }
                     }}
+                    state={state.lockedFilter.state || "selected"}
                   />
                 </If>
                 <If condition={state.reasonFilter.length > 0}>
@@ -126,6 +129,7 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
                     removeAction={() => {
                       return { method: "remove", type: "reason", value: reasonFilter.value }
                     }}
+                    state={reasonFilter.state}
                   />
                 ))}
               </ul>

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -3,6 +3,7 @@ import FilterChip from "components/FilterChip"
 import If from "components/If"
 import { Dispatch } from "react"
 import { Filter, FilterAction, FilterState } from "types/CourtCaseFilter"
+import { countFilterChips } from "utils/filterChips"
 
 interface Props {
   state: Filter
@@ -11,15 +12,8 @@ interface Props {
 }
 
 const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: Props) => {
-  const noOfChips =
-    [state.dateFilter, state.lockedFilter, state.urgentFilter]
-      .map((filter): number => {
-        return filter.value !== undefined && filter.state === sectionState ? 1 : 0
-      })
-      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === sectionState).length
-
   return (
-    <If condition={noOfChips > 0}>
+    <If condition={countFilterChips(state, sectionState) > 0}>
       <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{`${sectionState} filters`}</h2>
       <ul className="moj-filter-tags">
         <If

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import FilterChip from "components/FilterChip"
+import If from "components/If"
+import { Dispatch } from "react"
+import { Filter, FilterAction, FilterState } from "types/CourtCaseFilter"
+
+interface Props {
+  state: Filter
+  dispatch: Dispatch<FilterAction>
+  sectionState: FilterState
+}
+
+const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: Props) => {
+  const noOfChips =
+    [state.dateFilter, state.lockedFilter, state.urgentFilter]
+      .map((filter): number => {
+        return filter.value !== undefined && filter.state === sectionState ? 1 : 0
+      })
+      .reduce((i, x) => i + x, 0) + state.reasonFilter.filter((filter) => filter.state === sectionState).length
+
+  return (
+    <If condition={noOfChips > 0}>
+      <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{`${sectionState} filters`}</h2>
+      <ul className="moj-filter-tags">
+        <If
+          condition={
+            state.urgentFilter.value !== undefined &&
+            state.urgentFilter.label !== undefined &&
+            state.urgentFilter.state === sectionState
+          }
+        >
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
+          <FilterChip
+            chipLabel={state.urgentFilter.label!}
+            dispatch={dispatch}
+            removeAction={() => {
+              return { method: "remove", type: "urgency", value: state.urgentFilter.value! }
+            }}
+            state={state.urgentFilter.state || sectionState}
+          />
+        </If>
+        <If
+          condition={
+            state.dateFilter.value !== undefined &&
+            state.dateFilter.label !== undefined &&
+            state.dateFilter.state === sectionState
+          }
+        >
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
+          <FilterChip
+            chipLabel={state.dateFilter.label!}
+            dispatch={dispatch}
+            removeAction={() => {
+              return { method: "remove", type: "date", value: state.dateFilter.value! }
+            }}
+            state={state.dateFilter.state || sectionState}
+          />
+        </If>
+        <If
+          condition={
+            state.lockedFilter.value !== undefined &&
+            state.lockedFilter.label !== undefined &&
+            state.lockedFilter.state === sectionState
+          }
+        >
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
+          <FilterChip
+            chipLabel={state.lockedFilter.label!}
+            dispatch={dispatch}
+            removeAction={() => {
+              return { method: "remove", type: "locked", value: state.lockedFilter.value! }
+            }}
+            state={state.lockedFilter.state || sectionState}
+          />
+        </If>
+        <If condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
+        </If>
+
+        {state.reasonFilter
+          .filter((reasonFilter) => reasonFilter.state === sectionState)
+          .map((reasonFilter) => (
+            <FilterChip
+              key={reasonFilter.value}
+              chipLabel={reasonFilter.value}
+              dispatch={dispatch}
+              removeAction={() => {
+                return { method: "remove", type: "reason", value: reasonFilter.value }
+              }}
+              state={reasonFilter.state}
+            />
+          ))}
+      </ul>
+    </If>
+  )
+}
+
+export default FilterChipSection

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -9,12 +9,15 @@ interface Props {
   state: Filter
   dispatch: Dispatch<FilterAction>
   sectionState: FilterState
+  marginTop: boolean
 }
 
-const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: Props) => {
+const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState, marginTop }: Props) => {
   return (
     <If condition={countFilterChips(state, sectionState) > 0}>
-      <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{`${sectionState} filters`}</h2>
+      <h2
+        className={"govuk-heading-m govuk-!-margin-bottom-0" + (marginTop ? " govuk-!-margin-top-2" : "")}
+      >{`${sectionState} filters`}</h2>
 
       <If
         condition={
@@ -23,8 +26,8 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
           state.urgentFilter.state === sectionState
         }
       >
-        <h3>{"Urgency"}</h3>
-        <ul className="moj-filter-tags">
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
+        <ul className="moj-filter-tags govuk-!-margin-bottom-0">
           <FilterChip
             chipLabel={state.urgentFilter.label!}
             dispatch={dispatch}
@@ -43,7 +46,7 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
         }
       >
         <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
-        <ul className="moj-filter-tags">
+        <ul className="moj-filter-tags govuk-!-margin-bottom-0">
           <FilterChip
             chipLabel={state.dateFilter.label!}
             dispatch={dispatch}
@@ -62,7 +65,7 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
         }
       >
         <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
-        <ul className="moj-filter-tags">
+        <ul className="moj-filter-tags govuk-!-margin-bottom-0">
           <FilterChip
             chipLabel={state.lockedFilter.label!}
             dispatch={dispatch}
@@ -75,7 +78,7 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
       </If>
       <If condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
         <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
-        <ul className="moj-filter-tags">
+        <ul className="moj-filter-tags govuk-!-margin-bottom-0">
           {state.reasonFilter
             .filter((reasonFilter) => reasonFilter.state === sectionState)
             .map((reasonFilter) => (

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -15,15 +15,16 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
   return (
     <If condition={countFilterChips(state, sectionState) > 0}>
       <h2 className="govuk-heading-m govuk-!-margin-bottom-0">{`${sectionState} filters`}</h2>
-      <ul className="moj-filter-tags">
-        <If
-          condition={
-            state.urgentFilter.value !== undefined &&
-            state.urgentFilter.label !== undefined &&
-            state.urgentFilter.state === sectionState
-          }
-        >
-          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Urgency"}</h3>
+
+      <If
+        condition={
+          state.urgentFilter.value !== undefined &&
+          state.urgentFilter.label !== undefined &&
+          state.urgentFilter.state === sectionState
+        }
+      >
+        <h3>{"Urgency"}</h3>
+        <ul className="moj-filter-tags">
           <FilterChip
             chipLabel={state.urgentFilter.label!}
             dispatch={dispatch}
@@ -32,15 +33,17 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
             }}
             state={state.urgentFilter.state || sectionState}
           />
-        </If>
-        <If
-          condition={
-            state.dateFilter.value !== undefined &&
-            state.dateFilter.label !== undefined &&
-            state.dateFilter.state === sectionState
-          }
-        >
-          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
+        </ul>
+      </If>
+      <If
+        condition={
+          state.dateFilter.value !== undefined &&
+          state.dateFilter.label !== undefined &&
+          state.dateFilter.state === sectionState
+        }
+      >
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Date range"}</h3>
+        <ul className="moj-filter-tags">
           <FilterChip
             chipLabel={state.dateFilter.label!}
             dispatch={dispatch}
@@ -49,15 +52,17 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
             }}
             state={state.dateFilter.state || sectionState}
           />
-        </If>
-        <If
-          condition={
-            state.lockedFilter.value !== undefined &&
-            state.lockedFilter.label !== undefined &&
-            state.lockedFilter.state === sectionState
-          }
-        >
-          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
+        </ul>
+      </If>
+      <If
+        condition={
+          state.lockedFilter.value !== undefined &&
+          state.lockedFilter.label !== undefined &&
+          state.lockedFilter.state === sectionState
+        }
+      >
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Locked state"}</h3>
+        <ul className="moj-filter-tags">
           <FilterChip
             chipLabel={state.lockedFilter.label!}
             dispatch={dispatch}
@@ -66,25 +71,26 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState }: P
             }}
             state={state.lockedFilter.state || sectionState}
           />
-        </If>
-        <If condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
-          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
-        </If>
-
-        {state.reasonFilter
-          .filter((reasonFilter) => reasonFilter.state === sectionState)
-          .map((reasonFilter) => (
-            <FilterChip
-              key={reasonFilter.value}
-              chipLabel={reasonFilter.value}
-              dispatch={dispatch}
-              removeAction={() => {
-                return { method: "remove", type: "reason", value: reasonFilter.value }
-              }}
-              state={reasonFilter.state}
-            />
-          ))}
-      </ul>
+        </ul>
+      </If>
+      <If condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
+        <ul className="moj-filter-tags">
+          {state.reasonFilter
+            .filter((reasonFilter) => reasonFilter.state === sectionState)
+            .map((reasonFilter) => (
+              <FilterChip
+                key={reasonFilter.value}
+                chipLabel={reasonFilter.value}
+                dispatch={dispatch}
+                removeAction={() => {
+                  return { method: "remove", type: "reason", value: reasonFilter.value }
+                }}
+                state={reasonFilter.state}
+              />
+            ))}
+        </ul>
+      </If>
     </If>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,9 +113,7 @@ const Home: NextPage<Props> = ({
         {"Court cases"}
       </Heading>
       <CourtCaseWrapper
-        filter={
-          <CourtCaseFilter courtCaseTypes={courtCaseTypes} dateRange={dateRange} urgency={urgent} locked={locked} />
-        }
+        filter={<CourtCaseFilter />}
         appliedFilters={
           <AppliedFilters filters={{ courtCaseTypes, keywords, dateRange, urgency: urgent, locked: locked }} />
         }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,7 +113,9 @@ const Home: NextPage<Props> = ({
         {"Court cases"}
       </Heading>
       <CourtCaseWrapper
-        filter={<CourtCaseFilter />}
+        filter={
+          <CourtCaseFilter courtCaseTypes={courtCaseTypes} dateRange={dateRange} urgency={urgent} locked={locked} />
+        }
         appliedFilters={
           <AppliedFilters filters={{ courtCaseTypes, keywords, dateRange, urgency: urgent, locked: locked }} />
         }

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -3,7 +3,7 @@ import { Reason } from "./CaseListQueryParams"
 export type FilterAction =
   | { method: FilterMethod; type: "urgency"; value: boolean }
   | { method: FilterMethod; type: "date"; value: string }
-  | { method: FilterMethod; type: "locked"; value: boolean }
+  | { method: FilterMethod; type: "locked"; value: string }
   | { method: FilterMethod; type: "reason"; value: Reason }
 
 export type FilterType = "urgency" | "date" | "locked" | "reason"
@@ -19,7 +19,7 @@ export type FilterState = {
     label?: string
   }
   lockedFilter: {
-    value?: boolean
+    value?: string
     label?: string
   }
   reasonFilter: {

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -3,7 +3,7 @@ import { Reason } from "./CaseListQueryParams"
 export type FilterAction =
   | { method: FilterMethod; type: "urgency"; value: boolean }
   | { method: FilterMethod; type: "date"; value: string }
-  | { method: FilterMethod; type: "locked"; value: string }
+  | { method: FilterMethod; type: "locked"; value: boolean }
   | { method: FilterMethod; type: "reason"; value: Reason }
 
 export type FilterType = "urgency" | "date" | "locked" | "reason"
@@ -19,7 +19,7 @@ export type FilterState = {
     label?: string
   }
   lockedFilter: {
-    value?: string
+    value?: boolean
     label?: string
   }
   reasonFilter: {

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -1,0 +1,28 @@
+import { Reason } from "./CaseListQueryParams"
+
+export type FilterAction =
+  | { method: FilterMethod; type: "urgency"; value: boolean }
+  | { method: FilterMethod; type: "date"; value: string }
+  | { method: FilterMethod; type: "locked"; value: boolean }
+  | { method: FilterMethod; type: "reason"; value: Reason }
+
+export type FilterType = "urgency" | "date" | "locked" | "reason"
+export type FilterMethod = "add" | "remove"
+export type FilterValue = boolean | string | Reason
+export type FilterState = {
+  urgentFilter: {
+    value?: boolean
+    label?: string
+  }
+  dateFilter: {
+    value?: string
+    label?: string
+  }
+  lockedFilter: {
+    value?: boolean
+    label?: string
+  }
+  reasonFilter: {
+    value: Reason[]
+  }
+}

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -9,20 +9,25 @@ export type FilterAction =
 export type FilterType = "urgency" | "date" | "locked" | "reason"
 export type FilterMethod = "add" | "remove"
 export type FilterValue = boolean | string | Reason
-export type FilterState = {
+export type FilterState = "selected" | "applied"
+export type Filter = {
   urgentFilter: {
     value?: boolean
+    state?: FilterState
     label?: string
   }
   dateFilter: {
     value?: string
+    state?: FilterState
     label?: string
   }
   lockedFilter: {
     value?: boolean
+    state?: FilterState
     label?: string
   }
   reasonFilter: {
-    value: Reason[]
-  }
+    value: Reason
+    state: FilterState
+  }[]
 }

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -9,7 +9,7 @@ export type FilterAction =
 export type FilterType = "urgency" | "date" | "locked" | "reason"
 export type FilterMethod = "add" | "remove"
 export type FilterValue = boolean | string | Reason
-export type FilterState = "selected" | "applied"
+export type FilterState = "Selected" | "Applied"
 export type Filter = {
   urgentFilter: {
     value?: boolean

--- a/src/utils/filterChips.ts
+++ b/src/utils/filterChips.ts
@@ -1,0 +1,14 @@
+import { Filter, FilterState } from "types/CourtCaseFilter"
+
+const countFilterChips = (state: Filter, countOfState?: FilterState): number => {
+  return (
+    [state.dateFilter, state.lockedFilter, state.urgentFilter]
+      .map((filter): number => {
+        return filter.value !== undefined && (countOfState === undefined || filter.state === countOfState) ? 1 : 0
+      })
+      .reduce((x, y) => x + y, 0) +
+    state.reasonFilter.filter((filter) => countOfState === undefined || filter.state === countOfState).length
+  )
+}
+
+export { countFilterChips }


### PR DESCRIPTION
We now show Selected and Applied filters chips in the filter panel, these are displayed under there own heading as shown in the designs:
 
- Created a `FilterChip` component that has custom styles depending on the filter state
- Added the filter state that we use with a reducer to keep track of the current state of Selected and Applied filters
- Broke out a lot of the of the shelf GDS component into there own components to keep the `CourtCaseFilter` having less raw html
- Added a good bank of test for the filter chips and pulled existing test inline with the new functionality implemented in this P.R

This is the state of `Selected filters` before applying

![image](https://user-images.githubusercontent.com/65510707/209358159-53ea4667-5be1-4bbe-8ab7-da39347c9d65.png)

This is the state of `Applied filters` after applying
![image](https://user-images.githubusercontent.com/65510707/209358299-3acf2fca-1ac8-4899-9d92-fa18c3f94fb7.png)

This is the state if more filters are selected 
![image](https://user-images.githubusercontent.com/65510707/209358458-deb388e7-44ce-480b-a41e-4019002a8d23.png)

