### PR TITLE
Remove redundant headings from filter sections

### DIFF
--- a/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
+++ b/src/components/CourtDateFilter/CourtCaseTypeOptions.tsx
@@ -12,7 +12,6 @@ const courtCaseTypeOptions = ["Exceptions", "Triggers"]
 const CourtCaseTypeOptions: React.FC<Props> = ({ courtCaseTypes, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
-      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Case type"}</legend>
       <div className="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
         {courtCaseTypeOptions.map((caseType) => (
           <div className="govuk-checkboxes__item" key={caseType}>

--- a/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
+++ b/src/components/CourtDateFilter/CourtDateFilterOptions.tsx
@@ -23,7 +23,6 @@ const labelForDateRange = (namedDateRange: string): string =>
 const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
-      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Court date"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
         <RadioButton
           name={"courtDate"}

--- a/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
+++ b/src/components/CourtDateFilter/UrgencyFilterOptions.tsx
@@ -16,7 +16,6 @@ const UrgencyOptions: KeyValuePair<string, boolean> = {
 const UrgencyFilterOptions: React.FC<Props> = ({ urgency, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
-      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Urgency"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
         {Object.keys(UrgencyOptions).map((optionName) => (
           <RadioButton

--- a/src/components/LockedFilter/LockedFilterOptions.tsx
+++ b/src/components/LockedFilter/LockedFilterOptions.tsx
@@ -17,7 +17,6 @@ const LockedOptions: KeyValuePair<string, boolean> = {
 const LockedFilterOptions: React.FC<Props> = ({ locked, dispatch }: Props) => {
   return (
     <fieldset className="govuk-fieldset">
-      <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">{"Locked state"}</legend>
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
         {lockedFilters.map((optionName) => (
           <RadioButton


### PR DESCRIPTION
The design spec has just the collapsible section headings, and the redundant headings inside the collapsible section have the same text as the collapsible section heading

Before: 
![Screenshot 2023-01-11 at 10 09 40](https://user-images.githubusercontent.com/7249529/211778368-3b29c9a7-0995-4a75-a786-795254bf78f0.png)

After:
![Screenshot 2023-01-11 at 10 12 01](https://user-images.githubusercontent.com/7249529/211778600-13188150-594c-45bc-a105-c9e4d72a1b58.png)
