### PR TITLE
fix: 🐛 supervisord npm error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ FROM ${BUILD_IMAGE} as runner
 
 RUN useradd nextjs && \
     groupadd nodejs && \
-    usermod -a -G nodejs nextjs
+    usermod -a -G nodejs nextjs && \
+    npm config set cache /tmp/npm --global
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production


### PR DESCRIPTION
supvisord was running npm as "nextjs" user but that user did not have permission to write cache and logs in the right place, this causes npm to return a 243 error and supervisord thinks the process has exited, but node continues to run. Setting the cache to `/tmp` resolves the error.