### PR TITLE
Filter by case state

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -11,7 +11,8 @@ import {
   insertDummyCourtCasesWithUrgencies,
   insertDummyCourtCasesWithNotes,
   insertCourtCasesWithCourtDates,
-  insertMultipleDummyCourtCasesWithLock
+  insertMultipleDummyCourtCasesWithLock,
+  insertMultipleDummyCourtCasesWithResolutionTimestamp
 } from "./test/utils/insertCourtCases"
 import { getCourtCaseById } from "./test/utils/getCourtCaseById"
 import { insertTriggers } from "./test/utils/manageTriggers"
@@ -84,6 +85,13 @@ export default defineConfig({
             params.triggerLockedByUsername,
             params.orgCodes
           )
+        },
+
+        insertMultipleDummyCourtCasesWithResolutionTimestamp(params: {
+          resolutionTimestamps: (Date | null)[]
+          orgCode: string
+        }) {
+          return insertMultipleDummyCourtCasesWithResolutionTimestamp(params.resolutionTimestamps, params.orgCode)
         },
 
         insertMultipleDummyCourtCasesWithLock(params: {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -98,6 +98,19 @@ describe("Case list", () => {
       cy.contains("Locked cases only").should("exist")
     })
 
+    it("Should expand and collapse case state filter navigation", () => {
+      cy.visit("/bichard")
+      cy.get("button[id=filter-button]").click()
+
+      cy.contains("Unresolved & resolved cases").should("exist")
+
+      cy.contains("Case state").parent().parent().parent().find("button").click()
+      cy.contains("Unresolved & resolved cases").should("not.exist")
+
+      cy.contains("Case state").parent().parent().parent().find("button").click()
+      cy.contains("Unresolved & resolved cases").should("exist")
+    })
+
     it("Should display cases filtered by defendant name", () => {
       cy.task("insertCourtCasesWithDefendantNames", {
         defendantNames: ["Bruce Wayne", "Barbara Gordon", "Alfred Pennyworth"],
@@ -387,6 +400,40 @@ describe("Case list", () => {
       // Removing non-urgent filter tag all case should be shown with the filter disabled
       cy.get(".moj-filter-tags a.moj-filter__tag").contains("Non-urgent").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 4)
+    })
+
+    it("Should filter cases by case state", () => {
+      const resolutionTimestamp = new Date()
+      cy.task("insertMultipleDummyCourtCasesWithResolutionTimestamp", {
+        resolutionTimestamps: [null, resolutionTimestamp, resolutionTimestamp, resolutionTimestamp],
+        orgCode: "011111"
+      })
+
+      cy.visit("/bichard")
+
+      // Filter for resolved and unresolved cases
+      cy.get("button[id=filter-button]").click()
+      cy.get("#unresolved-and-resolved").click()
+      cy.get("button[id=search]").click()
+
+      cy.get("tr").not(":first").should("have.length", 4)
+      cy.get("tr").not(":first").contains("Case00000").should("exist")
+
+      // Removing case state filter tag unresolved cases should be shown with the filter disabled
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Unresolved & resolved cases").click({ force: true })
+      cy.get("tr").not(":first").should("have.length", 1)
+
+      // Filter for resolved cases
+      cy.get("button[id=filter-button]").click()
+      cy.get("#resolved").click()
+      cy.get("button[id=search]").click()
+
+      cy.get("tr").not(":first").should("have.length", 3)
+      cy.get("tr").contains("Case00001").should("exist")
+
+      // Removing case state filter tag unresolved cases should be shown with the filter disabled
+      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Resolved cases").click({ force: true })
+      cy.get("tr").not(":first").should("have.length", 1)
     })
 
     it("Should filter cases by locked state", () => {

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -129,6 +129,30 @@ describe("Case list", () => {
       })
     })
 
+    describe("Case state", () => {
+      it("Should apply the 'Unresolved & resolved cases' filter chip", () => {
+        cy.get("#filter-button").click()
+        cy.get("#unresolved-and-resolved").click()
+
+        cy.get(".govuk-heading-s").contains("Case state").should("exist")
+        cy.get(".moj-filter__tag").contains("Unresolved & resolved cases").should("exist")
+        cy.get(".moj-filter__tag").contains("Resolved cases").should("not.exist")
+      })
+
+      it("Should apply the 'Resolved cases' radio button and cancel it when the 'X' is clicked", () => {
+        cy.get("#filter-button").click()
+        cy.get("#resolved").click()
+
+        cy.get(".govuk-heading-s").contains("Case state").should("exist")
+        cy.get(".moj-filter__tag").contains("Resolved cases").should("exist")
+        cy.get(".moj-filter__tag").contains("Unresolved & resolved cases").should("not.exist")
+
+        // Removes the urgent filter chips
+        cy.get("li button.moj-filter__tag").contains("Resolved cases").trigger("click")
+        cy.get(".moj-filter__tag").should("not.exist")
+      })
+    })
+
     describe("Locked status", () => {
       it("Should apply the 'Locked cases only' filter chips then remove this chips to the original state", () => {
         cy.get("#filter-button").click()

--- a/src/components/CaseStateFilter/CaseStateFilterOptions.tsx
+++ b/src/components/CaseStateFilter/CaseStateFilterOptions.tsx
@@ -1,0 +1,31 @@
+import RadioButton from "components/RadioButton/RadioButton"
+import type { Dispatch } from "react"
+import type { FilterAction } from "types/CourtCaseFilter"
+import caseStateFilters, { caseStateLabels } from "utils/caseStateFilters"
+import { parameterizeString } from "utils/validators/stringFormatUtils"
+
+interface Props {
+  state?: string
+  dispatch: Dispatch<FilterAction>
+}
+
+const CaseStateFilterOptions: React.FC<Props> = ({}: Props) => {
+  return (
+    <fieldset className="govuk-fieldset">
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Case state"}</legend>
+      <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
+        {caseStateFilters.map((optionName) => (
+          <RadioButton
+            name={"state"}
+            key={parameterizeString(optionName)}
+            id={parameterizeString(optionName)}
+            value={optionName}
+            label={caseStateLabels[optionName]}
+          />
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+export default CaseStateFilterOptions

--- a/src/components/CaseStateFilter/CaseStateFilterOptions.tsx
+++ b/src/components/CaseStateFilter/CaseStateFilterOptions.tsx
@@ -1,5 +1,6 @@
 import RadioButton from "components/RadioButton/RadioButton"
 import type { Dispatch } from "react"
+import { CaseState } from "types/CaseListQueryParams"
 import type { FilterAction } from "types/CourtCaseFilter"
 import caseStateFilters, { caseStateLabels } from "utils/caseStateFilters"
 import { parameterizeString } from "utils/validators/stringFormatUtils"
@@ -9,7 +10,7 @@ interface Props {
   dispatch: Dispatch<FilterAction>
 }
 
-const CaseStateFilterOptions: React.FC<Props> = ({}: Props) => {
+const CaseStateFilterOptions: React.FC<Props> = ({ state, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Case state"}</legend>
@@ -19,8 +20,13 @@ const CaseStateFilterOptions: React.FC<Props> = ({}: Props) => {
             name={"state"}
             key={parameterizeString(optionName)}
             id={parameterizeString(optionName)}
+            checked={state === optionName}
             value={optionName}
             label={caseStateLabels[optionName]}
+            onChange={(event) => {
+              const filterValue = event.target.value as CaseState
+              dispatch({ method: "add", type: "caseState", value: filterValue })
+            }}
           />
         ))}
       </div>

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -2,6 +2,7 @@ import FilterTag from "components/FilterTag/FilterTag"
 import If from "components/If"
 import { useRouter } from "next/router"
 import { Reason } from "types/CaseListQueryParams"
+import { caseStateLabels } from "utils/caseStateFilters"
 import { deleteQueryParam, deleteQueryParamsByName } from "utils/deleteQueryParam"
 
 interface Props {
@@ -11,6 +12,7 @@ interface Props {
     dateRange?: string | null
     urgency?: string | null
     locked?: string | null
+    caseState?: string | null
   }
 }
 
@@ -22,7 +24,8 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
     (filters.keywords && filters.keywords.length > 0) ||
     !!filters.urgency ||
     !!filters.dateRange ||
-    !!filters.locked
+    !!filters.locked ||
+    !!filters.caseState
 
   const removeQueryParamFromPath = (paramToRemove: { [key: string]: string }): string => {
     deleteQueryParamsByName(["pageNum"], query)
@@ -67,6 +70,14 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               <FilterTag
                 tag={filters.urgency ?? ""}
                 href={removeQueryParamFromPath({ urgency: filters.urgency ?? "" })}
+              />
+            </li>
+          </If>
+          <If condition={!!filters.caseState}>
+            <li>
+              <FilterTag
+                tag={caseStateLabels[String(filters.caseState)] ?? ""}
+                href={removeQueryParamFromPath({ state: filters.caseState ?? "" })}
               />
             </li>
           </If>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export const ShouldBeAccessible: ComponentStory<typeof CourtCaseFilter> = () => (
   <div data-testid="filters">
-    <CourtCaseFilter courtCaseTypes={[]} dateRange={null} urgency={null} locked={null} />
+    <CourtCaseFilter courtCaseTypes={[]} dateRange={null} urgency={null} locked={null} caseState={null} />
   </div>
 )
 
@@ -23,7 +23,13 @@ ShouldBeAccessible.play = async ({ canvasElement }) => {
 }
 
 export const WhenThereAreFiltersApplied: ComponentStory<typeof CourtCaseFilter> = () => (
-  <CourtCaseFilter courtCaseTypes={["Exceptions"]} dateRange={"today"} urgency={"Urgent"} locked={"Locked"} />
+  <CourtCaseFilter
+    courtCaseTypes={["Exceptions"]}
+    dateRange={"today"}
+    urgency={"Urgent"}
+    locked={"Locked"}
+    caseState={"Resolved"}
+  />
 )
 
 WhenThereAreFiltersApplied.play = ({ canvasElement }) => {

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -12,6 +12,7 @@ import type { Filter, FilterAction } from "types/CourtCaseFilter"
 import { countFilterChips } from "utils/filterChips"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
 import FilterChipSection from "./FilterChipSection"
+import { caseStateLabels } from "utils/caseStateFilters"
 
 interface Props {
   courtCaseTypes: Reason[]
@@ -32,6 +33,10 @@ const reducer = (state: Filter, action: FilterAction): Filter => {
       newState.dateFilter.value = action.value
       newState.dateFilter.label = action.value
       newState.dateFilter.state = "Selected"
+    } else if (action.type === "caseState") {
+      newState.caseStateFilter.value = action.value
+      newState.caseStateFilter.label = caseStateLabels[action.value ?? ""]
+      newState.caseStateFilter.state = "Selected"
     } else if (action.type === "locked") {
       newState.lockedFilter.value = action.value
       newState.lockedFilter.label = action.value ? "Locked" : "Unlocked"
@@ -50,9 +55,12 @@ const reducer = (state: Filter, action: FilterAction): Filter => {
     } else if (action.type === "date") {
       newState.dateFilter.value = undefined
       newState.dateFilter.label = undefined
+    } else if (action.type === "caseState") {
+      newState.caseStateFilter.value = undefined
+      newState.caseStateFilter.label = undefined
     } else if (action.type === "locked") {
       newState.lockedFilter.value = undefined
-      newState.dateFilter.label = undefined
+      newState.lockedFilter.label = undefined
     } else if (action.type === "reason") {
       newState.reasonFilter = newState.reasonFilter.filter((reasonFilter) => reasonFilter.value !== action.value)
     }

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import CaseStateFilterOptions from "components/CaseStateFilter/CaseStateFilterOptions"
 import CourtCaseTypeOptions from "components/CourtDateFilter/CourtCaseTypeOptions"
 import UrgencyFilterOptions from "components/CourtDateFilter/UrgencyFilterOptions"
 import If from "components/If"
@@ -6,7 +7,7 @@ import LockedFilterOptions from "components/LockedFilter/LockedFilterOptions"
 import { HintText } from "govuk-react"
 import { ReactNode, useState, useReducer } from "react"
 import { createUseStyles } from "react-jss"
-import { Reason } from "types/CaseListQueryParams"
+import { CaseState, Reason } from "types/CaseListQueryParams"
 import type { Filter, FilterAction } from "types/CourtCaseFilter"
 import { countFilterChips } from "utils/filterChips"
 import CourtDateFilterOptions from "../../components/CourtDateFilter/CourtDateFilterOptions"
@@ -17,6 +18,7 @@ interface Props {
   dateRange: string | null
   urgency: string | null
   locked: string | null
+  caseState: CaseState | null
 }
 
 const reducer = (state: Filter, action: FilterAction): Filter => {
@@ -136,11 +138,12 @@ const ExpandingFilters: React.FC<{ filterName: string; children: ReactNode }> = 
   )
 }
 
-const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked }: Props) => {
+const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, locked, caseState }: Props) => {
   const initialFilterState: Filter = {
     urgentFilter: urgency !== null ? { value: urgency === "Urgent", state: "Applied", label: urgency } : {},
     dateFilter: dateRange !== null ? { value: dateRange, state: "Applied", label: dateRange } : {},
     lockedFilter: locked !== null ? { value: locked === "Locked", state: "Applied", label: locked } : {},
+    caseStateFilter: caseState !== null ? { value: caseState, state: "Applied", label: caseState } : {},
     reasonFilter: courtCaseTypes.map((courtCaseType) => {
       return { value: courtCaseType, state: "Applied" }
     })
@@ -203,6 +206,12 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
             <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
             <ExpandingFilters filterName={"Court date"}>
               <CourtDateFilterOptions dateRange={state.dateFilter.value} dispatch={dispatch} />
+            </ExpandingFilters>
+          </div>
+          <div>
+            <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
+            <ExpandingFilters filterName={"Case state"}>
+              <CaseStateFilterOptions state={state.caseStateFilter.value} dispatch={dispatch} />
             </ExpandingFilters>
           </div>
           <div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -195,14 +195,14 @@ const CourtCaseFilter: React.FC<Props> = ({ courtCaseTypes, dateRange, urgency, 
           </div>
           <div className={classes["govuk-form-group"]}>
             <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
-            <ExpandingFilters filterName={"Court date"}>
-              <CourtDateFilterOptions dateRange={state.dateFilter.value} dispatch={dispatch} />
+            <ExpandingFilters filterName={"Urgency"}>
+              <UrgencyFilterOptions urgency={state.urgentFilter.value} dispatch={dispatch} />
             </ExpandingFilters>
           </div>
           <div className={classes["govuk-form-group"]}>
             <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
-            <ExpandingFilters filterName={"Urgency"}>
-              <UrgencyFilterOptions urgency={state.urgentFilter.value} dispatch={dispatch} />
+            <ExpandingFilters filterName={"Court date"}>
+              <CourtDateFilterOptions dateRange={state.dateFilter.value} dispatch={dispatch} />
             </ExpandingFilters>
           </div>
           <div>

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -59,6 +59,25 @@ const FilterChipSection: React.FC<Props> = ({ state, dispatch, sectionState, mar
       </If>
       <If
         condition={
+          state.caseStateFilter.value !== undefined &&
+          state.caseStateFilter.label !== undefined &&
+          state.caseStateFilter.state === sectionState
+        }
+      >
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Case state"}</h3>
+        <ul className="moj-filter-tags govuk-!-margin-bottom-0">
+          <FilterChip
+            chipLabel={state.caseStateFilter.label!}
+            dispatch={dispatch}
+            removeAction={() => {
+              return { method: "remove", type: "caseState", value: state.caseStateFilter.value! }
+            }}
+            state={state.caseStateFilter.state || sectionState}
+          />
+        </ul>
+      </If>
+      <If
+        condition={
           state.lockedFilter.value !== undefined &&
           state.lockedFilter.label !== undefined &&
           state.lockedFilter.state === sectionState

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns"
-import { Brackets, DataSource, IsNull } from "typeorm"
+import { Brackets, DataSource, IsNull, Not } from "typeorm"
 import { CaseListQueryParams } from "types/CaseListQueryParams"
 import { ListCourtCaseResult } from "types/ListCourtCasesResult"
 import PromiseResult from "types/PromiseResult"
@@ -20,7 +20,7 @@ const listCourtCases = async (
     urgent,
     courtDateRange,
     locked,
-    unresolved
+    caseState
   }: CaseListQueryParams
 ): PromiseResult<ListCourtCaseResult> => {
   const pageNumValidated = (pageNum ? parseInt(pageNum, 10) : 1) - 1 // -1 because the db index starts at 0
@@ -57,9 +57,13 @@ const listCourtCases = async (
     query.andWhere("courtCase.courtDate <= :to", { to: format(courtDateRange.to, "yyyy-MM-dd") })
   }
 
-  if (unresolved) {
+  if (!caseState) {
     query.andWhere({
       resolutionTimestamp: IsNull()
+    })
+  } else if (caseState === "Resolved") {
+    query.andWhere({
+      resolutionTimestamp: Not(IsNull())
     })
   }
 

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns"
-import { Brackets, DataSource } from "typeorm"
+import { Brackets, DataSource, IsNull } from "typeorm"
 import { CaseListQueryParams } from "types/CaseListQueryParams"
 import { ListCourtCaseResult } from "types/ListCourtCasesResult"
 import PromiseResult from "types/PromiseResult"
@@ -19,7 +19,8 @@ const listCourtCases = async (
     reasons: resultFilter,
     urgent,
     courtDateRange,
-    locked
+    locked,
+    unresolved
   }: CaseListQueryParams
 ): PromiseResult<ListCourtCaseResult> => {
   const pageNumValidated = (pageNum ? parseInt(pageNum, 10) : 1) - 1 // -1 because the db index starts at 0
@@ -54,6 +55,12 @@ const listCourtCases = async (
   if (courtDateRange) {
     query.andWhere("courtCase.courtDate >= :from", { from: format(courtDateRange.from, "yyyy-MM-dd") })
     query.andWhere("courtCase.courtDate <= :to", { to: format(courtDateRange.to, "yyyy-MM-dd") })
+  }
+
+  if (unresolved) {
+    query.andWhere({
+      resolutionTimestamp: IsNull()
+    })
   }
 
   if (locked !== undefined) {

--- a/src/types/CaseListQueryParams.ts
+++ b/src/types/CaseListQueryParams.ts
@@ -22,4 +22,5 @@ export type CaseListQueryParams = {
   maxPageItems: string
   courtDateRange?: CourtDateRange
   locked?: boolean
+  unresolved?: boolean
 }

--- a/src/types/CaseListQueryParams.ts
+++ b/src/types/CaseListQueryParams.ts
@@ -9,6 +9,8 @@ export type CourtDateRange = {
   to: Date
 }
 
+export type CaseState = "Resolved" | "Unresolved and resolved" | undefined
+
 export type Urgency = "Urgent" | "Non-urgent" | undefined
 
 export type CaseListQueryParams = {
@@ -22,5 +24,5 @@ export type CaseListQueryParams = {
   maxPageItems: string
   courtDateRange?: CourtDateRange
   locked?: boolean
-  unresolved?: boolean
+  caseState?: CaseState
 }

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -1,10 +1,11 @@
-import { Reason } from "./CaseListQueryParams"
+import { CaseState, Reason } from "./CaseListQueryParams"
 
 export type FilterAction =
   | { method: FilterMethod; type: "urgency"; value: boolean }
   | { method: FilterMethod; type: "date"; value: string }
   | { method: FilterMethod; type: "locked"; value: boolean }
   | { method: FilterMethod; type: "reason"; value: Reason }
+  | { method: FilterMethod; type: "state"; value: CaseState }
 
 export type FilterType = "urgency" | "date" | "locked" | "reason"
 export type FilterMethod = "add" | "remove"
@@ -23,6 +24,11 @@ export type Filter = {
   }
   lockedFilter: {
     value?: boolean
+    state?: FilterState
+    label?: string
+  }
+  caseStateFilter: {
+    value?: CaseState
     state?: FilterState
     label?: string
   }

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -5,7 +5,7 @@ export type FilterAction =
   | { method: FilterMethod; type: "date"; value: string }
   | { method: FilterMethod; type: "locked"; value: boolean }
   | { method: FilterMethod; type: "reason"; value: Reason }
-  | { method: FilterMethod; type: "state"; value: CaseState }
+  | { method: FilterMethod; type: "caseState"; value: CaseState }
 
 export type FilterType = "urgency" | "date" | "locked" | "reason"
 export type FilterMethod = "add" | "remove"

--- a/src/utils/caseStateFilters.ts
+++ b/src/utils/caseStateFilters.ts
@@ -1,0 +1,10 @@
+import KeyValuePair from "types/KeyValuePair"
+
+export const caseStateLabels: KeyValuePair<string, string> = {
+  "Unresolved and resolved": "Unresolved & resolved cases",
+  Resolved: "Resolved cases"
+}
+
+const caseStateFilters: string[] = ["Unresolved and resolved", "Resolved"]
+
+export default caseStateFilters

--- a/src/utils/filterChips.ts
+++ b/src/utils/filterChips.ts
@@ -2,7 +2,7 @@ import { Filter, FilterState } from "types/CourtCaseFilter"
 
 const countFilterChips = (state: Filter, countOfState?: FilterState): number => {
   return (
-    [state.dateFilter, state.lockedFilter, state.urgentFilter]
+    [state.dateFilter, state.lockedFilter, state.urgentFilter, state.caseStateFilter]
       .map((filter): number => {
         return filter.value !== undefined && (countOfState === undefined || filter.state === countOfState) ? 1 : 0
       })

--- a/src/utils/validators/stringFormatUtils.ts
+++ b/src/utils/validators/stringFormatUtils.ts
@@ -1,0 +1,1 @@
+export const parameterizeString = (str: string): string => str.replace(/\s+/g, "-").toLowerCase()

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -768,7 +768,27 @@ describe("listCourtCases", () => {
   })
 
   describe("Filter cases by case state", () => {
-    it("Should filter cases that are unresolved ", async () => {
+    it("Should return unresolved cases if case state not set", async () => {
+      const orgCode = "36FP"
+      const resolutionTimestamp = new Date()
+      await insertMultipleDummyCourtCasesWithResolutionTimestamp(
+        [null, resolutionTimestamp, resolutionTimestamp, resolutionTimestamp],
+        orgCode
+      )
+
+      const result = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100"
+      })
+
+      expect(isError(result)).toBeFalsy()
+      const { result: cases } = result as ListCourtCaseResult
+
+      expect(cases).toHaveLength(1)
+      expect(cases.map((c) => c.resolutionTimestamp)).toStrictEqual([null])
+    })
+
+    it("Should filter cases that are resolved", async () => {
       const orgCode = "36FP"
       const dummyTimestamp = new Date()
       await insertMultipleDummyCourtCasesWithResolutionTimestamp(
@@ -779,28 +799,28 @@ describe("listCourtCases", () => {
       const result = await listCourtCases(dataSource, {
         forces: [orgCode],
         maxPageItems: "100",
-        unresolved: true
+        caseState: "Resolved"
       })
 
       expect(isError(result)).toBeFalsy()
       const { result: cases } = result as ListCourtCaseResult
 
-      expect(cases).toHaveLength(1)
-      expect(cases.map((c) => c.resolutionTimestamp)).toStrictEqual([null])
+      expect(cases).toHaveLength(3)
+      expect(cases.map((c) => c.resolutionTimestamp)).toStrictEqual([dummyTimestamp, dummyTimestamp, dummyTimestamp])
     })
 
-    it("Should return all cases if a falsy value ", async () => {
+    it("Should return all cases if case state is 'Unresolved and resolved'", async () => {
       const orgCode = "36FP"
-      const resolutionTimestamp = new Date()
+      const dummyTimestamp = new Date()
       await insertMultipleDummyCourtCasesWithResolutionTimestamp(
-        [null, resolutionTimestamp, resolutionTimestamp, resolutionTimestamp],
+        [null, dummyTimestamp, dummyTimestamp, dummyTimestamp],
         orgCode
       )
 
       const result = await listCourtCases(dataSource, {
         forces: [orgCode],
         maxPageItems: "100",
-        unresolved: false
+        caseState: "Unresolved and resolved"
       })
 
       expect(isError(result)).toBeFalsy()
@@ -809,9 +829,9 @@ describe("listCourtCases", () => {
       expect(cases).toHaveLength(4)
       expect(cases.map((c) => c.resolutionTimestamp)).toStrictEqual([
         null,
-        resolutionTimestamp,
-        resolutionTimestamp,
-        resolutionTimestamp
+        dummyTimestamp,
+        dummyTimestamp,
+        dummyTimestamp
       ])
     })
   })

--- a/test/utils/insertCourtCases.ts
+++ b/test/utils/insertCourtCases.ts
@@ -154,6 +154,28 @@ const insertMultipleDummyCourtCasesWithLock = async (
   return insertCourtCases(existingCourtCases)
 }
 
+const insertMultipleDummyCourtCasesWithResolutionTimestamp = async (
+  resolutionTimestamp: (Date | null)[],
+  orgCode: string
+) => {
+  const existingCourtCases: CourtCase[] = []
+  for (let index = 0; index < resolutionTimestamp.length; index++) {
+    existingCourtCases.push(
+      await getDummyCourtCase({
+        orgForPoliceFilter: orgCode.padEnd(6, " "),
+        errorId: index,
+        messageId: String(index).padStart(5, "x"),
+        ptiurn: "Case" + String(index).padStart(5, "0"),
+        errorCount: 1,
+        triggerCount: 1,
+        resolutionTimestamp: resolutionTimestamp[index] ?? null
+      })
+    )
+  }
+
+  return insertCourtCases(existingCourtCases)
+}
+
 const insertDummyCourtCasesWithUrgencies = async (urgencies: boolean[], orgCode: string) => {
   const existingCourtCases: CourtCase[] = await Promise.all(
     urgencies.map((urgency, index) =>
@@ -233,5 +255,6 @@ export {
   insertDummyCourtCasesWithUrgencies,
   insertDummyCourtCasesWithNotes,
   insertDummyCourtCasesWithTriggers,
-  insertMultipleDummyCourtCasesWithLock
+  insertMultipleDummyCourtCasesWithLock,
+  insertMultipleDummyCourtCasesWithResolutionTimestamp
 }


### PR DESCRIPTION
Add case state filter options according to design
- `Unresolved & resolved cases` or `Resolved cases`
- `Unresolved cases` returned if no case state filter is applied


![image](https://user-images.githubusercontent.com/22743709/211631824-02e9d4d5-0ee2-46b5-9c74-9b3fc64c6854.png)
