### PR TITLE
Bicaws 2608 Add reason field to display error and trigger details

### DIFF
--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -60,7 +60,7 @@ describe("Case list", () => {
 
         // Wait for the page to fully load
         cy.get("h1")
-        
+
         cy.checkA11y(undefined, a11yConfig, logAccessibilityViolations)
       })
     })
@@ -291,28 +291,32 @@ describe("Case list", () => {
       it("Should display reason (errors and triggers) with correct formatting", () => {
         cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "011111" }, { orgForPoliceFilter: "011111" }])
 
-        cy.task("insertException", { caseId: 0, exceptionCode: "HO200212", errorReport: "HO200212||ds:Reason" })
         cy.task("insertException", {
           caseId: 0,
-          exceptionCode: "HO200212",
-          errorReport: "HO200212||ds:Reason,HO200212||ds:Reason"
+          exceptionCode: "HO100310",
+          errorReport: "HO100310||ds:OffenceReasonSequence"
         })
         cy.task("insertException", {
           caseId: 0,
-          exceptionCode: "HO200213",
-          errorReport: "HO200212||ds:Reason,HO200212||ds:Reason"
+          exceptionCode: "HO100322",
+          errorReport: "HO100322||ds:OrganisationUnitCode"
+        })
+        cy.task("insertException", {
+          caseId: 0,
+          exceptionCode: "HO100310",
+          errorReport: "HO100310||ds:OffenceReasonSequence"
         })
 
         const triggers: TestTrigger[] = [
           {
             triggerId: 0,
-            triggerCode: "TRPR0107",
+            triggerCode: "TRPR0010",
             status: "Unresolved",
             createdAt: new Date("2022-07-09T10:22:34.000Z")
           },
           {
             triggerId: 1,
-            triggerCode: "TRPR0107",
+            triggerCode: "TRPR0015",
             status: "Unresolved",
             createdAt: new Date("2022-07-09T10:22:34.000Z")
           }
@@ -322,9 +326,10 @@ describe("Case list", () => {
         cy.login("bichard01@example.com", "password")
         cy.visit("/bichard")
 
-        cy.get("tr").eq(0).get("td:nth-child(7)").contains("Reason")
-        cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO200212")
-        cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0107")
+        cy.get("tr").not(":first").get("td:nth-child(8)").contains("HO100310 (2)")
+        cy.get("tr").not(":first").get("td:nth-child(8)").contains("HO100322")
+        // cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0010 - Conditional bail")
+        // cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0015 - Personal details changed")
       })
 
       it("can display cases ordered by urgency", () => {

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -328,8 +328,8 @@ describe("Case list", () => {
 
         cy.get("tr").not(":first").get("td:nth-child(8)").contains("HO100310 (2)")
         cy.get("tr").not(":first").get("td:nth-child(8)").contains("HO100322")
-        // cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0010 - Conditional bail")
-        // cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0015 - Personal details changed")
+        cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0010 - Conditional bail")
+        cy.get("tr").not(":first").get("td:nth-child(8)").contains("TRPR0015 - Personal details changed")
       })
 
       it("can display cases ordered by urgency", () => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@ministryofjustice/frontend": "^1.6.4",
     "@moj-bichard7-developers/bichard7-next-core": "^1.1.7",
+    "@moj-bichard7-developers/bichard7-next-data": "^2.0.47",
     "@types/lodash.clonedeep": "^4.5.7",
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "date-fns": "^2.29.3",

--- a/src/features/CourtCaseList/CourtCaseList.stories.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.stories.tsx
@@ -28,6 +28,7 @@ const courtCase = {
   defendantName: "Allocation Trigger",
   errorId: 79057,
   errorReason: "HO100206",
+  errorReport: "HO100206",
   messageId: "cf60600b-52a0-4bc7-b117-3acfb851a7f5",
   notes: [userNote, userNote, systemNote],
   orgForPoliceFilter: "36FP  ",

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -8,6 +8,7 @@ import type { QueryOrder } from "types/CaseListQueryParams"
 import LockedByTag from "./tags/LockedByTag"
 import NotesTag from "./tags/NotesTag"
 import UrgentTag from "./tags/UrgentTag"
+import groupErrorsFromReport from "utils/formatReasons/groupErrorsFromReport"
 
 interface Props {
   courtCases: CourtCase[]
@@ -67,6 +68,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
       { courtDate, ptiurn, defendantName, courtName, triggers, errorReport, isUrgent, notes, errorLockedByUsername },
       idx
     ) => {
+      const exceptions = groupErrorsFromReport(errorReport)
       return (
         <Table.Row key={idx} style={{ verticalAlign: "top" }}>
           <Table.Cell>
@@ -91,9 +93,14 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
             <NotesTag notes={notes} />
           </Table.Cell>
           <Table.Cell>
-            <GridRow>{errorReport}</GridRow>
+            {Object.keys(exceptions).map((code, codeId) => (
+              <GridRow key={`exception_${codeId}`}>
+                {code}
+                <b>&nbsp;{exceptions[code] > 1 ? `(${exceptions[code]})` : ""}</b>
+              </GridRow>
+            ))}
             {triggers?.map((trigger, triggerId) => (
-              <GridRow key={triggerId}>{trigger.triggerCode}</GridRow>
+              <GridRow key={`trigger_${triggerId}`}>{trigger.triggerCode}</GridRow>
             ))}
           </Table.Cell>
           <Table.Cell>

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -53,7 +53,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
       </Table.CellHeader>
       <Table.CellHeader>{"Notes"}</Table.CellHeader>
       <Table.CellHeader>
-        <Link href={orderByParams("errorReason")} id="exceptions">
+        <Link href={orderByParams("reason")} id="exceptions">
           {"Reason"}
         </Link>
       </Table.CellHeader>

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -9,6 +9,7 @@ import LockedByTag from "./tags/LockedByTag"
 import NotesTag from "./tags/NotesTag"
 import UrgentTag from "./tags/UrgentTag"
 import groupErrorsFromReport from "utils/formatReasons/groupErrorsFromReport"
+import getTriggerWithDescription from "utils/formatReasons/getTriggerWithDescription"
 
 interface Props {
   courtCases: CourtCase[]
@@ -100,7 +101,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
               </GridRow>
             ))}
             {triggers?.map((trigger, triggerId) => (
-              <GridRow key={`trigger_${triggerId}`}>{trigger.triggerCode}</GridRow>
+              <GridRow key={`trigger_${triggerId}`}>{getTriggerWithDescription(trigger.triggerCode)}</GridRow>
             ))}
           </Table.Cell>
           <Table.Cell>

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -1,9 +1,9 @@
 import DateTime from "components/DateTime"
 import If from "components/If"
-import { Link, Paragraph, Table } from "govuk-react"
 import Image from "next/image"
 import { useRouter } from "next/router"
 import CourtCase from "services/entities/CourtCase"
+import { Table, Link, GridRow, Paragraph } from "govuk-react"
 import type { QueryOrder } from "types/CaseListQueryParams"
 import LockedByTag from "./tags/LockedByTag"
 import NotesTag from "./tags/NotesTag"
@@ -50,10 +50,9 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
         </Link>
       </Table.CellHeader>
       <Table.CellHeader>{"Notes"}</Table.CellHeader>
-      <Table.CellHeader>{"Triggers"}</Table.CellHeader>
       <Table.CellHeader>
         <Link href={orderByParams("errorReason")} id="exceptions">
-          {"Exceptions"}
+          {"Reason"}
         </Link>
       </Table.CellHeader>
       <Table.CellHeader>
@@ -65,11 +64,11 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
   )
   const tableBody = courtCases.map(
     (
-      { courtDate, ptiurn, defendantName, courtName, triggers, errorReason, isUrgent, notes, errorLockedByUsername },
+      { courtDate, ptiurn, defendantName, courtName, triggers, errorReport, isUrgent, notes, errorLockedByUsername },
       idx
     ) => {
       return (
-        <Table.Row key={idx}>
+        <Table.Row key={idx} style={{ verticalAlign: "top" }}>
           <Table.Cell>
             <If condition={!!errorLockedByUsername}>
               <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
@@ -91,8 +90,12 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
           <Table.Cell>
             <NotesTag notes={notes} />
           </Table.Cell>
-          <Table.Cell>{triggers?.map((trigger) => trigger.triggerCode).join(", ")}</Table.Cell>
-          <Table.Cell>{errorReason}</Table.Cell>
+          <Table.Cell>
+            <GridRow>{errorReport}</GridRow>
+            {triggers?.map((trigger, triggerId) => (
+              <GridRow key={triggerId}>{trigger.triggerCode}</GridRow>
+            ))}
+          </Table.Cell>
           <Table.Cell>
             <LockedByTag lockedBy={errorLockedByUsername} />
           </Table.Cell>

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -58,7 +58,7 @@ const listCourtCases = async (
   if (reasonsSearch) {
     query.andWhere(
       new Brackets((qb) => {
-        qb.where("courtCase.trigger_reason ilike '%' || :reason || '%'", {
+        qb.where("trigger.trigger_code ilike '%' || :reason || '%'", {
           reason: reasonsSearch
         }).orWhere("courtCase.error_report ilike '%' || :reason || '%'", {
           reason: reasonsSearch

--- a/src/utils/formatReasons/getTriggerWithDescription.test.ts
+++ b/src/utils/formatReasons/getTriggerWithDescription.test.ts
@@ -1,0 +1,8 @@
+import getTriggerWithDescription from "./getTriggerWithDescription"
+
+describe("getTriggerWithDescription", () => {
+  it("add short description to a trigger", () => {
+    expect(getTriggerWithDescription("TRPR0012")).toStrictEqual("TRPR0012 - Warrant withdrawn")
+    expect(getTriggerWithDescription("TRPR0015")).toStrictEqual("TRPR0015 - Personal details changed")
+  })
+})

--- a/src/utils/formatReasons/getTriggerWithDescription.ts
+++ b/src/utils/formatReasons/getTriggerWithDescription.ts
@@ -1,0 +1,13 @@
+import triggerDefinitions from "@moj-bichard7-developers/bichard7-next-data/dist/data/trigger-definitions.json"
+
+const getTriggerWithDescription = (triggerCode: string): string => {
+  let triggerWithDescription = triggerCode
+  triggerDefinitions.forEach((record) => {
+    if (record.code === triggerCode) {
+      triggerWithDescription = `${triggerCode} - ${record.shortDescription}`
+    }
+  })
+  return triggerWithDescription
+}
+
+export default getTriggerWithDescription

--- a/src/utils/formatReasons/groupErrorsFromReport.test.ts
+++ b/src/utils/formatReasons/groupErrorsFromReport.test.ts
@@ -1,0 +1,13 @@
+import groupErrorsFromReport from "./groupErrorsFromReport"
+
+describe("groupErrorsFromReport", () => {
+  it("can map all exceptions from the error report", () => {
+    const errorReport = "HO100322||ds:OrganisationUnitCode, HO100323||ds:NextHearingDate HO100310||ds:NextHearingDate"
+    expect(groupErrorsFromReport(errorReport)).toStrictEqual({ HO100322: 1, HO100323: 1, HO100310: 1 })
+  })
+
+  it("can group multiple occurrences of a code", () => {
+    const errorReport = "HO100322||ds:OrganisationUnitCode, HO100322||ds:NextHearingDate HO100310||ds:NextHearingDate"
+    expect(groupErrorsFromReport(errorReport)).toStrictEqual({ HO100322: 2, HO100310: 1 })
+  })
+})

--- a/src/utils/formatReasons/groupErrorsFromReport.ts
+++ b/src/utils/formatReasons/groupErrorsFromReport.ts
@@ -1,0 +1,11 @@
+import KeyValuePair from "types/KeyValuePair"
+
+const groupErrorsFromReport = (errorReport: string): KeyValuePair<string, number> => {
+  const errorsCodes: KeyValuePair<string, number> = {}
+  errorReport.match(/(HO)[0-9]{1,9}/g)?.forEach((code) => {
+    errorsCodes[code] = errorsCodes[code] ? errorsCodes[code] + 1 : (errorsCodes[code] = 1)
+  })
+  return errorsCodes
+}
+
+export default groupErrorsFromReport

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -500,6 +500,70 @@ describe("listCourtCases", () => {
     expect(totalCasesDesc).toEqual(3)
   })
 
+  it("should order by error reason as primary order when ordered by reason", async () => {
+    const orgCode = "36FPA1"
+    await insertCourtCasesWithFields(
+      ["HO100100", "HO100101", "HO100102"].map((code) => ({ errorReason: code, orgForPoliceFilter: orgCode }))
+    )
+
+    const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
+    expect(isError(resultAsc)).toBe(false)
+    const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
+
+    expect(casesAsc).toHaveLength(3)
+    expect(casesAsc[0].errorReason).toStrictEqual("HO100100")
+    expect(casesAsc[1].errorReason).toStrictEqual("HO100101")
+    expect(casesAsc[2].errorReason).toStrictEqual("HO100102")
+    expect(totalCasesAsc).toEqual(3)
+
+    const resultDesc = await listCourtCases(dataSource, {
+      forces: [orgCode],
+      maxPageItems: "100",
+      orderBy: "reason",
+      order: "desc"
+    })
+    expect(isError(resultDesc)).toBe(false)
+    const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
+
+    expect(casesDesc).toHaveLength(3)
+    expect(casesDesc[0].errorReason).toStrictEqual("HO100102")
+    expect(casesDesc[1].errorReason).toStrictEqual("HO100101")
+    expect(casesDesc[2].errorReason).toStrictEqual("HO100100")
+    expect(totalCasesDesc).toEqual(3)
+  })
+
+  it("should order by trigger reason as secondary order when ordered by reason", async () => {
+    const orgCode = "36FPA1"
+    await insertCourtCasesWithFields(
+      ["TRPR0010", "TRPR0011", "TRPR0012"].map((code) => ({ triggerReason: code, orgForPoliceFilter: orgCode }))
+    )
+
+    const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
+    expect(isError(resultAsc)).toBe(false)
+    const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
+
+    expect(casesAsc).toHaveLength(3)
+    expect(casesAsc[0].triggerReason).toStrictEqual("TRPR0010")
+    expect(casesAsc[1].triggerReason).toStrictEqual("TRPR0011")
+    expect(casesAsc[2].triggerReason).toStrictEqual("TRPR0012")
+    expect(totalCasesAsc).toEqual(3)
+
+    const resultDesc = await listCourtCases(dataSource, {
+      forces: [orgCode],
+      maxPageItems: "100",
+      orderBy: "reason",
+      order: "desc"
+    })
+    expect(isError(resultDesc)).toBe(false)
+    const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
+
+    expect(casesDesc).toHaveLength(3)
+    expect(casesDesc[0].triggerReason).toStrictEqual("TRPR0012")
+    expect(casesDesc[1].triggerReason).toStrictEqual("TRPR0011")
+    expect(casesDesc[2].triggerReason).toStrictEqual("TRPR0010")
+    expect(totalCasesDesc).toEqual(3)
+  })
+
   describe("filter by defendant name", () => {
     it("should list cases when there is a case insensitive match", async () => {
       const orgCode = "01FPA1"

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -695,11 +695,10 @@ describe("listCourtCases", () => {
 
       const errorToInclude = "HO100322"
       const anotherErrorToInclude = "HO100323"
-      const errorReport = `${errorToInclude}||ds:OrganisationUnitCode, ${anotherErrorToInclude}||ds:NextHearingDate`
       const errorNotToInclude = "HO200212"
 
-      await insertException(0, errorToInclude, errorReport)
-      await insertException(0, anotherErrorToInclude, errorReport)
+      await insertException(0, errorToInclude, `${errorToInclude}||ds:OrganisationUnitCode`)
+      await insertException(0, anotherErrorToInclude, `${anotherErrorToInclude}||ds:NextHearingDate`)
       await insertException(1, errorNotToInclude, `${errorNotToInclude}||ds:XMLField`)
 
       let result = await listCourtCases(dataSource, {
@@ -712,7 +711,9 @@ describe("listCourtCases", () => {
       let { result: cases } = result as ListCourtCaseResult
 
       expect(cases).toHaveLength(1)
-      expect(cases[0].errorReport).toStrictEqual(errorReport)
+      expect(cases[0].errorReport).toStrictEqual(
+        `${errorToInclude}||ds:OrganisationUnitCode, ${anotherErrorToInclude}||ds:NextHearingDate`
+      )
 
       result = await listCourtCases(dataSource, {
         forces: ["01"],
@@ -724,7 +725,9 @@ describe("listCourtCases", () => {
       cases = (result as ListCourtCaseResult).result
 
       expect(cases).toHaveLength(1)
-      expect(cases[0].errorReport).toStrictEqual(errorReport)
+      expect(cases[0].errorReport).toStrictEqual(
+        `${errorToInclude}||ds:OrganisationUnitCode, ${anotherErrorToInclude}||ds:NextHearingDate`
+      )
     })
   })
 

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -686,7 +686,7 @@ describe("listCourtCases", () => {
       cases = (result as ListCourtCaseResult).result
 
       expect(cases).toHaveLength(2)
-      expect(cases[0].triggers[1].triggerCode).toStrictEqual(triggerToIncludePartialMatch.triggerCode)
+      expect(cases[0].triggers[0].triggerCode).toStrictEqual(triggerToIncludePartialMatch.triggerCode)
       expect(cases[1].errorReason).toStrictEqual(errorToIncludePartialMatch)
     })
 

--- a/test/utils/manageExceptions.ts
+++ b/test/utils/manageExceptions.ts
@@ -10,7 +10,10 @@ export default async (caseId: number, exceptionCode: string, errorReport?: strin
     .set({
       errorCount: () => "error_count + 1",
       errorReason: exceptionCode,
-      ...(errorReport && { errorReport: errorReport })
+      ...(errorReport && {
+        errorReport: () =>
+          `(CASE WHEN (error_report = '') THEN '${errorReport}' ELSE error_report || ', ' || '${errorReport}' END)`
+      })
     })
     .where("errorId = :id", { id: caseId })
     .execute()

--- a/test/utils/manageTriggers.ts
+++ b/test/utils/manageTriggers.ts
@@ -31,7 +31,7 @@ const insertTriggers = async (caseId: number, triggers: TestTrigger[]): Promise<
     .update(CourtCase)
     .set({
       triggerCount: () => "trigger_count + 1",
-      triggerReason: triggers.map((t) => t.triggerCode).join(", ")
+      triggerReason: triggers[triggers.length - 1].triggerCode
     })
     .where("errorId = :id", { id: caseId })
     .execute()


### PR DESCRIPTION
### Context
Currently, we show Triggers and Exceptions in two separate columns; these should be displayed under the reason column

### Changes
- Map the errors from `errorReport` field and display according to design
- Install the standing data package
- Utilise the `trigger-definitions` from the standing data package to append the triggers with a short description
- Update the order by logic in `listCourtCases` so it uses both `errorReason` and `triggerReason` fields when ordering by reason(since reasons live in two separate columns in DB this is the best sorting mechanism I could come up with)
- Fix a bug when searching for cases by trigger code

![image](https://user-images.githubusercontent.com/22743709/215134671-d65770e2-bf39-4de0-a6ef-b9635d76af95.png)
