### PR TITLE
Add codebuild config to seed generated data in e2e as part of pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ run:
 goss:
 	GOSS_SLEEP=15 dgoss run -e DB_HOST=$(DB_HOST) "ui:latest"
 
+setup-e2e-env:
+	./scripts/setup-e2e-env.sh
+
 .PHONY: destroy
 destroy:
 	$(DOCKER_COMPOSE) down

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ goss:
 setup-e2e-env:
 	./scripts/setup-e2e-env.sh
 
+generate-codebuild-vpn:
+	./scripts/generate-codebuild-vpn
+
 .PHONY: destroy
 destroy:
 	$(DOCKER_COMPOSE) down

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ setup-e2e-env:
 	./scripts/setup-e2e-env.sh
 
 generate-codebuild-vpn:
-	./scripts/generate-codebuild-vpn
+	./scripts/generate-codebuild-vpn.sh
 
 .PHONY: destroy
 destroy:

--- a/scripts/generate-codebuild-vpn.sh
+++ b/scripts/generate-codebuild-vpn.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -ev
+
+TEMP_ROLE=$(aws sts assume-role --role-session-name "next" --role-arn "${ASSUME_ROLE_ARN}")
+export AWS_ACCESS_KEY_ID=$(echo $TEMP_ROLE | jq -r .Credentials.AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo $TEMP_ROLE | jq -r .Credentials.SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo $TEMP_ROLE | jq -r .Credentials.SessionToken)
+
+aws ssm get-parameter \
+  --name /cjse-bichard7-${WORKSPACE}-base-infra/vpn/user_private_key \
+  --with-decryption --query "Parameter.Value" --output text > ~/client1.domain.tld.key
+aws ssm get-parameter \
+  --name /cjse-bichard7-${WORKSPACE}-base-infra/vpn/user_certificate_body \
+  --with-decryption --query "Parameter.Value" --output text > ~/client1.domain.tld.crt
+aws ssm get-parameter \
+  --name /cjse-bichard7-${WORKSPACE}-base-infra/vpn/certificate_chain \
+  --with-decryption --query "Parameter.Value" --output text > ~/ca.crt
+aws ssm get-parameter \
+  --name /cjse-bichard7-${WORKSPACE}-base-infra/vpn/config \
+  --with-decryption --query "Parameter.Value" --output text > ~/cjse-${WORKSPACE}-config.ovpn
+
+sed -i '/client1.domain.tld.crt/Q' ~/cjse-${WORKSPACE}-config.ovpn
+CERT=$(sed  -n '/-----BEGIN CERTIFICATE-----/,$P' ~/client1.domain.tld.crt)
+echo -e "<cert>\n${CERT}\n</cert>" >> ~/cjse-${WORKSPACE}-config.ovpn
+KEY=$(cat ~/client1.domain.tld.key)
+echo -e "<key>\n${KEY}\n</key>" >> ~/cjse-${WORKSPACE}-config.ovpn

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -6,6 +6,11 @@ import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromTable from "../test/utils/deleteFromTable"
 
+if (process.env.DEPLOY_NAME !== "e2e-test") {
+  console.error("Not running in e2e environment, bailing out. Set DEPLOY_NAME='e2e-test' if you're sure.")
+  process.exit(1)
+}
+
 const minCases = 500
 const maxCases = 1_000
 const forceId = process.env.FORCE_ID || "01"

