### PR TITLE
Update seed-data to fix triggers and exceptions filtering

### DIFF
--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -34,7 +34,7 @@ export default async (
   const isResolved = randomBoolean()
   const triggers = createDummyTriggers(dataSource, caseId, caseDate)
   const notes = createDummyNotes(dataSource, caseId, triggers, isResolved)
-
+  const { errorReport, errorReason, exceptionCount } = createDummyExceptions()
   const courtCase = await dataSource.getRepository(CourtCase).save({
     errorId: caseId,
     messageId: uuidv4(),
@@ -46,16 +46,16 @@ export default async (
     triggerStatus: createResolutionStatus(),
     errorQualityChecked: 1,
     triggerQualityChecked: 1,
-    triggerCount: 0,
+    triggerCount: triggers.length,
     isUrgent: randomBoolean(),
     asn: createDummyAsn(caseDate.getFullYear(), orgCode + faker.random.alpha(2).toUpperCase()),
     courtCode: createDummyCourtCode(orgCode),
     hearingOutcome: dummyAHO.hearingOutcomeXml,
-    errorReport: createDummyExceptions(),
+    errorReport: errorReport,
     createdTimestamp: caseDate,
-    errorReason: "",
+    errorReason: errorReason,
     triggerReason: "",
-    errorCount: 0,
+    errorCount: exceptionCount,
     userUpdatedFlag: randomBoolean() ? 1 : 0,
     courtDate: caseDate,
     ptiurn: ptiurn,

--- a/test/helpers/createDummyExceptions.ts
+++ b/test/helpers/createDummyExceptions.ts
@@ -34,12 +34,16 @@ const fields = [
   "OrganisationUnitCode"
 ]
 
-export default (): string => {
+export default (): { errorReason: string; errorReport: string; exceptionCount: number } => {
   if (Math.random() > 0.5) {
-    return ""
+    return { errorReason: "", errorReport: "", exceptionCount: 0 }
   }
 
   const numExceptions = Math.min(Math.round(exponential(2) * 2), 5) + 1
   const exceptions = sampleMany(possibleExceptions, { size: numExceptions })
-  return exceptions.map((exception) => `${exception}||br7:${sampleOne(fields)}`).join(", ")
+  return {
+    errorReport: exceptions.map((exception) => `${exception}||br7:${sampleOne(fields)}`).join(", "),
+    errorReason: exceptions[0],
+    exceptionCount: exceptions.length
+  }
 }


### PR DESCRIPTION
Helper functions was not seeding all the data associated with triggers and exceptions.