### PR TITLE
NewUI: fixed Page component padding

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,24 @@
+import { createUseStyles } from "react-jss"
+
 interface HeaderProps {
   serviceName: string
   organisationName: string
   userName: string
 }
+
+const useStyles = createUseStyles({
+  "max-width": {
+    maxWidth: "100%",
+    padding: "0 40px"
+  }
+})
+
 const Header: React.FC<HeaderProps> = ({ organisationName, serviceName, userName }: HeaderProps) => {
+  const classes = useStyles()
   return (
     <>
       <header className="moj-header" role="banner">
-        <div className="moj-header__container">
+        <div className={`${classes["max-width"]} moj-header__container`}>
           <div className="moj-header__logo">
             <svg
               aria-hidden="true"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { createUseStyles } from "react-jss"
+import { useCustomStyles } from "../../../styles/customStyles"
 
 interface HeaderProps {
   serviceName: string
@@ -6,15 +6,8 @@ interface HeaderProps {
   userName: string
 }
 
-const useStyles = createUseStyles({
-  "max-width": {
-    maxWidth: "100%",
-    padding: "0 40px"
-  }
-})
-
 const Header: React.FC<HeaderProps> = ({ organisationName, serviceName, userName }: HeaderProps) => {
-  const classes = useStyles()
+  const classes = useCustomStyles()
   return (
     <>
       <header className="moj-header" role="banner">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,11 @@
-import { Page, Footer } from "govuk-react"
+import { Footer } from "govuk-react"
 import { ReactNode } from "react"
 import User from "../services/entities/User"
 import { useRouter } from "next/router"
 import Header from "./Header"
 import NavBar from "./NavBar"
 import PhaseBanner from "./PhaseBanner"
+import PageTemplate from "./PageTemplate"
 
 interface Props {
   children: ReactNode
@@ -13,19 +14,15 @@ interface Props {
 
 const Layout = ({ children, user }: Props) => {
   const { basePath } = useRouter()
-  const header = (
-    <>
-      <Header serviceName={"Bichard7"} organisationName={"Ministry of Justice"} userName={user.username} />
-      <NavBar groups={user.groups} />
-    </>
-  )
 
   return (
     <>
-      <Page header={header}>
+      <Header serviceName={"Bichard7"} organisationName={"Ministry of Justice"} userName={user.username} />
+      <NavBar groups={user.groups} />
+      <PageTemplate>
         <PhaseBanner phase={"prototype"} />
         {children}
-      </Page>
+      </PageTemplate>
       <Footer
         copyright={{
           image: {

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -2,6 +2,7 @@ import If from "components/If"
 import { useRouter } from "next/router"
 import hasUserManagementAccess from "services/hasUserManagementAccess"
 import { default as GroupName } from "types/GroupName"
+import { createUseStyles } from "react-jss"
 
 interface NavItemProps {
   name: string
@@ -33,10 +34,18 @@ const UserManagementNavItem: React.FC<NavBarProps> = (groups) => {
   )
 }
 
+const useStyles = createUseStyles({
+  "max-width": {
+    maxWidth: "100%",
+    padding: "0 40px"
+  }
+})
+
 const NavBar: React.FC<NavBarProps> = ({ groups }) => {
+  const classes = useStyles()
   return (
     <div className="moj-primary-navigation" role="navigation">
-      <div className="moj-primary-navigation__container">
+      <div className={`${classes["max-width"]} moj-primary-navigation__container`}>
         <div className="moj-primary-navigation__nav">
           <nav className="moj-primary-navigation" aria-label="Primary navigation">
             <ul className="moj-primary-navigation__list">

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -2,7 +2,7 @@ import If from "components/If"
 import { useRouter } from "next/router"
 import hasUserManagementAccess from "services/hasUserManagementAccess"
 import { default as GroupName } from "types/GroupName"
-import { createUseStyles } from "react-jss"
+import { useCustomStyles } from "../../../styles/customStyles"
 
 interface NavItemProps {
   name: string
@@ -34,15 +34,8 @@ const UserManagementNavItem: React.FC<NavBarProps> = (groups) => {
   )
 }
 
-const useStyles = createUseStyles({
-  "max-width": {
-    maxWidth: "100%",
-    padding: "0 40px"
-  }
-})
-
 const NavBar: React.FC<NavBarProps> = ({ groups }) => {
-  const classes = useStyles()
+  const classes = useCustomStyles()
   return (
     <div className="moj-primary-navigation" role="navigation">
       <div className={`${classes["max-width"]} moj-primary-navigation__container`}>

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,19 +1,12 @@
 import { ReactNode } from "react"
-import { createUseStyles } from "react-jss"
+import { useCustomStyles } from "../../styles/customStyles"
 
 interface Props {
   children: ReactNode
 }
 
-const useStyles = createUseStyles({
-  "govuk-width-container": {
-    maxWidth: "100%",
-    padding: "30px 40px"
-  }
-})
-
 const PageTemplate = ({ children }: Props) => {
-  const classes = useStyles()
+  const classes = useCustomStyles()
   return (
     <div className={classes["govuk-width-container"]}>
       <main id="main-content" role="main">

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react"
+import { createUseStyles } from "react-jss"
+
+interface Props {
+  children: ReactNode
+}
+
+const useStyles = createUseStyles({
+  "govuk-width-container": {
+    maxWidth: "100%",
+    padding: "30px 40px"
+  }
+})
+
+const PageTemplate = ({ children }: Props) => {
+  const classes = useStyles()
+  return (
+    <div className={classes["govuk-width-container"]}>
+      <main id="main-content" role="main">
+        {children}
+      </main>
+    </div>
+  )
+}
+
+export default PageTemplate

--- a/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useCustomStyles } from "../../../styles/customStyles"
 
 interface Props {
   filter: React.ReactNode
@@ -9,10 +10,10 @@ interface Props {
 
 const CourtCaseFilterWrapper: React.FC<Props> = ({ filter, appliedFilters, courtCaseList, pagination }: Props) => {
   const [isVisible, setVisible] = useState(false)
-
+  const classes = useCustomStyles()
   return (
     <>
-      <div className="moj-filter-layout">
+      <div className={`${classes["top-padding"]} moj-filter-layout`}>
         <div className="moj-filter-layout__filter">
           <div className={isVisible ? "moj-filter" : "moj-filter moj-hidden"}>{filter}</div>
         </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,23 +1,24 @@
-import CourtCaseFilter from "features/CourtCaseFilters/CourtCaseFilter"
-import AppliedFilters from "features/CourtCaseFilters/AppliedFilters"
-import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
-import { Reason, QueryOrder, Urgency } from "types/CaseListQueryParams"
-import { isError } from "types/Result"
-import CourtCaseList from "features/CourtCaseList/CourtCaseList"
 import Layout from "components/Layout"
 import Pagination from "components/Pagination/Pagination"
-import User from "services/entities/User"
-import getDataSource from "services/getDataSource"
+import AppliedFilters from "features/CourtCaseFilters/AppliedFilters"
+import CourtCaseFilter from "features/CourtCaseFilters/CourtCaseFilter"
+import CourtCaseWrapper from "features/CourtCaseFilters/CourtCaseFilterWrapper"
+import CourtCaseList from "features/CourtCaseList/CourtCaseList"
+import { Heading } from "govuk-react"
 import { withAuthentication, withMultipleServerSideProps } from "middleware"
 import type { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from "next"
 import Head from "next/head"
 import { ParsedUrlQuery } from "querystring"
-import listCourtCases from "services/listCourtCases"
 import type CourtCase from "services/entities/CourtCase"
-import CourtCaseWrapper from "features/CourtCaseFilters/CourtCaseFilterWrapper"
+import User from "services/entities/User"
+import getDataSource from "services/getDataSource"
+import listCourtCases from "services/listCourtCases"
+import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
+import { QueryOrder, Reason, Urgency } from "types/CaseListQueryParams"
+import { isError } from "types/Result"
 import { mapDateRange, validateNamedDateRange } from "utils/validators/validateDateRanges"
-import { validateQueryParams } from "utils/validators/validateQueryParams"
 import { mapLockFilter } from "utils/validators/validateLockFilter"
+import { validateQueryParams } from "utils/validators/validateQueryParams"
 
 interface Props {
   user: User
@@ -108,6 +109,9 @@ const Home: NextPage<Props> = ({
       <meta name="description" content="Case List | Bichard7" />
     </Head>
     <Layout user={user}>
+      <Heading as="h1" size="LARGE">
+        {"Court cases"}
+      </Heading>
       <CourtCaseWrapper
         filter={
           <CourtCaseFilter courtCaseTypes={courtCaseTypes} dateRange={dateRange} urgency={urgent} locked={locked} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,6 @@ import Head from "next/head"
 import { ParsedUrlQuery } from "querystring"
 import listCourtCases from "services/listCourtCases"
 import type CourtCase from "services/entities/CourtCase"
-import { Heading } from "govuk-react"
 import CourtCaseWrapper from "features/CourtCaseFilters/CourtCaseFilterWrapper"
 import { mapDateRange, validateNamedDateRange } from "utils/validators/validateDateRanges"
 import { validateQueryParams } from "utils/validators/validateQueryParams"
@@ -109,9 +108,6 @@ const Home: NextPage<Props> = ({
       <meta name="description" content="Case List | Bichard7" />
     </Head>
     <Layout user={user}>
-      <Heading as="h1" size="LARGE">
-        {"Court cases"}
-      </Heading>
       <CourtCaseWrapper
         filter={
           <CourtCaseFilter courtCaseTypes={courtCaseTypes} dateRange={dateRange} urgency={urgent} locked={locked} />

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -1,0 +1,12 @@
+import { createUseStyles } from "react-jss"
+
+export const useCustomStyles = createUseStyles({
+  "max-width": {
+    maxWidth: "100%",
+    padding: "0 40px"
+  },
+  "govuk-width-container": {
+    maxWidth: "100%",
+    padding: "30px 40px"
+  }
+})

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -8,5 +8,8 @@ export const useCustomStyles = createUseStyles({
   "govuk-width-container": {
     maxWidth: "100%",
     padding: "30px 40px"
+  },
+  "top-padding": {
+    paddingTop: "30px"
   }
 })


### PR DESCRIPTION
This PR removes the white spacing on either side of the page. 
Created a custom Page component `PageTemplate` as the Gov-react component enforced a set width and was complex to change. 

- Used JSS to apply custom styling. 
- Made a central JSS file to store all custom styles.

Note:
A `<h1>` header is required to pass A11y tests which is not included in the figma designs. Need feedback from designers on this. This may need modified in future. 
https://www.figma.com/file/LHxGJpfSjuTczcqrFzUQNc/06_B7_22-Handover-hifi-case-list-screens?node-id=321%3A2571&t=5X7f8vkVtEOL1YGs-0

Before
![image](https://user-images.githubusercontent.com/105787366/210812453-674b81f1-f0f3-43c6-9fcb-d51e37c89772.png)

After
![image](https://user-images.githubusercontent.com/105787366/210812359-466ab84b-fbd7-4065-8342-0930e1a774fc.png)

![image](https://user-images.githubusercontent.com/105787366/210813059-69ee92d3-99dd-4476-95d6-4676e99f9d9d.png)

