### PR TITLE
BICAWS-2642: Update applied filter section to match design

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -747,6 +747,30 @@ describe("Case list", () => {
         confirmMultipleFieldsNotDisplayed(["Case00001", "Case00002", "Case00003"])
       })
     })
+
+    describe("Applied filter section", () => {
+      it("Should show the applied filter section when the filter panel is hidden", () => {
+        visitBasePathAndShowFilters()
+        inputAndSearch("keywords", "Bruce Wayne")
+
+        cy.contains("Show filter")
+        cy.contains("Hide filter").should("not.exist")
+        cy.contains("Filters applied")
+        cy.contains("Clear filters")
+      })
+      it("Should hide the applied filter section when the filter panel is shown", () => {
+        visitBasePathAndShowFilters()
+        inputAndSearch("keywords", "Bruce Wayne")
+
+        cy.contains("Show filter")
+        cy.contains("Show filter").click()
+        cy.contains("Show filter").should("not.exist")
+        cy.contains("Hide filter")
+        cy.contains("Filters applied").should("not.exist")
+        cy.contains("Clear filters").should("not.exist")
+        cy.contains("Applied filters")
+      })
+    })
   })
 })
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -2,6 +2,7 @@ import { addDays, format, subDays, subMonths, subWeeks } from "date-fns"
 import { TestTrigger } from "../../../test/utils/manageTriggers"
 import hashedPassword from "../../fixtures/hashedPassword"
 import a11yConfig from "../../support/a11yConfig"
+import { confirmFiltersAppliedContains } from "../../support/helpers"
 import logAccessibilityViolations from "../../support/logAccessibilityViolations"
 
 function visitBasePathAndShowFilters() {
@@ -38,10 +39,6 @@ function confirmMultipleFieldsNotDisplayed(fields: string[]) {
   fields.forEach((field) => {
     cy.contains(field).should("not.exist")
   })
-}
-
-function confirmFiltersAppliedContains(filterTag: string) {
-  cy.get(".moj-filter-tags a.moj-filter__tag").contains(filterTag)
 }
 
 describe("Case list", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -40,6 +40,10 @@ function confirmMultipleFieldsNotDisplayed(fields: string[]) {
   })
 }
 
