### PR TITLE
Don't show unstyled content during page loads

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": "plugin:@next/next/recommended",
   "env": {
     "es6": true
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-decorators": "^7.20.13",
     "@jest/globals": "^29.3.1",
+    "@next/eslint-plugin-next": "^13.1.4",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-interactions": "^6.5.15",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import "date-time-format-timezone"
 import type { AppProps } from "next/app"
 import { useEffect } from "react"
 import "../../styles/globals.scss"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,6 @@
 import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from "next/document"
 import React from "react"
+import { createGenerateId, JssProvider, SheetsRegistry } from "react-jss"
 import { ServerStyleSheet } from "styled-components"
 import generateCsp from "utils/generateCsp"
 import generateNonce from "utils/generateNonce"
@@ -52,18 +53,38 @@ class GovUkDocument extends Document<DocumentProps> {
     const nonce = generateNonce()
     ctx.res?.setHeader("Content-Security-Policy", generateCsp(nonce))
 
+    // styled-components
     const sheet = new ServerStyleSheet()
     const originalRenderPage = ctx.renderPage
 
+    // react-jss
+    const registry = new SheetsRegistry()
+    const generateId = createGenerateId()
+
+    // include styles from both styled-components and react-jss
     try {
       ctx.renderPage = () => {
         return originalRenderPage({
-          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />)
+          enhanceApp: (App) => (props) =>
+            (
+              <JssProvider registry={registry} generateId={generateId}>
+                {sheet.collectStyles(<App {...props} />)}
+              </JssProvider>
+            )
         })
       }
 
       const initialProps = await Document.getInitialProps(ctx)
-      const additionalProps = { nonce, styles: [initialProps.styles, sheet.getStyleElement()] }
+      const additionalProps = {
+        nonce,
+        styles: [
+          initialProps.styles,
+          sheet.getStyleElement(),
+          <style key="react-jss" id="server-side-styles-react-jss">
+            {registry.toString()}
+          </style>
+        ]
+      }
 
       return {
         ...initialProps,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,6 @@
 import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from "next/document"
 import React from "react"
+import { ServerStyleSheet } from "styled-components"
 import generateCsp from "utils/generateCsp"
 import generateNonce from "utils/generateNonce"
 import { basePath } from "../../next.config"
@@ -51,16 +52,31 @@ class GovUkDocument extends Document<DocumentProps> {
     const nonce = generateNonce()
     ctx.res?.setHeader("Content-Security-Policy", generateCsp(nonce))
 
-    const initialProps = await Document.getInitialProps(ctx)
-    const additionalProps = { nonce }
-    return {
-      ...initialProps,
-      ...additionalProps
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () => {
+        return originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />)
+        })
+      }
+
+      const initialProps = await Document.getInitialProps(ctx)
+      const additionalProps = { nonce, styles: [initialProps.styles, sheet.getStyleElement()] }
+
+      return {
+        ...initialProps,
+        ...additionalProps
+      }
+    } finally {
+      sheet.seal()
     }
   }
 
   render() {
     const { nonce } = this.props
+
     return (
       <Html className="govuk-template" lang="en">
         <Head>


### PR DESCRIPTION
Previously, pages would show unstyled content before the javascript content of the page had loaded and executed, and if javascript was disabled, the styled would never load in. This looked like the following screenshot:

![Screenshot 2023-01-23 at 09 41 15](https://user-images.githubusercontent.com/7249529/214067677-3ce3d10a-2801-4ab4-89fc-1d9deb58dbfd.png)

We use both `styled-components` and `react-jss` to give styles to our components. These styles were not being included in the initial server-side rendered page, and were only loaded upon rehydration by JS.

This PR includes styles from both `styled-components` and `react-jss` in the initial page by loading them in our custom `_document.tsx`. Now, before the page JS loads it looks like this:

![Screenshot 2023-01-23 at 14 38 02](https://user-images.githubusercontent.com/7249529/214068938-280e64d8-93de-4499-a404-6f83481d63c5.png)


References:
* https://styled-components.com/docs/advanced#server-side-rendering
* https://github.com/vercel/next.js/tree/canary/examples/with-styled-components
* https://cssinjs.org/jss-api?v=v10.9.2#style-sheets-registry
* https://github.com/vercel/next.js/tree/canary/examples/with-react-jss