### PR TITLE
Handle unescaped JSON in the feature flags column of the users table

### DIFF
--- a/src/services/entities/transformers/featureFlagTransformer.ts
+++ b/src/services/entities/transformers/featureFlagTransformer.ts
@@ -2,7 +2,7 @@ import { ValueTransformer } from "typeorm"
 
 const featureFlagTransformer: ValueTransformer = {
   to: (value) => value,
-  from: (value) => (value && value !== null && Object.keys(value)?.length > 0 ? value : {})
+  from: (value) => value ?? {}
 }
 
 export default featureFlagTransformer

--- a/src/services/entities/transformers/featureFlagTransformer.ts
+++ b/src/services/entities/transformers/featureFlagTransformer.ts
@@ -2,7 +2,7 @@ import { ValueTransformer } from "typeorm"
 
 const featureFlagTransformer: ValueTransformer = {
   to: (value) => JSON.stringify(value),
-  from: (value) => (value && value !== null && Object.keys(value)?.length > 0 ? JSON.parse(value) : {})
+  from: (value) => (value && value !== null && Object.keys(value)?.length > 0 ? JSON.parse(JSON.stringify(value)) : {})
 }
 
 export default featureFlagTransformer

--- a/src/services/entities/transformers/featureFlagTransformer.ts
+++ b/src/services/entities/transformers/featureFlagTransformer.ts
@@ -1,8 +1,8 @@
 import { ValueTransformer } from "typeorm"
 
 const featureFlagTransformer: ValueTransformer = {
-  to: (value) => JSON.stringify(value),
-  from: (value) => (value && value !== null && Object.keys(value)?.length > 0 ? JSON.parse(JSON.stringify(value)) : {})
+  to: (value) => value,
+  from: (value) => (value && value !== null && Object.keys(value)?.length > 0 ? value : {})
 }
 
 export default featureFlagTransformer

--- a/test/services/getUser.integration.test.ts
+++ b/test/services/getUser.integration.test.ts
@@ -2,7 +2,7 @@ import { DataSource } from "typeorm"
 import getDataSource from "../../src/services/getDataSource"
 import { isError } from "../../src/types/Result"
 import User from "../../src/services/entities/User"
-import { deleteUsers, getDummyUser, insertUsers } from "../utils/manageUsers"
+import { deleteUsers, getDummyUser, insertUsers, runQuery } from "../utils/manageUsers"
 import getUser from "../../src/services/getUser"
 import GroupName from "types/GroupName"
 
@@ -65,5 +65,17 @@ describe("getUser", () => {
 
     const actualUser = result as User
     expect(actualUser).toStrictEqual(inputUser)
+  })
+
+  it("should fetch feature flags correctly when unescaped values are in the DB", async () => {
+    const inputUser = await getDummyUser()
+    await insertUsers(inputUser)
+    await runQuery(`UPDATE br7own.users SET feature_flags = '{"test_flag":true}' WHERE username = 'Bichard01';`)
+
+    const result = await getUser(dataSource, inputUser.username)
+    expect(isError(result)).toBe(false)
+
+    const actualUser = result as User
+    expect(actualUser.featureFlags).toStrictEqual({ test_flag: true })
   })
 })

--- a/test/utils/manageUsers.ts
+++ b/test/utils/manageUsers.ts
@@ -34,6 +34,11 @@ const insertUserIntoGroup = async (emailAddress: string, groupName: string): Pro
   )
 }
 
+const runQuery = async (query: string) => {
+  const dataSource = await getDataSource()
+  return dataSource.manager.query(query)
+}
+
 const insertUsers = async (users: User | User[], userGroups?: string[]): Promise<InsertResult> => {
   const dataSource = await getDataSource()
   const result = await dataSource.createQueryBuilder().insert().into(User).values(users).execute()
@@ -65,4 +70,4 @@ const deleteUsers = async (): Promise<InsertResult> => {
   return dataSource.manager.query(`DELETE FROM br7own.users_groups; DELETE FROM br7own.users`)
 }
 
-export { getDummyUser, insertUsers, insertUsersWithOverrides, deleteUsers, insertUserIntoGroup }
+export { getDummyUser, insertUsers, insertUsersWithOverrides, deleteUsers, insertUserIntoGroup, runQuery }


### PR DESCRIPTION
This PR fixes an issue where the UI returns a 502 error when visited by a user who has unescaped json in the feature flags column in the database, for example `{"test_flag": true}`. This is the case for all users in production, but was not causing the tests to fail because the tests insert users through the typeORM json transformer which escapes the JSON string, for example `"{\"test_flag\": true}"`

We have added a test which sets a users feature flags to unescaped JSON and verifies the value retrieved, which tests just the fetch side of the JSON transformer, instead of the other tests which only ever test both sides at once.