+function confirmFiltersAppliedContains(filterTag: string) {
+  cy.get(".moj-filter-tags a.moj-filter__tag").contains(filterTag)
+}
+
 describe("Case list", () => {
   context("When filters applied", () => {
     before(() => {
@@ -157,7 +161,7 @@ describe("Case list", () => {
       cy.contains("Bruce Wayne")
       confirmMultipleFieldsNotDisplayed(["Barbara Gordon", "Alfred Pennyworth"])
       cy.get("tr").should("have.length", 2)
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Bruce Wayne")
+      confirmFiltersAppliedContains("Bruce Wayne")
 
       removeFilterTag("Bruce Wayne")
       confirmMultipleFieldsDisplayed(["Bruce Wayne", "Barbara Gordon", "Alfred Pennyworth"])
@@ -176,7 +180,7 @@ describe("Case list", () => {
       cy.contains("Manchester Court")
       confirmMultipleFieldsNotDisplayed(["London Court", "Bristol Court"])
       cy.get("tr").should("have.length", 2)
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Manchester Court")
+      confirmFiltersAppliedContains("Manchester Court")
 
       // Removing filter tag
       removeFilterTag("Manchester Court")
@@ -196,7 +200,7 @@ describe("Case list", () => {
       cy.contains("Case00001")
       confirmMultipleFieldsNotDisplayed(["Case00002", "Case00003"])
       cy.get("tr").should("have.length", 2)
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Case00001")
+      confirmFiltersAppliedContains("Case00001")
 
       // Removing filter tag
       removeFilterTag("Case00001")
@@ -227,7 +231,7 @@ describe("Case list", () => {
       cy.contains("Case00000")
       confirmMultipleFieldsNotDisplayed(["Case00001", "Case00002"])
       cy.get("tr").should("have.length", 3)
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("TRPR0107")
+      confirmFiltersAppliedContains("TRPR0107")
       removeFilterTag("TRPR0107")
 
       cy.get("button[id=filter-button]").click()
@@ -236,7 +240,7 @@ describe("Case list", () => {
       cy.contains("Case00001")
       confirmMultipleFieldsNotDisplayed(["Case00000", "Case00002"])
       cy.get("tr").should("have.length", 2)
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("HO200212")
+      confirmFiltersAppliedContains("HO200212")
 
       // Removing filter tag
       removeFilterTag("HO200212")
@@ -482,8 +486,8 @@ describe("Case list", () => {
 
       cy.contains("Hide filter").click()
 
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("exist")
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("01/01/2022 - 31/12/2022").click({ force: true })
+      confirmFiltersAppliedContains("01/01/2022 - 31/12/2022")
+      removeFilterTag("01/01/2022 - 31/12/2022")
       cy.get("tr").not(":first").should("have.length", 13)
     })
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -179,7 +179,6 @@ describe("Case list", () => {
       cy.get("tr").should("have.length", 2)
       confirmFiltersAppliedContains("Manchester Court")
 
-      // Removing filter tag
       removeFilterTag("Manchester Court")
       confirmMultipleFieldsDisplayed(["Manchester Court", "London Court", "Bristol Court"])
     })
@@ -199,7 +198,6 @@ describe("Case list", () => {
       cy.get("tr").should("have.length", 2)
       confirmFiltersAppliedContains("Case00001")
 
-      // Removing filter tag
       removeFilterTag("Case00001")
       confirmMultipleFieldsDisplayed(["Case00001", "Case00002", "Case00003"])
     })
@@ -239,7 +237,6 @@ describe("Case list", () => {
       cy.get("tr").should("have.length", 2)
       confirmFiltersAppliedContains("HO200212")
 
-      // Removing filter tag
       removeFilterTag("HO200212")
       confirmMultipleFieldsDisplayed(["Case00000", "Case00001", "Case00002"])
     })

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -480,6 +480,8 @@ describe("Case list", () => {
 
       cy.get("tr").not(":first").should("have.length", 7)
 
+      cy.contains("Hide filter").click()
+
       cy.get(".moj-filter-tags a.moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("exist")
       cy.get(".moj-filter-tags a.moj-filter__tag").contains("01/01/2022 - 31/12/2022").click({ force: true })
       cy.get("tr").not(":first").should("have.length", 13)

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -367,6 +367,7 @@ describe("Case list", () => {
       cy.get("#my-cases-filter").should("be.checked")
 
       // Clears filter chip and check the checkbox is deselected
+      cy.contains("Hide filter").click()
       cy.contains("Clear filters").click()
       cy.get("#filter-button").contains("Show filter").click()
       cy.get("#my-cases-filter").should("not.be.checked")

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -1,4 +1,5 @@
 import hashedPassword from "../../fixtures/hashedPassword"
+import { confirmFiltersAppliedContains } from "../../support/helpers"
 
 export function removeFilterChip() {
   cy.get("li button.moj-filter__tag").trigger("click")
@@ -121,7 +122,7 @@ describe("Case list", () => {
         cy.get("button#search").click()
 
         cy.get(".govuk-heading-m").contains("Applied filters").should("exist")
-        cy.get(".moj-filter-tags a.moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("exist")
+        confirmFiltersAppliedContains("01/01/2022 - 31/12/2022")
       })
 
       it.skip("Should apply the 'Custom date filter' filter chips then remove this chips to the original state", () => {

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -2,6 +2,7 @@ import User from "services/entities/User"
 import { TestTrigger } from "../../test/utils/manageTriggers"
 import hashedPassword from "../fixtures/hashedPassword"
 import a11yConfig from "../support/a11yConfig"
+import { confirmFiltersAppliedContains } from "../support/helpers"
 import logAccessibilityViolations from "../support/logAccessibilityViolations"
 
 const loginAndGoToUrl = (emailAddress = "bichard01@example.com", url = "/bichard") => {
@@ -876,10 +877,10 @@ describe("Case list", () => {
       cy.get("#urgent").click()
       cy.get("#search").click()
 
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Urgent").should("exist")
+      confirmFiltersAppliedContains("Urgent")
 
       cy.get("li.moj-pagination__item").contains("Next").click()
-      cy.get(".moj-filter-tags a.moj-filter__tag").contains("Urgent").should("exist")
+      confirmFiltersAppliedContains("Urgent")
     })
   })
 })

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -1,0 +1,3 @@
+export function confirmFiltersAppliedContains(filterTag: string) {
+  cy.get(".moj-filter-tags a.moj-filter__tag").contains(filterTag)
+}

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -13,10 +13,10 @@ interface Props {
 const useStyles = createUseStyles({
   appliedFilter: {
     backgroundColor: darkGray,
-    color: "#ffffff",
+    color: "white",
     "&:hover": {
       backgroundColor: darkGray,
-      color: "#ffffff"
+      color: "white"
     },
     "&:after": {
       backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction, state }: Props) => {
   const classes = useCustomStyles()
-  const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes["dark-gray-filter-tag"] : "")
+  const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes["dark-grey-filter-tag"] : "")
   return (
     <li>
       <button className={buttonClass} onClick={() => dispatch(removeAction())} style={{ cursor: "pointer" }}>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -14,7 +14,7 @@ const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction, state 
   const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes["dark-gray-filter-tag"] : "")
   return (
     <li>
-      <button className={buttonClass} onClick={() => dispatch(removeAction())}>
+      <button className={buttonClass} onClick={() => dispatch(removeAction())} style={{ cursor: "pointer" }}>
         <span className="govuk-visually-hidden">{"Remove this filter"}</span>
         {chipLabel}
       </button>

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch } from "react"
 import { createUseStyles } from "react-jss"
 import type { FilterAction, FilterState } from "types/CourtCaseFilter"
+import { darkGray } from "utils/colours"
 
 interface Props {
   chipLabel: string
@@ -11,10 +12,10 @@ interface Props {
 
 const useStyles = createUseStyles({
   appliedFilter: {
-    backgroundColor: "#62696D",
+    backgroundColor: darkGray,
     color: "#ffffff",
     "&:hover": {
-      backgroundColor: "#62696D",
+      backgroundColor: darkGray,
       color: "#ffffff"
     },
     "&:after": {

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,7 +1,6 @@
 import type { Dispatch } from "react"
-import { createUseStyles } from "react-jss"
 import type { FilterAction, FilterState } from "types/CourtCaseFilter"
-import { darkGray } from "utils/colours"
+import { useCustomStyles } from "../../styles/customStyles"
 
 interface Props {
   chipLabel: string
@@ -10,23 +9,9 @@ interface Props {
   state: FilterState
 }
 
-const useStyles = createUseStyles({
-  appliedFilter: {
-    backgroundColor: darkGray,
-    color: "white",
-    "&:hover": {
-      backgroundColor: darkGray,
-      color: "white"
-    },
-    "&:after": {
-      backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"
-    }
-  }
-})
-
 const FilterChip: React.FC<Props> = ({ chipLabel, dispatch, removeAction, state }: Props) => {
-  const classes = useStyles()
-  const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes.appliedFilter : "")
+  const classes = useCustomStyles()
+  const buttonClass = "moj-filter__tag " + (state === "Applied" ? classes["dark-gray-filter-tag"] : "")
   return (
     <li>
       <button className={buttonClass} onClick={() => dispatch(removeAction())}>

--- a/src/components/FilterTag/FilterTag.tsx
+++ b/src/components/FilterTag/FilterTag.tsx
@@ -8,7 +8,7 @@ interface Props {
 const FilterTag: React.FC<Props> = ({ tag, href }: Props) => {
   const classes = useCustomStyles()
   return (
-    <a className={`moj-filter__tag ${classes["dark-gray-filter-tag"]}`} href={href}>
+    <a className={`moj-filter__tag ${classes["dark-grey-filter-tag"]}`} href={href}>
       <span className="govuk-visually-hidden">{`Remove ${tag} filter`}</span>
       {tag}
     </a>

--- a/src/components/FilterTag/FilterTag.tsx
+++ b/src/components/FilterTag/FilterTag.tsx
@@ -1,11 +1,14 @@
+import { useCustomStyles } from "../../../styles/customStyles"
+
 interface Props {
   tag: string
   href: string
 }
 
 const FilterTag: React.FC<Props> = ({ tag, href }: Props) => {
+  const classes = useCustomStyles()
   return (
-    <a className="moj-filter__tag" href={href}>
+    <a className={`moj-filter__tag ${classes["dark-gray-filter-tag"]}`} href={href}>
       <span className="govuk-visually-hidden">{`Remove ${tag} filter`}</span>
       {tag}
     </a>

--- a/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
@@ -41,7 +41,7 @@ const CourtCaseFilterWrapper: React.FC<Props> = ({
               >
                 {isVisible ? "Hide filter" : "Show filter"}
               </button>
-              <div className="moj-button-menu__wrapper">{appliedFilters}</div>
+              {!isVisible && <div className="moj-button-menu__wrapper">{appliedFilters}</div>}
             </div>
           </div>
 

--- a/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilterWrapper.tsx
@@ -16,13 +16,13 @@ const CourtCaseFilterWrapper: React.FC<Props> = ({
   paginationTop,
   paginationBottom
 }: Props) => {
-  const [isVisible, setVisible] = useState(false)
+  const [areAppliedFiltersShown, setAreAppliedFiltersShown] = useState(false)
   const classes = useCustomStyles()
   return (
     <>
       <div className={`${classes["top-padding"]} moj-filter-layout`}>
         <div className="moj-filter-layout__filter">
-          <div className={isVisible ? "moj-filter" : "moj-filter moj-hidden"}>{filter}</div>
+          <div className={areAppliedFiltersShown ? "moj-filter" : "moj-filter moj-hidden"}>{filter}</div>
         </div>
 
         <div className="moj-filter-layout__content">
@@ -36,12 +36,12 @@ const CourtCaseFilterWrapper: React.FC<Props> = ({
                 aria-haspopup="true"
                 aria-expanded="false"
                 onClick={() => {
-                  setVisible(!isVisible)
+                  setAreAppliedFiltersShown(!areAppliedFiltersShown)
                 }}
               >
-                {isVisible ? "Hide filter" : "Show filter"}
+                {areAppliedFiltersShown ? "Hide filter" : "Show filter"}
               </button>
-              {!isVisible && <div className="moj-button-menu__wrapper">{appliedFilters}</div>}
+              {!areAppliedFiltersShown && <div className="moj-button-menu__wrapper">{appliedFilters}</div>}
             </div>
           </div>
 

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -1,5 +1,5 @@
-const darkGray = "#62696D"
+const darkGrey = "#62696D"
 const tagBlue = "#e9f1f8"
 const textBlue = "#114e81"
 
-export { darkGray, tagBlue, textBlue }
+export { darkGrey, tagBlue, textBlue }

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -1,4 +1,5 @@
+const darkGray = "#62696D"
 const tagBlue = "#e9f1f8"
 const textBlue = "#114e81"
 
-export { tagBlue, textBlue }
+export { darkGray, tagBlue, textBlue }

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -18,9 +18,9 @@ export const useCustomStyles = createUseStyles({
   },
   "dark-gray-filter-tag": {
     background: darkGray,
-    color: "#ffffff",
+    color: "white",
     "&:visited": {
-      color: "#ffffff"
+      color: "white"
     },
     "&:after": {
       backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -1,5 +1,5 @@
 import { createUseStyles } from "react-jss"
-import { darkGray } from "utils/colours"
+import { darkGrey } from "utils/colours"
 
 export const useCustomStyles = createUseStyles({
   "max-width": {
@@ -16,8 +16,8 @@ export const useCustomStyles = createUseStyles({
   "margin-top-bottom": {
     margin: "12px 0"
   },
-  "dark-gray-filter-tag": {
-    background: darkGray,
+  "dark-grey-filter-tag": {
+    background: darkGrey,
     color: "white",
     "&:visited": {
       color: "white"

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -24,6 +24,9 @@ export const useCustomStyles = createUseStyles({
     },
     "&:after": {
       backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"
+    },
+    "&:link": {
+      color: "white"
     }
   }
 })

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -1,4 +1,5 @@
 import { createUseStyles } from "react-jss"
+import { darkGray } from "utils/colours"
 
 export const useCustomStyles = createUseStyles({
   "max-width": {
@@ -14,5 +15,15 @@ export const useCustomStyles = createUseStyles({
   },
   "margin-top-bottom": {
     margin: "12px 0"
+  },
+  "dark-gray-filter-tag": {
+    background: darkGray,
+    color: "#ffffff",
+    "&:visited": {
+      color: "#ffffff"
+    },
+    "&:after": {
+      backgroundImage: "url(/bichard/moj_assets/images/icon-tag-remove-cross-white.svg)"
+    }
   }
 })


### PR DESCRIPTION
Ticket: [BICAWS-2642](https://dsdmoj.atlassian.net/jira/software/projects/BICAWS/boards/522?selectedIssue=BICAWS-2642)

Changes:
- hide applied filter section when filter panel is open,
- change the background colour of the filter chip to a dark grey (#62696D),
- add a test to check if the applied filter section is hidden when filter panel is open,
- add a test to check if the applied filter section is shown when filter panel is closed,
- create `confirmFiltersAppliedContains` helper function that checks filters applied,
- create `dark-gray-filter-tag` custom style to create the grey looks of the buttons,
- rename `isVisible` state in `CourtCaseFilterWrapper.tsx` to `areAppliedFiltersShown` in order to increase readability,
- introduce `darkGray` colour variable.

[BICAWS-2642]: https://dsdmoj.atlassian.net/browse/BICAWS-2642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