### PR TITLE
Add script to seed the database with more realistic data

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "@faker-js/faker": "^7.6.0",
     "@jest/globals": "^29.4.1",
     "@next/eslint-plugin-next": "^13.1.6",
+    "@stdlib/random-base-exponential": "^0.0.6",
+    "@stdlib/random-sample": "^0.0.7",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "update-deps": "ncu -u && npm install",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "test-storybook": "test-storybook"
+    "test-storybook": "test-storybook",
+    "seed-data": "ts-node ./scripts/seed-data.ts"
   },
   "dependencies": {
     "@govuk-react/select": "^0.10.5",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-decorators": "^7.20.13",
+    "@faker-js/faker": "^7.6.0",
     "@jest/globals": "^29.4.1",
     "@next/eslint-plugin-next": "^13.1.6",
     "@storybook/addon-actions": "^6.5.16",
@@ -82,11 +84,13 @@
     "@types/lodash.frompairs": "^4.0.7",
     "@types/lodash.get": "^4.4.7",
     "@types/lodash.isobject": "^3.0.7",
+    "@types/lodash.sample": "^4.2.7",
     "@types/node": "18.11.19",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
     "@types/stompit": "^0.26.3",
     "@types/styled-components": "^5.1.26",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "axe-core": "^4.6.3",
@@ -114,6 +118,7 @@
     "jsonwebtoken": "^9.0.0",
     "lint-staged": "^13.1.0",
     "lodash.frompairs": "^4.0.1",
+    "lodash.sample": "^4.2.1",
     "mockdate": "^3.0.5",
     "npm-check-updates": "^16.6.4",
     "pg-promise": "^11.2.0",

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { subDays } from "date-fns"
-import Trigger from "../src/services/entities/Trigger"
 import CourtCase from "../src/services/entities/CourtCase"
+import Trigger from "../src/services/entities/Trigger"
 import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromTable from "../test/utils/deleteFromTable"

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { subDays } from "date-fns"
+import CourtCase from "../src/services/entities/CourtCase"
 import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
+import deleteFromTable from "../test/utils/deleteFromTable"
 import { insertCourtCases } from "../test/utils/insertCourtCases"
 
 const minCases = 100
@@ -14,9 +17,12 @@ const numCases = Math.round(Math.random() * numCasesRange) + minCases
 console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
 
 getDataSource().then(async (dataSource) => {
+  await deleteFromTable(CourtCase)
+
   const courtCases = new Array(numCases)
     .fill(0)
     .map(() => createDummyCase(dataSource, forceId, subDays(new Date(), maxCaseAge)))
+    .sort((caseA, caseB) => caseB.courtDate!.getTime() - caseA.courtDate!.getTime())
 
   await insertCourtCases(courtCases)
 })

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,0 +1,24 @@
+import { subDays } from "date-fns"
+import getDataSource from "../src/services/getDataSource"
+import createDummyCase from "../test/helpers/createDummyCase"
+import { insertCourtCases } from "../test/utils/insertCourtCases"
+
+const minCases = 100
+const maxCases = 1_000
+const forceId = process.env.FORCE_ID || "01"
+const maxCaseAge = 12 * 30
+
+const numCasesRange = maxCases - minCases
+const numCases = Math.round(Math.random() * numCasesRange) + minCases
+
+console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
+
+getDataSource().then(async (dataSource) => {
+  const courtCases = new Array(numCases)
+    .fill(0)
+    .map(() => createDummyCase(dataSource, forceId, subDays(new Date(), maxCaseAge)))
+
+  await insertCourtCases(courtCases)
+})
+
+export {}

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,6 +1,7 @@
 import { subDays } from "date-fns"
 import CourtCase from "../src/services/entities/CourtCase"
 import Trigger from "../src/services/entities/Trigger"
+import Note from "../src/services/entities/Trigger"
 import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromTable from "../test/utils/deleteFromTable"
@@ -18,6 +19,7 @@ console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
 getDataSource().then(async (dataSource) => {
   await deleteFromTable(CourtCase)
   await deleteFromTable(Trigger)
+  await deleteFromTable(Note)
 
   await Promise.all(
     new Array(numCases)

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { subDays } from "date-fns"
+import Trigger from "../src/services/entities/Trigger"
 import CourtCase from "../src/services/entities/CourtCase"
 import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromTable from "../test/utils/deleteFromTable"
-import { insertCourtCases } from "../test/utils/insertCourtCases"
 
 const minCases = 100
 const maxCases = 1_000
@@ -18,13 +18,13 @@ console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
 
 getDataSource().then(async (dataSource) => {
   await deleteFromTable(CourtCase)
+  await deleteFromTable(Trigger)
 
-  const courtCases = new Array(numCases)
-    .fill(0)
-    .map(() => createDummyCase(dataSource, forceId, subDays(new Date(), maxCaseAge)))
-    .sort((caseA, caseB) => caseB.courtDate!.getTime() - caseA.courtDate!.getTime())
-
-  await insertCourtCases(courtCases)
+  await Promise.all(
+    new Array(numCases)
+      .fill(0)
+      .map((_, idx) => createDummyCase(dataSource, idx, forceId, subDays(new Date(), maxCaseAge)))
+  )
 })
 
 export {}

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -6,7 +6,7 @@ import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromTable from "../test/utils/deleteFromTable"
 
-const minCases = 100
+const minCases = 500
 const maxCases = 1_000
 const forceId = process.env.FORCE_ID || "01"
 const maxCaseAge = 12 * 30

--- a/test/helpers/createDummyAsn.ts
+++ b/test/helpers/createDummyAsn.ts
@@ -1,8 +1,5 @@
 import { faker } from "@faker-js/faker"
 
 // see page 48 of https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/862971/cjs-data-standards-catalogue-6.pdf
-export default (year: number, orgCode: string): string => {
-  const id = faker.random.numeric(11, { allowLeadingZeros: true })
-  const checkCharacter = faker.random.alpha().toUpperCase()
-  return `${year - 2000}${orgCode.padEnd(7, "0")}${id}${checkCharacter}`
-}
+export default (year: number, orgCode: string): string =>
+  `${year - 2000}${orgCode.padEnd(7, "0")}${faker.random.alpha().toUpperCase()}${faker.random.alpha().toUpperCase()}`

--- a/test/helpers/createDummyAsn.ts
+++ b/test/helpers/createDummyAsn.ts
@@ -1,4 +1,8 @@
-// TODO: generate this according to page 48 of https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/862971/cjs-data-standards-catalogue-6.pdf
-export default (_: number, __: string): string => {
-  return "9352HQ01123456N"
+import { faker } from "@faker-js/faker"
+
+// see page 48 of https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/862971/cjs-data-standards-catalogue-6.pdf
+export default (year: number, orgCode: string): string => {
+  const id = faker.random.numeric(11, { allowLeadingZeros: true })
+  const checkCharacter = faker.random.alpha().toUpperCase()
+  return `${year - 2000}${orgCode.padEnd(7, "0")}${id}${checkCharacter}`
 }

--- a/test/helpers/createDummyAsn.ts
+++ b/test/helpers/createDummyAsn.ts
@@ -1,0 +1,4 @@
+// TODO: generate this according to page 48 of https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/862971/cjs-data-standards-catalogue-6.pdf
+export default (_: number, __: string): string => {
+  return "9352HQ01123456N"
+}

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -1,13 +1,13 @@
+import { faker } from "@faker-js/faker"
 import { differenceInDays, subDays } from "date-fns"
 import sample from "lodash.sample"
+import { DataSource } from "typeorm"
 import { v4 as uuidv4 } from "uuid"
 import CourtCase from "../../src/services/entities/CourtCase"
 import { ResolutionStatus } from "../../src/types/ResolutionStatus"
 import createDummyAsn from "./createDummyAsn"
 import createDummyCourtCode from "./createDummyCourtCode"
 import createDummyPtiurn from "./createDummyPtiurn"
-import { faker } from "@faker-js/faker"
-import { DataSource } from "typeorm"
 
 const randomResolutionStatus = (): ResolutionStatus => {
   const choices: ResolutionStatus[] = ["Unresolved", "Resolved", "Submitted"]
@@ -22,7 +22,7 @@ const randomBoolean = (): boolean => sample([true, false]) ?? true
 export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: Date, dateTo?: Date): CourtCase => {
   const dateRangeDays = dateFrom && dateTo ? differenceInDays(dateFrom, dateTo) : 12 * 30
   const caseDate = subDays(new Date(dateTo || new Date()), Math.round(Math.random() * dateRangeDays))
-  const ptiurn = createDummyPtiurn()
+  const ptiurn = createDummyPtiurn(caseDate.getFullYear(), orgForPoliceFilter + faker.random.alpha(2).toUpperCase())
 
   const courtCase = dataSource.getRepository(CourtCase).create({
     messageId: uuidv4(),
@@ -34,7 +34,7 @@ export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: D
     triggerQualityChecked: 1,
     triggerCount: 0,
     isUrgent: randomBoolean(),
-    asn: createDummyAsn(caseDate.getFullYear(), orgForPoliceFilter),
+    asn: createDummyAsn(caseDate.getFullYear(), orgForPoliceFilter + faker.random.alpha(2).toUpperCase()),
     courtCode: createDummyCourtCode(),
     hearingOutcome: "",
     errorReport: "",

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -7,6 +7,7 @@ import CourtCase from "../../src/services/entities/CourtCase"
 import dummyAHO from "../test-data/AnnotatedHO1.json"
 import createDummyAsn from "./createDummyAsn"
 import createDummyCourtCode from "./createDummyCourtCode"
+import createDummyExceptions from "./createDummyExceptions"
 import createDummyNotes from "./createDummyNotes"
 import createDummyPtiurn from "./createDummyPtiurn"
 import createDummyTriggers from "./createDummyTriggers"
@@ -50,7 +51,7 @@ export default async (
     asn: createDummyAsn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase()),
     courtCode: createDummyCourtCode(orgCode),
     hearingOutcome: dummyAHO.hearingOutcomeXml,
-    errorReport: "",
+    errorReport: createDummyExceptions(),
     createdTimestamp: caseDate,
     errorReason: "",
     triggerReason: "",

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -47,7 +47,7 @@ export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: D
     ptiurn: ptiurn,
     courtName: faker.address.city(),
     messageReceivedTimestamp: caseDate,
-    defendantName: faker.name.fullName(),
+    defendantName: faker.name.firstName() + " " + faker.name.lastName(),
     courtRoom: Math.round(Math.random() * 15)
       .toString()
       .padStart(2, "0"),

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -1,42 +1,47 @@
 import { faker } from "@faker-js/faker"
 import { differenceInDays, subDays } from "date-fns"
 import sample from "lodash.sample"
+// import Trigger from "../../src/services/entities/Trigger"
 import { DataSource } from "typeorm"
 import { v4 as uuidv4 } from "uuid"
 import CourtCase from "../../src/services/entities/CourtCase"
-import { ResolutionStatus } from "../../src/types/ResolutionStatus"
+import dummyAHO from "../test-data/AnnotatedHO1.json"
 import createDummyAsn from "./createDummyAsn"
 import createDummyCourtCode from "./createDummyCourtCode"
 import createDummyPtiurn from "./createDummyPtiurn"
-
-const randomResolutionStatus = (): ResolutionStatus => {
-  const choices: ResolutionStatus[] = ["Unresolved", "Resolved", "Submitted"]
-  return sample(choices) || "Unresolved"
-}
+import createDummyTriggers from "./createDummyTriggers"
+import createResolutionStatus from "./createResolutionStatus"
 
 const randomPhase = (): number => sample([1, 2, 3]) || 1
 
 const randomBoolean = (): boolean => sample([true, false]) ?? true
 
-// Generates a random case with no triggers or exceptions
-export default (dataSource: DataSource, orgCode: string, dateFrom?: Date, dateTo?: Date): CourtCase => {
+export default async (
+  dataSource: DataSource,
+  caseId: number,
+  orgCode: string,
+  dateFrom?: Date,
+  dateTo?: Date
+): Promise<CourtCase> => {
   const dateRangeDays = dateFrom && dateTo ? differenceInDays(dateFrom, dateTo) : 12 * 30
   const caseDate = subDays(new Date(dateTo || new Date()), Math.round(Math.random() * dateRangeDays))
   const ptiurn = createDummyPtiurn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase())
+  const triggers = createDummyTriggers(dataSource, caseId, caseDate)
 
-  const courtCase = dataSource.getRepository(CourtCase).create({
+  const courtCase = await dataSource.getRepository(CourtCase).save({
+    errorId: caseId,
     messageId: uuidv4(),
     orgForPoliceFilter: orgCode,
     phase: randomPhase(),
-    errorStatus: randomResolutionStatus(),
-    triggerStatus: randomResolutionStatus(),
+    errorStatus: createResolutionStatus(),
+    triggerStatus: createResolutionStatus(),
     errorQualityChecked: 1,
     triggerQualityChecked: 1,
     triggerCount: 0,
     isUrgent: randomBoolean(),
     asn: createDummyAsn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase()),
     courtCode: createDummyCourtCode(orgCode),
-    hearingOutcome: "",
+    hearingOutcome: dummyAHO.hearingOutcomeXml,
     errorReport: "",
     createdTimestamp: caseDate,
     errorReason: "",
@@ -56,7 +61,7 @@ export default (dataSource: DataSource, orgCode: string, dateFrom?: Date, dateTo
     triggerInsertedTimestamp: caseDate,
     pncUpdateEnabled: "Y",
     notes: [],
-    triggers: []
+    triggers: triggers
   })
 
   return courtCase

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -19,14 +19,14 @@ const randomPhase = (): number => sample([1, 2, 3]) || 1
 const randomBoolean = (): boolean => sample([true, false]) ?? true
 
 // Generates a random case with no triggers or exceptions
-export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: Date, dateTo?: Date): CourtCase => {
+export default (dataSource: DataSource, orgCode: string, dateFrom?: Date, dateTo?: Date): CourtCase => {
   const dateRangeDays = dateFrom && dateTo ? differenceInDays(dateFrom, dateTo) : 12 * 30
   const caseDate = subDays(new Date(dateTo || new Date()), Math.round(Math.random() * dateRangeDays))
-  const ptiurn = createDummyPtiurn(caseDate.getFullYear(), orgForPoliceFilter + faker.random.alpha(2).toUpperCase())
+  const ptiurn = createDummyPtiurn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase())
 
   const courtCase = dataSource.getRepository(CourtCase).create({
     messageId: uuidv4(),
-    orgForPoliceFilter,
+    orgForPoliceFilter: orgCode,
     phase: randomPhase(),
     errorStatus: randomResolutionStatus(),
     triggerStatus: randomResolutionStatus(),
@@ -34,8 +34,8 @@ export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: D
     triggerQualityChecked: 1,
     triggerCount: 0,
     isUrgent: randomBoolean(),
-    asn: createDummyAsn(caseDate.getFullYear(), orgForPoliceFilter + faker.random.alpha(2).toUpperCase()),
-    courtCode: createDummyCourtCode(),
+    asn: createDummyAsn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase()),
+    courtCode: createDummyCourtCode(orgCode),
     hearingOutcome: "",
     errorReport: "",
     createdTimestamp: caseDate,

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -1,0 +1,63 @@
+import { differenceInDays, subDays } from "date-fns"
+import sample from "lodash.sample"
+import { v4 as uuidv4 } from "uuid"
+import CourtCase from "../../src/services/entities/CourtCase"
+import { ResolutionStatus } from "../../src/types/ResolutionStatus"
+import createDummyAsn from "./createDummyAsn"
+import createDummyCourtCode from "./createDummyCourtCode"
+import createDummyPtiurn from "./createDummyPtiurn"
+import { faker } from "@faker-js/faker"
+import { DataSource } from "typeorm"
+
+const randomResolutionStatus = (): ResolutionStatus => {
+  const choices: ResolutionStatus[] = ["Unresolved", "Resolved", "Submitted"]
+  return sample(choices) || "Unresolved"
+}
+
+const randomPhase = (): number => sample([1, 2, 3]) || 1
+
+const randomBoolean = (): boolean => sample([true, false]) ?? true
+
+// Generates a random case with no triggers or exceptions
+export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: Date, dateTo?: Date): CourtCase => {
+  const dateRangeDays = dateFrom && dateTo ? differenceInDays(dateFrom, dateTo) : 12 * 30
+  const caseDate = subDays(new Date(dateTo || new Date()), Math.round(Math.random() * dateRangeDays))
+  const ptiurn = createDummyPtiurn()
+
+  const courtCase = dataSource.getRepository(CourtCase).create({
+    messageId: uuidv4(),
+    orgForPoliceFilter,
+    phase: randomPhase(),
+    errorStatus: randomResolutionStatus(),
+    triggerStatus: randomResolutionStatus(),
+    errorQualityChecked: 1,
+    triggerQualityChecked: 1,
+    triggerCount: 0,
+    isUrgent: randomBoolean(),
+    asn: createDummyAsn(23, orgForPoliceFilter),
+    courtCode: createDummyCourtCode(),
+    hearingOutcome: "",
+    errorReport: "",
+    createdTimestamp: caseDate,
+    errorReason: "",
+    triggerReason: "",
+    errorCount: 0,
+    userUpdatedFlag: randomBoolean() ? 1 : 0,
+    courtDate: caseDate,
+    ptiurn: ptiurn,
+    courtName: faker.address.city(),
+    messageReceivedTimestamp: caseDate,
+    defendantName: faker.name.fullName(),
+    courtRoom: Math.round(Math.random() * 15)
+      .toString()
+      .padStart(2, "0"),
+    courtReference: ptiurn,
+    errorInsertedTimestamp: caseDate,
+    triggerInsertedTimestamp: caseDate,
+    pncUpdateEnabled: "Y",
+    notes: [],
+    triggers: []
+  })
+
+  return courtCase
+}

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -34,7 +34,7 @@ export default (dataSource: DataSource, orgForPoliceFilter: string, dateFrom?: D
     triggerQualityChecked: 1,
     triggerCount: 0,
     isUrgent: randomBoolean(),
-    asn: createDummyAsn(23, orgForPoliceFilter),
+    asn: createDummyAsn(caseDate.getFullYear(), orgForPoliceFilter),
     courtCode: createDummyCourtCode(),
     hearingOutcome: "",
     errorReport: "",

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker"
 import { differenceInDays, subDays } from "date-fns"
 import sample from "lodash.sample"
-// import Trigger from "../../src/services/entities/Trigger"
 import { DataSource } from "typeorm"
 import { v4 as uuidv4 } from "uuid"
 import CourtCase from "../../src/services/entities/CourtCase"
@@ -19,7 +18,7 @@ const randomBoolean = (): boolean => sample([true, false]) ?? true
 
 const randomUsername = (): string => `${faker.name.firstName().toLowerCase()}.${faker.name.lastName().toLowerCase()}`
 
-const randomName = (): string => `${faker.name.firstName().toLowerCase()} ${faker.name.lastName().toLowerCase()}`
+const randomName = (): string => `${faker.name.firstName()} ${faker.name.lastName()}`
 
 export default async (
   dataSource: DataSource,

--- a/test/helpers/createDummyCourtCode.ts
+++ b/test/helpers/createDummyCourtCode.ts
@@ -1,1 +1,4 @@
-export default (): string => "B42AZ01"
+import { faker } from "@faker-js/faker"
+
+export default (forceCode: string): string =>
+  `B${forceCode}${faker.random.alpha(2).toUpperCase()}${faker.random.numeric(2, { allowLeadingZeros: true })}`

--- a/test/helpers/createDummyCourtCode.ts
+++ b/test/helpers/createDummyCourtCode.ts
@@ -1,0 +1,1 @@
+export default (): string => "B42AZ01"

--- a/test/helpers/createDummyExceptions.ts
+++ b/test/helpers/createDummyExceptions.ts
@@ -1,0 +1,45 @@
+import exponential from "@stdlib/random-base-exponential"
+import sampleMany from "@stdlib/random-sample"
+import { sample as sampleOne } from "lodash"
+
+const possibleExceptions = [
+  "HO100321",
+  "HO100304",
+  "HO100314",
+  "HO100301",
+  "HO100310",
+  "HO100302",
+  "HO100402",
+  "HO100404",
+  "HO100212",
+  "HO100324",
+  "HO100206",
+  "HO100325",
+  "HO100104",
+  "HO100322",
+  "HO100323",
+  "HO100306",
+  "HO100234",
+  "HO100101",
+  "HO100325",
+  "HO100113"
+]
+const fields = [
+  "ArrestSummonsNumber",
+  "OffenceReasonSequence",
+  "ActualOffenceWording",
+  "ResultClass",
+  "Reason",
+  "NextHearingDate",
+  "OrganisationUnitCode"
+]
+
+export default (): string => {
+  if (Math.random() > 0.5) {
+    return ""
+  }
+
+  const numExceptions = Math.min(Math.round(exponential(2) * 2), 5) + 1
+  const exceptions = sampleMany(possibleExceptions, { size: numExceptions })
+  return exceptions.map((exception) => `${exception}||br7:${sampleOne(fields)}`).join(", ")
+}

--- a/test/helpers/createDummyNotes.ts
+++ b/test/helpers/createDummyNotes.ts
@@ -1,0 +1,47 @@
+import { faker } from "@faker-js/faker"
+import { subSeconds } from "date-fns"
+import { countBy, sample } from "lodash"
+import { DataSource } from "typeorm"
+import Note from "../../src/services/entities/Note"
+import Trigger from "../../src/services/entities/Trigger"
+
+export default (dataSource: DataSource, caseId: number, triggers: Trigger[], isResolved: boolean): Note[] => {
+  const triggerCounts = countBy(triggers, (trigger) => trigger.triggerCode)
+  const triggerCountsNote =
+    "Trigger codes: " +
+    Object.entries(triggerCounts)
+      .map(([triggerCode, count]) => `${count} x ${triggerCode}`)
+      .join(", ")
+
+  const resolvedTriggerNotes = triggers
+    .filter((trigger) => trigger.resolvedAt !== null)
+    .map(
+      (trigger) =>
+        `${faker.name.firstName()}.${faker.name.lastName()}: Portal Action: Trigger Resolved. Code: ${
+          trigger.triggerCode
+        }`
+    )
+
+  const noteTexts = [triggerCountsNote, ...resolvedTriggerNotes]
+
+  if (isResolved) {
+    const reason = sample([
+      "Updated remand(s) manually on the PNC",
+      "Updated disposal(s) manually on the PNC",
+      "PNC record already has accurate results"
+    ])
+    const reasonText = Math.random() > 0.5 ? faker.lorem.sentence() : ""
+    noteTexts.push(
+      `${faker.name.firstName()}.${faker.name.lastName()}: Portal Action: Record Manually Resolved. Reason: ${reason}. Reason Text:${reasonText}`
+    )
+  }
+
+  return noteTexts.map((noteText) =>
+    dataSource.getRepository(Note).create({
+      noteText,
+      errorId: caseId,
+      userId: `${faker.name.firstName().toLowerCase()}.${faker.name.lastName().toLowerCase()}`.slice(0, 31),
+      createdAt: subSeconds(new Date(), Math.random() * 60 * 60 * 24 * 30)
+    })
+  )
+}

--- a/test/helpers/createDummyPtiurn.ts
+++ b/test/helpers/createDummyPtiurn.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker"
 
-export default (year: number, orgCode: string): string => {
-  return `${orgCode.padEnd(4, "0")}${faker.random.numeric(5, { allowLeadingZeros: true })}${year - 2000}`
-}
+// See page 104 of https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/862971/cjs-data-standards-catalogue-6.pdf
+export default (year: number, orgCode: string): string =>
+  `${orgCode.padEnd(4, "0")}${faker.random.numeric(5, { allowLeadingZeros: true })}${year - 2000}`

--- a/test/helpers/createDummyPtiurn.ts
+++ b/test/helpers/createDummyPtiurn.ts
@@ -1,0 +1,1 @@
+export default (): string => "42CY0300108"

--- a/test/helpers/createDummyPtiurn.ts
+++ b/test/helpers/createDummyPtiurn.ts
@@ -1,1 +1,5 @@
-export default (): string => "42CY0300108"
+import { faker } from "@faker-js/faker"
+
+export default (year: number, orgCode: string): string => {
+  return `${orgCode.padEnd(4, "0")}${faker.random.numeric(5, { allowLeadingZeros: true })}${year - 2000}`
+}

--- a/test/helpers/createDummyTriggers.ts
+++ b/test/helpers/createDummyTriggers.ts
@@ -48,7 +48,7 @@ export default (dataSource: DataSource, errorId: number, creationDate: Date): Tr
   const triggerCodes = sample(Object.keys(triggerDistribution), {
     size: numTriggers,
     probs,
-    replace: false
+    replace: true
   })
 
   return triggerCodes.map((triggerCode, idx) => {

--- a/test/helpers/createDummyTriggers.ts
+++ b/test/helpers/createDummyTriggers.ts
@@ -5,7 +5,7 @@ import { DataSource } from "typeorm"
 import Trigger from "../../src/services/entities/Trigger"
 import createResolutionStatus from "./createResolutionStatus"
 
-const triggerDistribution = {
+const triggerFrequency = {
   TRPR0015: 112166,
   TRPR0010: 86986,
   TRPR0020: 74545,
@@ -40,12 +40,12 @@ const triggerDistribution = {
   TRPS0002: 41,
   TRPS0013: 19
 }
-const totalFrequency = Object.values(triggerDistribution).reduce((a, b) => a + b, 0)
-const probs = Object.values(triggerDistribution).map((freq) => freq / totalFrequency)
+const totalFrequency = Object.values(triggerFrequency).reduce((a, b) => a + b, 0)
+const probs = Object.values(triggerFrequency).map((freq) => freq / totalFrequency)
 
 export default (dataSource: DataSource, errorId: number, creationDate: Date): Trigger[] => {
   const numTriggers = Math.min(Math.round(exponential(2) * 2), 5) + 1
-  const triggerCodes = sample(Object.keys(triggerDistribution), {
+  const triggerCodes = sample(Object.keys(triggerFrequency), {
     size: numTriggers,
     probs,
     replace: true

--- a/test/helpers/createDummyTriggers.ts
+++ b/test/helpers/createDummyTriggers.ts
@@ -1,0 +1,66 @@
+import { faker } from "@faker-js/faker"
+import exponential from "@stdlib/random-base-exponential"
+import sample from "@stdlib/random-sample"
+import { DataSource } from "typeorm"
+import Trigger from "../../src/services/entities/Trigger"
+import createResolutionStatus from "./createResolutionStatus"
+
+const triggerDistribution = {
+  TRPR0015: 112166,
+  TRPR0010: 86986,
+  TRPR0020: 74545,
+  TRPR0001: 61787,
+  TRPR0002: 42440,
+  TRPR0012: 28800,
+  TRPR0029: 27602,
+  TRPR0005: 22550,
+  TRPS0010: 18047,
+  TRPR0003: 17036,
+  TRPS0011: 16957,
+  TRPR0006: 16712,
+  TRPR0025: 15509,
+  TRPR0004: 13234,
+  TRPR0016: 12386,
+  TRPR0023: 12229,
+  TRPR0030: 9239,
+  TRPR0027: 9090,
+  TRPR0008: 4214,
+  TRPS0008: 2675,
+  TRPR0018: 2666,
+  TRPR0022: 1470,
+  TRPR0024: 588,
+  TRPR0028: 573,
+  TRPS0004: 557,
+  TRPR0026: 528,
+  TRPR0021: 363,
+  TRPR0019: 359,
+  TRPS0003: 347,
+  TRPR0007: 331,
+  TRPR0017: 117,
+  TRPS0002: 41,
+  TRPS0013: 19
+}
+const totalFrequency = Object.values(triggerDistribution).reduce((a, b) => a + b, 0)
+const probs = Object.values(triggerDistribution).map((freq) => freq / totalFrequency)
+
+export default (dataSource: DataSource, errorId: number, creationDate: Date): Trigger[] => {
+  const numTriggers = Math.min(Math.round(exponential(2) * 2), 5) + 1
+  const triggerCodes = sample(Object.keys(triggerDistribution), {
+    size: numTriggers,
+    probs,
+    replace: false
+  })
+
+  return triggerCodes.map((triggerCode, idx) => {
+    const status = createResolutionStatus()
+    return dataSource.getRepository(Trigger).create({
+      errorId,
+      triggerCode: triggerCode,
+      status: status,
+      createdAt: creationDate,
+      resolvedBy:
+        status === "Resolved" ? `${faker.name.firstName().toLowerCase()}.${faker.name.lastName().toLowerCase()}` : null,
+      triggerItemIdentity: idx
+    })
+  })
+}

--- a/test/helpers/createResolutionStatus.ts
+++ b/test/helpers/createResolutionStatus.ts
@@ -1,0 +1,7 @@
+import sample from "lodash.sample"
+import type { ResolutionStatus } from "../../src/types/ResolutionStatus"
+
+export default (): ResolutionStatus => {
+  const choices: ResolutionStatus[] = ["Unresolved", "Resolved", "Submitted"]
+  return sample(choices) || "Unresolved"
+}


### PR DESCRIPTION
This PR adds a script, `scripts/seed-data.ts`, which generates cases, notes, triggers and exceptions randomly, for a given force.

This gives more production-like data which should help avoid users getting distracted by the differences in data when testing.

Names and city names are generated using `faker`, and `std-lib` is used for sampling in a few places.

Screenshot of data generated by this script in the new UI:
![Screenshot 2023-02-09 at 18 37 00](https://user-images.githubusercontent.com/7249529/217906401-53bbc855-5df2-42f9-b55f-e2c1c98f3923.png)