--- a/scripts/setup-e2e-env.sh
+++ b/scripts/setup-e2e-env.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+env_check() {
+  if [ -z "$WORKSPACE" ]
+  then
+    echo "WORKSPACE env var has not been set"
+    exit 1
+  fi
+}
+
+env_check
+
+aws_credential_check () {
+  if [ -z "$AWS_ACCESS_KEY_ID" ]
+  then
+     echo "AWS_ACCESS_KEY_ID env var has not been set"
+     exit 1
+  fi
+
+  if [ -z "$AWS_SECRET_ACCESS_KEY" ]
+  then
+    echo "AWS_SECRET_ACCESS_KEY env var has not been set"
+    exit 1
+  fi
+}
+
+function fetchParam() {
+  ENVNAME=$1
+  SSM_PATH=$2
+
+  VALUE="$($AWS_CLI_PATH ssm get-parameter --name $SSM_PATH --with-decryption --query "Parameter.Value" --output "text")"
+  echo "export $ENVNAME=\"$VALUE\"" >> $TEST_ENV_FILE
+}
+
+mkdir -p e2e-tests/workspaces
+TEST_ENV_FILE="workspaces/${WORKSPACE}.env"
+rm -f $TEST_ENV_FILE
+
+if [ "$WORKSPACE" = 'local' ]
+then
+  exit 0
+fi
+
+AWS_CLI_PATH="$(which aws)"
+aws_credential_check
+HOSTED_ZONE=$($AWS_CLI_PATH route53 list-hosted-zones-by-name --query "HostedZones[?contains(Name, 'justice.gov.uk') && contains(Name, '${WORKSPACE}')].Name" --output text | sed 's/\.$//')
+DB_HOST=$($AWS_CLI_PATH rds describe-db-clusters --region eu-west-2 --filters Name=db-cluster-id,Values=cjse-${WORKSPACE}-bichard-7-aurora-cluster --query "DBClusters[0].Endpoint" --output text)
+
+if [ "$DB_HOST" = 'null' ]
+then
+  echo "Error fetching DB host"
+  exit 1
+fi
+
+mkdir -p workspaces
+rm -f $TEST_ENV_FILE
+
+echo "export DB_HOST=\"${DB_HOST}\"" >> $TEST_ENV_FILE
+fetchParam "DB_PASSWORD" "/cjse-${WORKSPACE}-bichard-7/rds/db/password"
+echo "export DB_SSL=\"true\"" >> $TEST_ENV_FILE
+echo "export DB_SSL_MODE=\"require\"" >> $TEST_ENV_FILE
+
+echo 'Done'

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -8,6 +8,8 @@ phases:
     commands:
       - scripts/generate-codebuild-vpn.sh
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+      - export NVM_DIR="$HOME/.nvm"
+      - \[ -s "$NVM_DIR/nvm.sh" \] && "$NVM_DIR/nvm.sh"
       - nvm use
       - npm ci
   build:

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -6,6 +6,7 @@ phases:
     runtime-versions:
       nodejs: 16
     commands:
+      - scripts/generate-codebuild-vpn.sh
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
       - nvm use
       - npm ci

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -7,10 +7,6 @@ phases:
       nodejs: 16
     commands:
       - scripts/generate-codebuild-vpn.sh
-      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-      - export NVM_DIR="$HOME/.nvm"
-      - \[ -s "$NVM_DIR/nvm.sh" \] && "$NVM_DIR/nvm.sh"
-      - nvm use
       - npm ci
   build:
     commands:

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -7,6 +7,7 @@ phases:
       nodejs: 16
     commands:
       - scripts/generate-codebuild-vpn.sh
+      - yum -y install openvpn
       - npm ci
   build:
     commands:

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -1,0 +1,23 @@
+---
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 16
+    commands:
+      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+      - nvm use
+      - npm ci
+  build:
+    commands:
+      - export OLD_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - export OLD_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - temp_role=$(aws sts assume-role --role-session-name "next" --role-arn "${ASSUME_ROLE_ARN}")
+      - export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
+      - export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
+      - export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)
+      - openvpn --config ~/cjse-${WORKSPACE}-config.ovpn --daemon
+      - make setup-e2e-tests
+      - source ./workspaces/${WORKSPACE}.env
+      - npm run seed-data

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -6,8 +6,8 @@ phases:
     runtime-versions:
       nodejs: 16
     commands:
-      - scripts/generate-codebuild-vpn.sh
       - yum -y install openvpn
+      - make generate-codebuild-vpn
       - npm ci
   build:
     commands:

--- a/seed-data-buildspec.yml
+++ b/seed-data-buildspec.yml
@@ -18,6 +18,6 @@ phases:
       - export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
       - export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)
       - openvpn --config ~/cjse-${WORKSPACE}-config.ovpn --daemon
-      - make setup-e2e-tests
+      - make setup-e2e-env
       - source ./workspaces/${WORKSPACE}.env
       - npm run seed-data


### PR DESCRIPTION
This PR:
* Adds a safeguard to the `seed-data` script, which checks if the `DEPLOY_NAME` environment variable is set to `e2e-test`
* Adds a script to generate the VPN config needed to connect to the database, taken from [the e2e-tests repo](https://github.com/ministryofjustice/bichard7-next-tests/blob/main/scripts/configure_codebuild_image.sh)
* Adds a script to generate DB credential environment variables, taken from [the e2e-tests repo](https://github.com/ministryofjustice/bichard7-next-tests/blob/main/scripts/setup-e2e-tests.sh) and pared down
* Adds a buildspec to run the `seed-data` script