### PR TITLE
Display triggers on a new row below exceptions

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -223,7 +223,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00000")
       cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00001").should("not.exist")
       cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00002").should("not.exist")
-      cy.get("tr").should("have.length", 2)
+      cy.get("tr").should("have.length", 3) // Triggers rendered on a new row
       cy.get(".moj-filter-tags a.moj-filter__tag").contains("TRPR0107")
       cy.get(".moj-filter-tags a.moj-filter__tag").contains("TRPR0107").click({ force: true })
 

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -372,19 +372,41 @@ describe("Case list", () => {
             orgForPoliceFilter: "011111"
           }))
         )
+        const triggers: TestTrigger[] = [
+          {
+            triggerId: 0,
+            triggerCode: "TRPR0001",
+            status: "Unresolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          }
+        ]
+        cy.task("insertTriggers", { caseId: 0, triggers })
+        cy.task("insertTriggers", { caseId: 1, triggers })
+        cy.task("insertTriggers", { caseId: 2, triggers })
+        cy.task("insertTriggers", { caseId: 3, triggers })
 
         cy.login("bichard01@example.com", "password")
         cy.visit("/bichard")
 
-        lockUsernames.forEach((lockUsername, idx) => {
-          if (lockUsername !== null) {
-            cy.get(`tbody tr:nth-child(${idx + 1}) .locked-by-tag`).should("have.text", lockUsername)
-            cy.get(`tbody tr:nth-child(${idx + 1}) img[alt="Lock icon"]`).should("exist")
-          } else {
-            cy.get(`tbody tr:nth-child(${idx + 1}) .locked-by-tag`).should("not.exist")
-            cy.get(`tbody tr:nth-child(${idx + 1}) img[alt="Lock icon"]`).should("not.exist")
-          }
-        })
+        //Error locks
+        cy.get(`tbody tr:nth-child(1) .locked-by-tag`).should("have.text", "Bichard01")
+        cy.get(`tbody tr:nth-child(1) img[alt="Lock icon"]`).should("exist")
+        cy.get(`tbody tr:nth-child(3) .locked-by-tag`).should("have.text", "Bichard02")
+        cy.get(`tbody tr:nth-child(3) img[alt="Lock icon"]`).should("exist")
+        cy.get(`tbody tr:nth-child(5) .locked-by-tag`).should("not.exist")
+        cy.get(`tbody tr:nth-child(5) img[alt="Lock icon"]`).should("not.exist")
+        cy.get(`tbody tr:nth-child(7) .locked-by-tag`).should("have.text", "A really really really long name")
+        cy.get(`tbody tr:nth-child(7) img[alt="Lock icon"]`).should("exist")
+
+        //Trigger locks
+        cy.get(`tbody tr:nth-child(2) .locked-by-tag`).should("have.text", "Bichard01")
+        cy.get(`tbody tr:nth-child(2) img[alt="Lock icon"]`).should("exist")
+        cy.get(`tbody tr:nth-child(4) .locked-by-tag`).should("have.text", "Bichard02")
+        cy.get(`tbody tr:nth-child(4) img[alt="Lock icon"]`).should("exist")
+        cy.get(`tbody tr:nth-child(6) .locked-by-tag`).should("not.exist")
+        cy.get(`tbody tr:nth-child(6) img[alt="Lock icon"]`).should("not.exist")
+        cy.get(`tbody tr:nth-child(8) .locked-by-tag`).should("have.text", "A really really really long name")
+        cy.get(`tbody tr:nth-child(8) img[alt="Lock icon"]`).should("exist")
       })
 
       it("can sort cases by who has locked it", () => {

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -139,12 +139,12 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
                 <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
               </If>
             </Table.Cell>
-            <Table.Cell></Table.Cell>
-            <Table.Cell></Table.Cell>
-            <Table.Cell></Table.Cell>
-            <Table.Cell></Table.Cell>
-            <Table.Cell></Table.Cell>
-            <Table.Cell></Table.Cell>
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
             <Table.Cell>
               {triggers?.map((trigger, triggerId) => (
                 <GridRow key={`trigger_${triggerId}`}>{getTriggerWithDescription(trigger.triggerCode)}</GridRow>

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -10,6 +10,17 @@ import NotesTag from "./tags/NotesTag"
 import UrgentTag from "./tags/UrgentTag"
 import groupErrorsFromReport from "utils/formatReasons/groupErrorsFromReport"
 import getTriggerWithDescription from "utils/formatReasons/getTriggerWithDescription"
+import { createUseStyles } from "react-jss"
+
+const useStyles = createUseStyles({
+  caseDetailsRow: {
+    verticalAlign: "top"
+  },
+  triggersRow: {
+    verticalAlign: "top",
+    backgroundColor: "#f3f2f1" // GDS light-grey color
+  }
+})
 
 interface Props {
   courtCases: CourtCase[]
@@ -17,6 +28,7 @@ interface Props {
 }
 
 const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) => {
+  const classes = useStyles()
   const { basePath, query } = useRouter()
 
   const orderByParams = (orderBy: string) => `${basePath}/?${new URLSearchParams({ ...query, orderBy, order })}`
@@ -64,14 +76,26 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
       </Table.CellHeader>
     </Table.Row>
   )
-  const tableBody = courtCases.map(
+  const tableBody: JSX.Element[] = []
+  courtCases.forEach(
     (
-      { courtDate, ptiurn, defendantName, courtName, triggers, errorReport, isUrgent, notes, errorLockedByUsername },
+      {
+        courtDate,
+        ptiurn,
+        defendantName,
+        courtName,
+        triggers,
+        errorReport,
+        isUrgent,
+        notes,
+        errorLockedByUsername,
+        triggerLockedByUsername
+      },
       idx
     ) => {
       const exceptions = groupErrorsFromReport(errorReport)
-      return (
-        <Table.Row key={idx} style={{ verticalAlign: "top" }}>
+      tableBody.push(
+        <Table.Row key={`case-details-row-${idx}`} className={classes.caseDetailsRow}>
           <Table.Cell>
             <If condition={!!errorLockedByUsername}>
               <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
@@ -100,15 +124,38 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
                 <b>&nbsp;{exceptions[code] > 1 ? `(${exceptions[code]})` : ""}</b>
               </GridRow>
             ))}
-            {triggers?.map((trigger, triggerId) => (
-              <GridRow key={`trigger_${triggerId}`}>{getTriggerWithDescription(trigger.triggerCode)}</GridRow>
-            ))}
           </Table.Cell>
           <Table.Cell>
             <LockedByTag lockedBy={errorLockedByUsername} />
           </Table.Cell>
         </Table.Row>
       )
+
+      if (triggers.length > 0) {
+        tableBody.push(
+          <Table.Row key={`triggers-row-${idx}`} className={classes.triggersRow}>
+            <Table.Cell>
+              <If condition={!!triggerLockedByUsername}>
+                <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
+              </If>
+            </Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell></Table.Cell>
+            <Table.Cell>
+              {triggers?.map((trigger, triggerId) => (
+                <GridRow key={`trigger_${triggerId}`}>{getTriggerWithDescription(trigger.triggerCode)}</GridRow>
+              ))}
+            </Table.Cell>
+            <Table.Cell>
+              <LockedByTag lockedBy={triggerLockedByUsername} />
+            </Table.Cell>
+          </Table.Row>
+        )
+      }
     }
   )
 

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -70,7 +70,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc" }: Props) =>
         </Link>
       </Table.CellHeader>
       <Table.CellHeader>
-        <Link href={orderByParams("errorLockedByUsername")} id="locked-by-sort">
+        <Link href={orderByParams("lockedBy")} id="locked-by-sort">
           {"Locked By"}
         </Link>
       </Table.CellHeader>

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -38,6 +38,10 @@ const listCourtCases = async (
   const sortOrder = order === "desc" ? "DESC" : "ASC"
   if (orderBy === "reason") {
     query.orderBy("courtCase.errorReason", sortOrder).addOrderBy("courtCase.triggerReason", sortOrder)
+  } else if (orderBy === "lockedBy") {
+    query
+      .orderBy("courtCase.errorLockedByUsername", sortOrder)
+      .addOrderBy("courtCase.triggerLockedByUsername", sortOrder)
   } else {
     const orderByQuery = `courtCase.${orderBy ?? "errorId"}`
     query.orderBy(orderByQuery, sortOrder)

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -500,68 +500,117 @@ describe("listCourtCases", () => {
     expect(totalCasesDesc).toEqual(3)
   })
 
-  it("should order by error reason as primary order when ordered by reason", async () => {
-    const orgCode = "36FPA1"
-    await insertCourtCasesWithFields(
-      ["HO100100", "HO100101", "HO100102"].map((code) => ({ errorReason: code, orgForPoliceFilter: orgCode }))
-    )
+  describe("ordered by 'lockedBy' reason", () => {
+    it("should order by error reason as primary order", async () => {
+      const orgCode = "36FPA1"
+      await insertCourtCasesWithFields(
+        ["HO100100", "HO100101", "HO100102"].map((code) => ({ errorReason: code, orgForPoliceFilter: orgCode }))
+      )
 
-    const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
-    expect(isError(resultAsc)).toBe(false)
-    const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
+      const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
+      expect(isError(resultAsc)).toBe(false)
+      const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
 
-    expect(casesAsc).toHaveLength(3)
-    expect(casesAsc[0].errorReason).toStrictEqual("HO100100")
-    expect(casesAsc[1].errorReason).toStrictEqual("HO100101")
-    expect(casesAsc[2].errorReason).toStrictEqual("HO100102")
-    expect(totalCasesAsc).toEqual(3)
+      expect(casesAsc).toHaveLength(3)
+      expect(casesAsc[0].errorReason).toStrictEqual("HO100100")
+      expect(casesAsc[1].errorReason).toStrictEqual("HO100101")
+      expect(casesAsc[2].errorReason).toStrictEqual("HO100102")
+      expect(totalCasesAsc).toEqual(3)
 
-    const resultDesc = await listCourtCases(dataSource, {
-      forces: [orgCode],
-      maxPageItems: "100",
-      orderBy: "reason",
-      order: "desc"
+      const resultDesc = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        orderBy: "reason",
+        order: "desc"
+      })
+      expect(isError(resultDesc)).toBe(false)
+      const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
+
+      expect(casesDesc).toHaveLength(3)
+      expect(casesDesc[0].errorReason).toStrictEqual("HO100102")
+      expect(casesDesc[1].errorReason).toStrictEqual("HO100101")
+      expect(casesDesc[2].errorReason).toStrictEqual("HO100100")
+      expect(totalCasesDesc).toEqual(3)
     })
-    expect(isError(resultDesc)).toBe(false)
-    const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
 
-    expect(casesDesc).toHaveLength(3)
-    expect(casesDesc[0].errorReason).toStrictEqual("HO100102")
-    expect(casesDesc[1].errorReason).toStrictEqual("HO100101")
-    expect(casesDesc[2].errorReason).toStrictEqual("HO100100")
-    expect(totalCasesDesc).toEqual(3)
+    it("should order by trigger reason as secondary order", async () => {
+      const orgCode = "36FPA1"
+      await insertCourtCasesWithFields(
+        ["TRPR0010", "TRPR0011", "TRPR0012"].map((code) => ({ triggerReason: code, orgForPoliceFilter: orgCode }))
+      )
+
+      const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
+      expect(isError(resultAsc)).toBe(false)
+      const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
+
+      expect(casesAsc).toHaveLength(3)
+      expect(casesAsc[0].triggerReason).toStrictEqual("TRPR0010")
+      expect(casesAsc[1].triggerReason).toStrictEqual("TRPR0011")
+      expect(casesAsc[2].triggerReason).toStrictEqual("TRPR0012")
+      expect(totalCasesAsc).toEqual(3)
+
+      const resultDesc = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        orderBy: "reason",
+        order: "desc"
+      })
+      expect(isError(resultDesc)).toBe(false)
+      const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
+
+      expect(casesDesc).toHaveLength(3)
+      expect(casesDesc[0].triggerReason).toStrictEqual("TRPR0012")
+      expect(casesDesc[1].triggerReason).toStrictEqual("TRPR0011")
+      expect(casesDesc[2].triggerReason).toStrictEqual("TRPR0010")
+      expect(totalCasesDesc).toEqual(3)
+    })
   })
 
-  it("should order by trigger reason as secondary order when ordered by reason", async () => {
-    const orgCode = "36FPA1"
-    await insertCourtCasesWithFields(
-      ["TRPR0010", "TRPR0011", "TRPR0012"].map((code) => ({ triggerReason: code, orgForPoliceFilter: orgCode }))
-    )
+  describe("ordered by 'lockedBy' username", () => {
+    it("should order by errorLockedByUsername as primary order and triggerLockedByUsername as secondary order", async () => {
+      const orgCode = "36FPA1"
 
-    const resultAsc = await listCourtCases(dataSource, { forces: [orgCode], maxPageItems: "100", orderBy: "reason" })
-    expect(isError(resultAsc)).toBe(false)
-    const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
+      await insertCourtCasesWithFields([
+        { errorLockedByUsername: "User1", triggerLockedByUsername: "User4", orgForPoliceFilter: orgCode },
+        { errorLockedByUsername: "User1", triggerLockedByUsername: "User3", orgForPoliceFilter: orgCode },
+        { errorLockedByUsername: "User2", triggerLockedByUsername: "User1", orgForPoliceFilter: orgCode }
+      ])
 
-    expect(casesAsc).toHaveLength(3)
-    expect(casesAsc[0].triggerReason).toStrictEqual("TRPR0010")
-    expect(casesAsc[1].triggerReason).toStrictEqual("TRPR0011")
-    expect(casesAsc[2].triggerReason).toStrictEqual("TRPR0012")
-    expect(totalCasesAsc).toEqual(3)
+      const resultAsc = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        orderBy: "lockedBy"
+      })
+      expect(isError(resultAsc)).toBe(false)
+      const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
 
-    const resultDesc = await listCourtCases(dataSource, {
-      forces: [orgCode],
-      maxPageItems: "100",
-      orderBy: "reason",
-      order: "desc"
+      expect(casesAsc).toHaveLength(3)
+      expect(casesAsc[0].errorLockedByUsername).toStrictEqual("User1")
+      expect(casesAsc[0].triggerLockedByUsername).toStrictEqual("User3")
+      expect(casesAsc[1].errorLockedByUsername).toStrictEqual("User1")
+      expect(casesAsc[1].triggerLockedByUsername).toStrictEqual("User4")
+      expect(casesAsc[2].errorLockedByUsername).toStrictEqual("User2")
+      expect(casesAsc[2].triggerLockedByUsername).toStrictEqual("User1")
+      expect(totalCasesAsc).toEqual(3)
+
+      const resultDesc = await listCourtCases(dataSource, {
+        forces: [orgCode],
+        maxPageItems: "100",
+        orderBy: "lockedBy",
+        order: "desc"
+      })
+      expect(isError(resultDesc)).toBe(false)
+      const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
+
+      expect(casesDesc).toHaveLength(3)
+      expect(casesDesc[0].errorLockedByUsername).toStrictEqual("User2")
+      expect(casesDesc[0].triggerLockedByUsername).toStrictEqual("User1")
+      expect(casesDesc[1].errorLockedByUsername).toStrictEqual("User1")
+      expect(casesDesc[1].triggerLockedByUsername).toStrictEqual("User4")
+      expect(casesDesc[2].errorLockedByUsername).toStrictEqual("User1")
+      expect(casesDesc[2].triggerLockedByUsername).toStrictEqual("User3")
+      expect(totalCasesDesc).toEqual(3)
     })
-    expect(isError(resultDesc)).toBe(false)
-    const { result: casesDesc, totalCases: totalCasesDesc } = resultDesc as ListCourtCaseResult
-
-    expect(casesDesc).toHaveLength(3)
-    expect(casesDesc[0].triggerReason).toStrictEqual("TRPR0012")
-    expect(casesDesc[1].triggerReason).toStrictEqual("TRPR0011")
-    expect(casesDesc[2].triggerReason).toStrictEqual("TRPR0010")
-    expect(totalCasesDesc).toEqual(3)
   })
 
   describe("filter by defendant name", () => {


### PR DESCRIPTION
### Changes
- Display triggers in a new row
- Display locked by status for triggers
- When sorting by locked status order by `errorLockedByUsername` and order by `triggerLockedByUsername`

<img width="1454" alt="image" src="https://user-images.githubusercontent.com/22743709/215507817-be1fc7c4-4bb2-4481-8327-ee38f8bbcf1f.png">
