### PR TITLE
BICAWS-2616: Filter panel bug with Court date radio buttons

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -1,5 +1,4 @@
 import { addDays, format, subDays, subMonths, subWeeks } from "date-fns"
-import { it } from "node:test"
 import { TestTrigger } from "../../../test/utils/manageTriggers"
 import hashedPassword from "../../fixtures/hashedPassword"
 import a11yConfig from "../../support/a11yConfig"

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -114,16 +114,15 @@ describe("Case list", () => {
 
       cy.contains("Date range")
 
-      cy.get("#date-range").click()
-      cy.get("#date-range-yesterday").click()
-
       collapseFilterSection("Court date", "#date-range")
       expandFilterSection("Court date", "#date-range")
 
-      // Custom date range is collapsed
+      // // Custom date range & date range are collapsed
       cy.get("#date-from").should("not.exist")
-      // Opening custom date range collapses date range
+      cy.get("#date-range-yesterday").should("not.exist")
+      // Opening custom date range collapses date range & opens custom date range
       cy.get("#custom-date-range").click()
+      cy.get("#date-from").should("exist")
       cy.get("#date-range-yesterday").should("not.exist")
     })
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -67,7 +67,8 @@ describe("Case list", () => {
 
     it("Should be accessible with conditional radio buttons opened", () => {
       visitBasePathAndShowFilters()
-      collapseFilterSection("Court date", "#date-range")
+      cy.contains("Court date").parent().parent().parent().find("button").click()
+      cy.get("#date-range").should("not.be.visible")
       expandFilterSection("Court date", "#date-range")
 
       cy.injectAxe()

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -138,6 +138,18 @@ describe("Case list", () => {
       cy.get("#date-range-yesterday").should("not.be.checked")
     })
 
+    it.only("Should remove the selection of the custom date range when it's been changed to the date range", () => {
+      visitBasePathAndShowFilters()
+      cy.get("#custom-date-range").click()
+      cy.get("#date-from").type("2022-01-01")
+      cy.get("#date-to").type("2022-12-31")
+      cy.get("#custom-date-range").should("be.checked")
+      cy.get("#date-range").click()
+      cy.get("#date-range-yesterday").click()
+      cy.get("#date-range").should("be.checked")
+      cy.get("#date-range-yesterday").should("be.checked")
+    })
+
     it("Should only have the checked attribute for the selected date range ratio button", () => {
       visitBasePathAndShowFilters()
       // no selection, nothing is checked

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -109,13 +109,22 @@ describe("Case list", () => {
       expandFilterSection("Case type", "#exceptions-type")
     })
 
-    it("Should expand and collapse court date filter navigation", () => {
+    it.only("Should expand and collapse court date filter navigation with the ratio conditional sections collapsed after the second expand", () => {
       visitBasePathAndShowFilters()
 
       cy.contains("Date range")
 
-      collapseFilterSection("Court date", "Date range")
-      expandFilterSection("Court date", "Date range")
+      cy.get("#date-range").click()
+      cy.get("#date-range-yesterday").click()
+
+      collapseFilterSection("Court date", "#date-range")
+      expandFilterSection("Court date", "#date-range")
+
+      // Custom date range is collapsed
+      cy.get("#date-from").should("not.exist")
+      // Opening custom date range collapses date range
+      cy.get("#custom-date-range").click()
+      cy.get("#date-range-yesterday").should("not.exist")
     })
 
     it("Should remove the selection of the date range when it's been changed to the custom date range", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -118,6 +118,16 @@ describe("Case list", () => {
       expandFilterSection("Court date", "Date range")
     })
 
+    it("Should remove the selection of the date range when it's been changed to the custom date range", () => {
+      visitBasePathAndShowFilters()
+      cy.get("#date-range").click()
+      cy.get("#date-range-yesterday").click()
+      cy.get("#date-range-yesterday").should("be.checked")
+      cy.get("#custom-date-range").click()
+      cy.get("#date-range").click()
+      cy.get("#date-range-yesterday").should("not.be.checked")
+    })
+
     it("Should expand and collapse urgency filter navigation", () => {
       visitBasePathAndShowFilters()
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -176,8 +176,8 @@ describe("Case list", () => {
 
       cy.contains("Unresolved & resolved cases")
 
-      collapseFilterSection("Case state", "Unresolved & resolved cases")
-      expandFilterSection("Case state", "Unresolved & resolved cases")
+      collapseFilterSection("Case state", "#unresolved-and-resolved")
+      expandFilterSection("Case state", "#unresolved-and-resolved")
     })
 
     it("Should display cases filtered by defendant name", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -105,8 +105,8 @@ describe("Case list", () => {
 
       cy.contains("Exceptions")
 
-      collapseFilterSection("Case type", "#exceptions-type")
-      expandFilterSection("Case type", "#exceptions-type")
+      collapseFilterSection("Reason", "#exceptions-type")
+      expandFilterSection("Reason", "#exceptions-type")
     })
 
     it("Should expand and collapse court date filter navigation with the ratio conditional sections collapsed after the second expand", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -128,18 +128,15 @@ describe("Case list", () => {
       cy.get("#date-range-yesterday").should("not.be.checked")
     })
 
-    it("Should only have the checked attribute for the selected date range ratio button", () => {
+    it.only("Should only have the checked attribute for the selected date range ratio button", () => {
       visitBasePathAndShowFilters()
       // no selection, no checked attribute
       cy.get("#date-range").should("not.have.attr", "checked")
       cy.get("#custom-date-range").should("not.have.attr", "checked")
-      // #date-range selection, #date-range has checked attribute
+      // #date-range-yesterday selected, #date-range has checked attribute
       cy.get("#date-range").click()
-      cy.get("#date-range").should("have.attr", "checked")
-      // #date-range-yesterday, #date-range &  #date-range-yesterday have checked attribute
       cy.get("#date-range-yesterday").click()
       cy.get("#date-range").should("have.attr", "checked")
-      cy.get("#date-range-yesterday").should("have.attr", "checked")
       cy.get("#custom-date-range").should("not.have.attr", "checked")
       // #custom-date-range, ##custom-date-range has checked attribute
       cy.get("#custom-date-range").click()

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -109,21 +109,22 @@ describe("Case list", () => {
       expandFilterSection("Case type", "#exceptions-type")
     })
 
-    it.only("Should expand and collapse court date filter navigation with the ratio conditional sections collapsed after the second expand", () => {
+    it("Should expand and collapse court date filter navigation with the ratio conditional sections collapsed after the second expand", () => {
       visitBasePathAndShowFilters()
 
       cy.contains("Date range")
 
-      collapseFilterSection("Court date", "#date-range")
+      cy.contains("Court date").parent().parent().parent().find("button").click()
+      cy.get("#date-range").should("not.be.visible")
       expandFilterSection("Court date", "#date-range")
 
-      // // Custom date range & date range are collapsed
-      cy.get("#date-from").should("not.exist")
-      cy.get("#date-range-yesterday").should("not.exist")
+      // Custom date range & date range are collapsed
+      cy.get("#date-from").should("not.be.visible")
+      cy.get("#date-range-yesterday").should("not.be.visible")
       // Opening custom date range collapses date range & opens custom date range
       cy.get("#custom-date-range").click()
-      cy.get("#date-from").should("exist")
-      cy.get("#date-range-yesterday").should("not.exist")
+      cy.get("#date-from").should("be.visible")
+      cy.get("#date-range-yesterday").should("not.be.visible")
     })
 
     it("Should remove the selection of the date range when it's been changed to the custom date range", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -1,4 +1,5 @@
 import { addDays, format, subDays, subMonths, subWeeks } from "date-fns"
+import { it } from "node:test"
 import { TestTrigger } from "../../../test/utils/manageTriggers"
 import hashedPassword from "../../fixtures/hashedPassword"
 import a11yConfig from "../../support/a11yConfig"
@@ -128,20 +129,20 @@ describe("Case list", () => {
       cy.get("#date-range-yesterday").should("not.be.checked")
     })
 
-    it.only("Should only have the checked attribute for the selected date range ratio button", () => {
+    it("Should only have the checked attribute for the selected date range ratio button", () => {
       visitBasePathAndShowFilters()
-      // no selection, no checked attribute
-      cy.get("#date-range").should("not.have.attr", "checked")
-      cy.get("#custom-date-range").should("not.have.attr", "checked")
-      // #date-range-yesterday selected, #date-range has checked attribute
+      // no selection, nothing is checked
+      cy.get("#date-range").should("not.be.checked")
+      cy.get("#custom-date-range").should("not.be.checked")
+      // #date-range-yesterday selected, #date-range is checked
       cy.get("#date-range").click()
       cy.get("#date-range-yesterday").click()
-      cy.get("#date-range").should("have.attr", "checked")
-      cy.get("#custom-date-range").should("not.have.attr", "checked")
-      // #custom-date-range, ##custom-date-range has checked attribute
+      cy.get("#date-range").should("be.checked")
+      cy.get("#custom-date-range").should("not.be.checked")
+      // #custom-date-range, ##custom-date-range is checked
       cy.get("#custom-date-range").click()
-      cy.get("#date-range").should("not.have.attr", "checked")
-      cy.get("#custom-date-range").should("have.attr", "checked")
+      cy.get("#date-range").should("not.be.checked")
+      cy.get("#custom-date-range").should("be.checked")
     })
 
     it("Should expand and collapse urgency filter navigation", () => {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -138,7 +138,7 @@ describe("Case list", () => {
       cy.get("#date-range-yesterday").should("not.be.checked")
     })
 
-    it.only("Should remove the selection of the custom date range when it's been changed to the date range", () => {
+    it("Should remove the selection of the custom date range when it's been changed to the date range", () => {
       visitBasePathAndShowFilters()
       cy.get("#custom-date-range").click()
       cy.get("#date-from").type("2022-01-01")

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -12,12 +12,12 @@ function visitBasePathAndShowFilters() {
 
 function collapseFilterSection(sectionToBeCollapsed: string, optionToBeCollapsed: string) {
   cy.contains(exactMatch(sectionToBeCollapsed), { matchCase: true }).parent().parent().parent().find("button").click()
-  cy.contains(optionToBeCollapsed).should("not.exist")
+  cy.get(optionToBeCollapsed).should("not.exist")
 }
 
 function expandFilterSection(sectionToBeExpanded: string, optionToBeExpanded: string) {
   cy.contains(exactMatch(sectionToBeExpanded), { matchCase: true }).parent().parent().parent().find("button").click()
-  cy.contains(optionToBeExpanded).should("exist")
+  cy.get(optionToBeExpanded).should("exist")
 }
 
 function removeFilterTag(filterTag: string) {

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -128,6 +128,25 @@ describe("Case list", () => {
       cy.get("#date-range-yesterday").should("not.be.checked")
     })
 
+    it("Should only have the checked attribute for the selected date range ratio button", () => {
+      visitBasePathAndShowFilters()
+      // no selection, no checked attribute
+      cy.get("#date-range").should("not.have.attr", "checked")
+      cy.get("#custom-date-range").should("not.have.attr", "checked")
+      // #date-range selection, #date-range has checked attribute
+      cy.get("#date-range").click()
+      cy.get("#date-range").should("have.attr", "checked")
+      // #date-range-yesterday, #date-range &  #date-range-yesterday have checked attribute
+      cy.get("#date-range-yesterday").click()
+      cy.get("#date-range").should("have.attr", "checked")
+      cy.get("#date-range-yesterday").should("have.attr", "checked")
+      cy.get("#custom-date-range").should("not.have.attr", "checked")
+      // #custom-date-range, ##custom-date-range has checked attribute
+      cy.get("#custom-date-range").click()
+      cy.get("#date-range").should("not.have.attr", "checked")
+      cy.get("#custom-date-range").should("have.attr", "checked")
+    })
+
     it("Should expand and collapse urgency filter navigation", () => {
       visitBasePathAndShowFilters()
 

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -67,8 +67,8 @@ describe("Case list", () => {
 
     it("Should be accessible with conditional radio buttons opened", () => {
       visitBasePathAndShowFilters()
-      collapseFilterSection("Court date", "Date range")
-      expandFilterSection("Court date", "Date range")
+      collapseFilterSection("Court date", "#date-range")
+      expandFilterSection("Court date", "#date-range")
 
       cy.injectAxe()
 
@@ -105,8 +105,8 @@ describe("Case list", () => {
 
       cy.contains("Exceptions")
 
-      collapseFilterSection("Reason", "Exceptions")
-      expandFilterSection("Reason", "Exceptions")
+      collapseFilterSection("Case type", "#exceptions-type")
+      expandFilterSection("Case type", "#exceptions-type")
     })
 
     it("Should expand and collapse court date filter navigation", () => {
@@ -149,8 +149,8 @@ describe("Case list", () => {
 
       cy.contains("Urgent cases only")
 
-      collapseFilterSection("Urgency", "Urgent cases only")
-      expandFilterSection("Urgency", "Urgent cases only")
+      collapseFilterSection("Urgency", "#urgent")
+      expandFilterSection("Urgency", "#urgent")
     })
 
     it("Should expand and collapse locked state filter navigation", () => {
@@ -158,8 +158,8 @@ describe("Case list", () => {
 
       cy.contains("Locked cases only")
 
-      collapseFilterSection("Locked state", "Locked cases only")
-      expandFilterSection("Locked state", "Locked cases only")
+      collapseFilterSection("Locked state", "#locked")
+      expandFilterSection("Locked state", "#locked")
     })
 
     it("Should expand and collapse case state filter navigation", () => {

--- a/src/components/ConditionalDisplay.tsx
+++ b/src/components/ConditionalDisplay.tsx
@@ -2,13 +2,13 @@ import type { ReactNode } from "react"
 import { useCustomStyles } from "../../styles/customStyles"
 
 interface Props {
-  isVisible: boolean
+  isDisplayed: boolean
   children: ReactNode
 }
 
-const ConditionalDisplay = ({ isVisible, children }: Props) => {
+const ConditionalDisplay = ({ isDisplayed, children }: Props) => {
   const classes = useCustomStyles()
-  return <div className={isVisible ? "" : classes.hidden}>{children}</div>
+  return <div className={isDisplayed ? "" : classes.hidden}>{children}</div>
 }
 
 export default ConditionalDisplay

--- a/src/components/ConditionalDisplay.tsx
+++ b/src/components/ConditionalDisplay.tsx
@@ -6,9 +6,9 @@ interface Props {
   children: ReactNode
 }
 
-const Hide = ({ isVisible, children }: Props) => {
+const ConditionalDisplay = ({ isVisible, children }: Props) => {
   const classes = useCustomStyles()
   return <div className={isVisible ? "" : classes.hidden}>{children}</div>
 }
 
-export default Hide
+export default ConditionalDisplay

--- a/src/components/ConditionalRender.tsx
+++ b/src/components/ConditionalRender.tsx
@@ -4,7 +4,7 @@ interface Props {
   isRendered: boolean
   children: ReactNode
 }
-const If = ({ isRendered, children }: Props) => {
+const ConditionalRender = ({ isRendered, children }: Props) => {
   if (!isRendered) {
     return null
   }
@@ -12,4 +12,4 @@ const If = ({ isRendered, children }: Props) => {
   return <>{children}</>
 }
 
-export default If
+export default ConditionalRender

--- a/src/components/FeatureFlag/FeatureFlag.tsx
+++ b/src/components/FeatureFlag/FeatureFlag.tsx
@@ -1,4 +1,4 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { ReactNode } from "react"
 import KeyValuePair from "types/KeyValuePair"
 
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const FeatureFlag: React.FC<Props> = ({ featureFlags, featureName, children }: Props) => {
-  return <If isRendered={featureFlags ? featureFlags[featureName] : false}>{children}</If>
+  return <ConditionalRender isRendered={featureFlags ? featureFlags[featureName] : false}>{children}</ConditionalRender>
 }
 
 export default FeatureFlag

--- a/src/components/FeatureFlag/FeatureFlag.tsx
+++ b/src/components/FeatureFlag/FeatureFlag.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const FeatureFlag: React.FC<Props> = ({ featureFlags, featureName, children }: Props) => {
-  return <If condition={featureFlags ? featureFlags[featureName] : false}>{children}</If>
+  return <If isRendered={featureFlags ? featureFlags[featureName] : false}>{children}</If>
 }
 
 export default FeatureFlag

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -68,6 +68,7 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
           dataAriaControls={"conditional-custom-date-range"}
           defaultChecked={hasCustomDateRange}
           label={"Custom date range"}
+          onChange={(event) => dispatch({ method: "remove", type: "date", value: event.target.value })}
         />
         <div className="govuk-radios__conditional" id="conditional-custom-date-range">
           <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">

--- a/src/components/Hide.tsx
+++ b/src/components/Hide.tsx
@@ -2,13 +2,13 @@ import type { ReactNode } from "react"
 import { useCustomStyles } from "../../styles/customStyles"
 
 interface Props {
-  isHidden: boolean
+  isVisible: boolean
   children: ReactNode
 }
 
-const Hide = ({ isHidden, children }: Props) => {
+const Hide = ({ isVisible, children }: Props) => {
   const classes = useCustomStyles()
-  return <div className={isHidden ? "" : classes.hidden}>{children}</div>
+  return <div className={isVisible ? "" : classes.hidden}>{children}</div>
 }
 
 export default Hide

--- a/src/components/Hide.tsx
+++ b/src/components/Hide.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react"
+import { useCustomStyles } from "../../styles/customStyles"
+
+interface Props {
+  isHidden: boolean
+  children: ReactNode
+}
+
+const Hide = ({ isHidden, children }: Props) => {
+  const classes = useCustomStyles()
+  return <div className={isHidden ? "" : classes.hidden}>{children}</div>
+}
+
+export default Hide

--- a/src/components/If.tsx
+++ b/src/components/If.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react"
 
 interface Props {
-  condition: boolean
+  isRendered: boolean
   children: ReactNode
 }
-const If = ({ condition, children }: Props) => {
-  if (!condition) {
+const If = ({ isRendered, children }: Props) => {
+  if (!isRendered) {
     return null
   }
 

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { useRouter } from "next/router"
 import hasUserManagementAccess from "services/hasUserManagementAccess"
 import { default as GroupName } from "types/GroupName"
@@ -28,9 +28,9 @@ const NavItem: React.FC<NavItemProps> = ({ name, link }: NavItemProps) => {
 
 const UserManagementNavItem: React.FC<NavBarProps> = (groups) => {
   return (
-    <If isRendered={hasUserManagementAccess(groups)}>
+    <ConditionalRender isRendered={hasUserManagementAccess(groups)}>
       <NavItem name={"User management"} link={"/users/users/"} />
-    </If>
+    </ConditionalRender>
   )
 }
 

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -28,7 +28,7 @@ const NavItem: React.FC<NavItemProps> = ({ name, link }: NavItemProps) => {
 
 const UserManagementNavItem: React.FC<NavBarProps> = (groups) => {
   return (
-    <If condition={hasUserManagementAccess(groups)}>
+    <If isRendered={hasUserManagementAccess(groups)}>
       <NavItem name={"User management"} link={"/users/users/"} />
     </If>
   )

--- a/src/features/AddNoteForm/AddNoteForm.tsx
+++ b/src/features/AddNoteForm/AddNoteForm.tsx
@@ -11,8 +11,8 @@ const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser, error }: Props) => 
     <Heading as="h2" size="MEDIUM">
       {"Add Note"}
     </Heading>
-    <If condition={lockedByAnotherUser}>{"Case is locked by another user."}</If>
-    <If condition={!lockedByAnotherUser}>
+    <If isRendered={lockedByAnotherUser}>{"Case is locked by another user."}</If>
+    <If isRendered={!lockedByAnotherUser}>
       <form method="POST" action="#">
         <FormGroup>
           <TextArea

--- a/src/features/AddNoteForm/AddNoteForm.tsx
+++ b/src/features/AddNoteForm/AddNoteForm.tsx
@@ -1,4 +1,4 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Button, FormGroup, Heading, TextArea } from "govuk-react"
 
 interface Props {
@@ -11,8 +11,8 @@ const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser, error }: Props) => 
     <Heading as="h2" size="MEDIUM">
       {"Add Note"}
     </Heading>
-    <If isRendered={lockedByAnotherUser}>{"Case is locked by another user."}</If>
-    <If isRendered={!lockedByAnotherUser}>
+    <ConditionalRender isRendered={lockedByAnotherUser}>{"Case is locked by another user."}</ConditionalRender>
+    <ConditionalRender isRendered={!lockedByAnotherUser}>
       <form method="POST" action="#">
         <FormGroup>
           <TextArea
@@ -32,7 +32,7 @@ const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser, error }: Props) => 
           {"Add"}
         </Button>
       </form>
-    </If>
+    </ConditionalRender>
   </>
 )
 

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -1,6 +1,6 @@
 import { AnnotatedHearingOutcome } from "@moj-bichard7-developers/bichard7-next-core/build/src/types/AnnotatedHearingOutcome"
 import DateTime from "components/DateTime"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import HearingOutcome from "components/HearingOutcome"
 import ResolveTrigger from "components/ResolveTrigger"
 import LinkButton from "components/LinkButton"
@@ -64,7 +64,7 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         </Table.Cell>
       </Table.Row>
     </Table>
-    <If isRendered={triggersVisible && (courtCase?.triggers?.length ?? 0) > 0}>
+    <ConditionalRender isRendered={triggersVisible && (courtCase?.triggers?.length ?? 0) > 0}>
       <Heading as="h3" size="MEDIUM">
         {"Triggers"}
       </Heading>
@@ -94,14 +94,14 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
           ))}
         </Table>
       </div>
-    </If>
-    <If isRendered={(courtCase?.triggers?.length ?? 0) === 0}>
+    </ConditionalRender>
+    <ConditionalRender isRendered={(courtCase?.triggers?.length ?? 0) === 0}>
       <Paragraph>{"Case has no triggers."}</Paragraph>
-    </If>
+    </ConditionalRender>
     <Heading as="h3" size="MEDIUM">
       {"Notes"}
     </Heading>
-    <If isRendered={(courtCase?.notes?.length ?? 0) > 0}>
+    <ConditionalRender isRendered={(courtCase?.notes?.length ?? 0) > 0}>
       <Table>
         {courtCase.notes.map((note, index) => (
           <Table.Row key={index}>
@@ -112,13 +112,13 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
           </Table.Row>
         ))}
       </Table>
-    </If>
-    <If isRendered={(courtCase?.notes?.length ?? 0) === 0}>
+    </ConditionalRender>
+    <ConditionalRender isRendered={(courtCase?.notes?.length ?? 0) === 0}>
       <Paragraph>{"Case has no notes."}</Paragraph>
-    </If>
-    <If isRendered={!lockedByAnotherUser}>
+    </ConditionalRender>
+    <ConditionalRender isRendered={!lockedByAnotherUser}>
       <LinkButton href="notes/add">{"Add Note"}</LinkButton>
-    </If>
+    </ConditionalRender>
   </>
 )
 

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -64,7 +64,7 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         </Table.Cell>
       </Table.Row>
     </Table>
-    <If condition={triggersVisible && (courtCase?.triggers?.length ?? 0) > 0}>
+    <If isRendered={triggersVisible && (courtCase?.triggers?.length ?? 0) > 0}>
       <Heading as="h3" size="MEDIUM">
         {"Triggers"}
       </Heading>
@@ -95,13 +95,13 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         </Table>
       </div>
     </If>
-    <If condition={(courtCase?.triggers?.length ?? 0) === 0}>
+    <If isRendered={(courtCase?.triggers?.length ?? 0) === 0}>
       <Paragraph>{"Case has no triggers."}</Paragraph>
     </If>
     <Heading as="h3" size="MEDIUM">
       {"Notes"}
     </Heading>
-    <If condition={(courtCase?.notes?.length ?? 0) > 0}>
+    <If isRendered={(courtCase?.notes?.length ?? 0) > 0}>
       <Table>
         {courtCase.notes.map((note, index) => (
           <Table.Row key={index}>
@@ -113,10 +113,10 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
         ))}
       </Table>
     </If>
-    <If condition={(courtCase?.notes?.length ?? 0) === 0}>
+    <If isRendered={(courtCase?.notes?.length ?? 0) === 0}>
       <Paragraph>{"Case has no notes."}</Paragraph>
     </If>
-    <If condition={!lockedByAnotherUser}>
+    <If isRendered={!lockedByAnotherUser}>
       <LinkButton href="notes/add">{"Add Note"}</LinkButton>
     </If>
   </>

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -1,5 +1,5 @@
 import FilterTag from "components/FilterTag/FilterTag"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { format } from "date-fns"
 import { useRouter } from "next/router"
 import { encode } from "querystring"
@@ -57,7 +57,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
 
   return (
     <div>
-      <If isRendered={hasAnyAppliedFilters()}>
+      <ConditionalRender isRendered={hasAnyAppliedFilters()}>
         <ul key={"applied-filters"} className="moj-filter-tags">
           <li>
             <p className="govuk-heading-s govuk-!-margin-bottom-0">{"Filters applied:"}</p>
@@ -78,36 +78,36 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
                 </li>
               )
             })}
-          <If isRendered={!!filters.courtName}>
+          <ConditionalRender isRendered={!!filters.courtName}>
             <li>
               <FilterTag
                 tag={filters.courtName ?? ""}
                 href={removeFilterFromPath({ courtName: filters.courtName ?? "" })}
               />
             </li>
-          </If>
-          <If isRendered={!!filters.reasonCode}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.reasonCode}>
             <li>
               <FilterTag
                 tag={filters.reasonCode ?? ""}
                 href={removeFilterFromPath({ reasonCode: filters.reasonCode ?? "" })}
               />
             </li>
-          </If>
-          <If isRendered={!!filters.ptiurn}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.ptiurn}>
             <li>
               <FilterTag tag={filters.ptiurn ?? ""} href={removeFilterFromPath({ ptiurn: filters.ptiurn ?? "" })} />
             </li>
-          </If>
-          <If isRendered={!!filters.dateRange}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.dateRange}>
             <li>
               <FilterTag
                 tag={filters.dateRange ?? ""}
                 href={removeFilterFromPath({ dateRange: filters.dateRange ?? "" })}
               />
             </li>
-          </If>
-          <If isRendered={!!filters.customDateFrom && !!filters.customDateTo}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.customDateFrom && !!filters.customDateTo}>
             <li>
               <FilterTag
                 tag={
@@ -119,33 +119,33 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
                 href={removeQueryParamsByName(["from", "to", "pageNum"])}
               />
             </li>
-          </If>
-          <If isRendered={!!filters.urgency}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.urgency}>
             <li>
               <FilterTag tag={filters.urgency ?? ""} href={removeFilterFromPath({ urgency: filters.urgency ?? "" })} />
             </li>
-          </If>
-          <If isRendered={!!filters.myCases}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.myCases}>
             <li>
               <FilterTag
                 tag={"Cases locked to me" ?? ""}
                 href={removeFilterFromPath({ myCases: String(filters.myCases) })}
               />
             </li>
-          </If>
-          <If isRendered={!!filters.locked}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.locked}>
             <li>
               <FilterTag tag={filters.locked ?? ""} href={removeFilterFromPath({ locked: filters.locked ?? "" })} />
             </li>
-          </If>
-          <If isRendered={!!filters.caseState}>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!filters.caseState}>
             <li>
               <FilterTag
                 tag={caseStateLabels[String(filters.caseState)] ?? ""}
                 href={removeFilterFromPath({ state: filters.caseState ?? "" })}
               />
             </li>
-          </If>
+          </ConditionalRender>
           <li>
             <p className="moj-filter__heading-action" id="clear-filters-applied">
               <a className="govuk-link govuk-link--no-visited-state" href="/bichard">
@@ -154,7 +154,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
             </p>
           </li>
         </ul>
-      </If>
+      </ConditionalRender>
     </div>
   )
 }

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -57,7 +57,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
 
   return (
     <div>
-      <If condition={hasAnyAppliedFilters()}>
+      <If isRendered={hasAnyAppliedFilters()}>
         <ul key={"applied-filters"} className="moj-filter-tags">
           <li>
             <p className="govuk-heading-s govuk-!-margin-bottom-0">{"Filters applied:"}</p>
@@ -78,7 +78,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
                 </li>
               )
             })}
-          <If condition={!!filters.courtName}>
+          <If isRendered={!!filters.courtName}>
             <li>
               <FilterTag
                 tag={filters.courtName ?? ""}
@@ -86,7 +86,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </If>
-          <If condition={!!filters.reasonCode}>
+          <If isRendered={!!filters.reasonCode}>
             <li>
               <FilterTag
                 tag={filters.reasonCode ?? ""}
@@ -94,12 +94,12 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </If>
-          <If condition={!!filters.ptiurn}>
+          <If isRendered={!!filters.ptiurn}>
             <li>
               <FilterTag tag={filters.ptiurn ?? ""} href={removeFilterFromPath({ ptiurn: filters.ptiurn ?? "" })} />
             </li>
           </If>
-          <If condition={!!filters.dateRange}>
+          <If isRendered={!!filters.dateRange}>
             <li>
               <FilterTag
                 tag={filters.dateRange ?? ""}
@@ -107,7 +107,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </If>
-          <If condition={!!filters.customDateFrom && !!filters.customDateTo}>
+          <If isRendered={!!filters.customDateFrom && !!filters.customDateTo}>
             <li>
               <FilterTag
                 tag={
@@ -120,12 +120,12 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </If>
-          <If condition={!!filters.urgency}>
+          <If isRendered={!!filters.urgency}>
             <li>
               <FilterTag tag={filters.urgency ?? ""} href={removeFilterFromPath({ urgency: filters.urgency ?? "" })} />
             </li>
           </If>
-          <If condition={!!filters.myCases}>
+          <If isRendered={!!filters.myCases}>
             <li>
               <FilterTag
                 tag={"Cases locked to me" ?? ""}
@@ -133,12 +133,12 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </If>
-          <If condition={!!filters.locked}>
+          <If isRendered={!!filters.locked}>
             <li>
               <FilterTag tag={filters.locked ?? ""} href={removeFilterFromPath({ locked: filters.locked ?? "" })} />
             </li>
           </If>
-          <If condition={!!filters.caseState}>
+          <If isRendered={!!filters.caseState}>
             <li>
               <FilterTag
                 tag={caseStateLabels[String(filters.caseState)] ?? ""}

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -261,8 +261,8 @@ const CourtCaseFilter: React.FC<Props> = ({
               <CourtDateFilterOptions
                 dateRange={state.dateFilter.value}
                 dispatch={dispatch}
-                customDateFrom={customDateFrom}
-                customDateTo={customDateTo}
+                customDateFrom={state.customDateFrom.value ?? null}
+                customDateTo={state.customDateTo.value ?? null}
               />
             </ExpandingFilters>
           </div>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -257,7 +257,7 @@ const CourtCaseFilter: React.FC<Props> = ({
           </div>
           <div className={classes["govuk-form-group"]}>
             <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
-            <ExpandingFilters filterName={"Court date"}>
+            <ExpandingFilters filterName={"Court date"} hideChildren={true}>
               <CourtDateFilterOptions
                 dateRange={state.dateFilter.value}
                 dispatch={dispatch}

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -73,7 +73,7 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren 
         </div>
       </div>
       {hideChildren ? (
-        <ConditionalDisplay isVisible={caseTypeIsVisible}>{children}</ConditionalDisplay>
+        <ConditionalDisplay isDisplayed={caseTypeIsVisible}>{children}</ConditionalDisplay>
       ) : (
         <If isRendered={caseTypeIsVisible}>{children}</If>
       )}

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -73,7 +73,7 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren 
         </div>
       </div>
       {hideChildren ? (
-        <Hide isHidden={caseTypeIsVisible}>{children}</Hide>
+        <Hide isVisible={caseTypeIsVisible}>{children}</Hide>
       ) : (
         <If condition={caseTypeIsVisible}>{children}</If>
       )}

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import Hide from "components/Hide"
+import ConditionalDisplay from "components/ConditionalDisplay"
 import If from "components/If"
 import { ReactNode, useState } from "react"
 import { createUseStyles } from "react-jss"
@@ -73,7 +73,7 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren 
         </div>
       </div>
       {hideChildren ? (
-        <Hide isVisible={caseTypeIsVisible}>{children}</Hide>
+        <ConditionalDisplay isVisible={caseTypeIsVisible}>{children}</ConditionalDisplay>
       ) : (
         <If isRendered={caseTypeIsVisible}>{children}</If>
       )}

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -75,7 +75,7 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren 
       {hideChildren ? (
         <Hide isVisible={caseTypeIsVisible}>{children}</Hide>
       ) : (
-        <If condition={caseTypeIsVisible}>{children}</If>
+        <If isRendered={caseTypeIsVisible}>{children}</If>
       )}
     </fieldset>
   )

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import ConditionalDisplay from "components/ConditionalDisplay"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { ReactNode, useState } from "react"
 import { createUseStyles } from "react-jss"
 
@@ -75,7 +75,7 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren 
       {hideChildren ? (
         <ConditionalDisplay isDisplayed={caseTypeIsVisible}>{children}</ConditionalDisplay>
       ) : (
-        <If isRendered={caseTypeIsVisible}>{children}</If>
+        <ConditionalRender isRendered={caseTypeIsVisible}>{children}</ConditionalRender>
       )}
     </fieldset>
   )

--- a/src/features/CourtCaseFilters/ExpandingFilters.tsx
+++ b/src/features/CourtCaseFilters/ExpandingFilters.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
+import Hide from "components/Hide"
 import If from "components/If"
 import { ReactNode, useState } from "react"
 import { createUseStyles } from "react-jss"
@@ -48,9 +49,10 @@ const DownArrow: React.FC = () => (
 interface Props {
   filterName: string
   children: ReactNode
+  hideChildren?: boolean
 }
 
-const ExpandingFilters: React.FC<Props> = ({ filterName, children }: { filterName: string; children: ReactNode }) => {
+const ExpandingFilters: React.FC<Props> = ({ filterName, children, hideChildren }: Props) => {
   const [caseTypeIsVisible, setCaseTypeVisible] = useState(true)
   const classes = useStyles()
   return (
@@ -70,7 +72,11 @@ const ExpandingFilters: React.FC<Props> = ({ filterName, children }: { filterNam
           </legend>
         </div>
       </div>
-      <If condition={caseTypeIsVisible}>{children}</If>
+      {hideChildren ? (
+        <Hide isHidden={caseTypeIsVisible}>{children}</Hide>
+      ) : (
+        <If condition={caseTypeIsVisible}>{children}</If>
+      )}
     </fieldset>
   )
 }

--- a/src/features/CourtCaseFilters/FilterChipRow.tsx
+++ b/src/features/CourtCaseFilters/FilterChipRow.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import FilterChip from "components/FilterChip"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Dispatch } from "react"
 import { FilterAction, FilterState } from "types/CourtCaseFilter"
 
@@ -16,7 +16,7 @@ interface Props {
 
 const FilterChipRow: React.FC<Props> = ({ chipLabel, condition, dispatch, type, label, state, value }: Props) => {
   return (
-    <If isRendered={condition}>
+    <ConditionalRender isRendered={condition}>
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{label}</h3>
       <ul className="moj-filter-tags govuk-!-margin-bottom-0">
         <FilterChip
@@ -28,7 +28,7 @@ const FilterChipRow: React.FC<Props> = ({ chipLabel, condition, dispatch, type, 
           state={state}
         />
       </ul>
-    </If>
+    </ConditionalRender>
   )
 }
 

--- a/src/features/CourtCaseFilters/FilterChipRow.tsx
+++ b/src/features/CourtCaseFilters/FilterChipRow.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const FilterChipRow: React.FC<Props> = ({ chipLabel, condition, dispatch, type, label, state, value }: Props) => {
   return (
-    <If condition={condition}>
+    <If isRendered={condition}>
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{label}</h3>
       <ul className="moj-filter-tags govuk-!-margin-bottom-0">
         <FilterChip

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -32,7 +32,7 @@ const FilterChipSection: React.FC<Props> = ({
       : ""
   return (
     <>
-      <If condition={anyFilterChips(state, sectionState)}>
+      <If isRendered={anyFilterChips(state, sectionState)}>
         <h2
           className={"govuk-heading-m govuk-!-margin-bottom-0" + (marginTop ? " govuk-!-margin-top-2" : "")}
         >{`${sectionState} filters`}</h2>
@@ -93,7 +93,7 @@ const FilterChipSection: React.FC<Props> = ({
           value={state.reasonCode.value!}
         />
 
-        <If condition={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
+        <If isRendered={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
           <ul className="moj-filter-tags govuk-!-margin-bottom-0">
             {state.reasonFilter
@@ -197,7 +197,7 @@ const FilterChipSection: React.FC<Props> = ({
           value={state.myCasesFilter.value!}
         />
       </If>
-      <If condition={!anyFilterChips(state, sectionState) && placeholderMessage !== undefined}>
+      <If isRendered={!anyFilterChips(state, sectionState) && placeholderMessage !== undefined}>
         <h2
           className={"govuk-heading-m govuk-!-margin-bottom-0" + (marginTop ? " govuk-!-margin-top-2" : "")}
         >{`${sectionState} filters`}</h2>

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import FilterChip from "components/FilterChip"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { format } from "date-fns"
 import { Dispatch } from "react"
 import { Filter, FilterAction, FilterState } from "types/CourtCaseFilter"
@@ -32,7 +32,7 @@ const FilterChipSection: React.FC<Props> = ({
       : ""
   return (
     <>
-      <If isRendered={anyFilterChips(state, sectionState)}>
+      <ConditionalRender isRendered={anyFilterChips(state, sectionState)}>
         <h2
           className={"govuk-heading-m govuk-!-margin-bottom-0" + (marginTop ? " govuk-!-margin-top-2" : "")}
         >{`${sectionState} filters`}</h2>
@@ -93,7 +93,9 @@ const FilterChipSection: React.FC<Props> = ({
           value={state.reasonCode.value!}
         />
 
-        <If isRendered={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}>
+        <ConditionalRender
+          isRendered={state.reasonFilter.filter((reasonFilter) => reasonFilter.state === sectionState).length > 0}
+        >
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{"Reason"}</h3>
           <ul className="moj-filter-tags govuk-!-margin-bottom-0">
             {state.reasonFilter
@@ -110,7 +112,7 @@ const FilterChipSection: React.FC<Props> = ({
                 />
               ))}
           </ul>
-        </If>
+        </ConditionalRender>
 
         <FilterChipRow
           chipLabel={state.urgentFilter.label!}
@@ -196,13 +198,13 @@ const FilterChipSection: React.FC<Props> = ({
           state={state.myCasesFilter.state || sectionState}
           value={state.myCasesFilter.value!}
         />
-      </If>
-      <If isRendered={!anyFilterChips(state, sectionState) && placeholderMessage !== undefined}>
+      </ConditionalRender>
+      <ConditionalRender isRendered={!anyFilterChips(state, sectionState) && placeholderMessage !== undefined}>
         <h2
           className={"govuk-heading-m govuk-!-margin-bottom-0" + (marginTop ? " govuk-!-margin-top-2" : "")}
         >{`${sectionState} filters`}</h2>
         <p>{placeholderMessage}</p>
-      </If>
+      </ConditionalRender>
     </>
   )
 }

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -130,7 +130,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc", currentUser
       tableBody.push(
         <Table.Row key={`case-details-row-${idx}`} className={classes.caseDetailsRow}>
           <Table.Cell>
-            <If condition={!!errorLockedByUsername}>
+            <If isRendered={!!errorLockedByUsername}>
               <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
             </If>
           </Table.Cell>
@@ -177,7 +177,7 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc", currentUser
         tableBody.push(
           <Table.Row key={`triggers-row-${idx}`} className={classes.triggersRow}>
             <Table.Cell>
-              <If condition={!!triggerLockedByUsername}>
+              <If isRendered={!!triggerLockedByUsername}>
                 <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
               </If>
             </Table.Cell>

--- a/src/features/CourtCaseList/CourtCaseList.tsx
+++ b/src/features/CourtCaseList/CourtCaseList.tsx
@@ -1,5 +1,5 @@
 import DateTime from "components/DateTime"
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import ColumnOrderIcons from "features/CourtCaseFilters/ColumnOrderIcons"
 import { GridRow, Link, Paragraph, Table } from "govuk-react"
 import Image from "next/image"
@@ -130,9 +130,9 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc", currentUser
       tableBody.push(
         <Table.Row key={`case-details-row-${idx}`} className={classes.caseDetailsRow}>
           <Table.Cell>
-            <If isRendered={!!errorLockedByUsername}>
+            <ConditionalRender isRendered={!!errorLockedByUsername}>
               <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
-            </If>
+            </ConditionalRender>
           </Table.Cell>
           <Table.Cell>
             <Link href={caseDetailsPath(courtCases[idx].errorId)} id={`Case details for ${defendantName}`}>
@@ -177,9 +177,9 @@ const CourtCaseList: React.FC<Props> = ({ courtCases, order = "asc", currentUser
         tableBody.push(
           <Table.Row key={`triggers-row-${idx}`} className={classes.triggersRow}>
             <Table.Cell>
-              <If isRendered={!!triggerLockedByUsername}>
+              <ConditionalRender isRendered={!!triggerLockedByUsername}>
                 <Image src={"/bichard/assets/images/lock.svg"} width={20} height={20} alt="Lock icon" />
-              </If>
+              </ConditionalRender>
             </Table.Cell>
             <Table.Cell />
             <Table.Cell />

--- a/src/features/CourtCaseList/tags/LockedByTag.tsx
+++ b/src/features/CourtCaseList/tags/LockedByTag.tsx
@@ -47,7 +47,7 @@ const LockedByTag: React.FC<{ lockedBy?: string | null; unlockPath?: string }> =
 }) => {
   const classes = useStyles()
   return (
-    <If condition={!!props.lockedBy}>
+    <If isRendered={!!props.lockedBy}>
       <Tag backgroundColor={tagBlue} color={textBlue} className={`locked-by-tag ${classes.LockedByTag}`}>
         <div className={classes.LockedByTag}>
           <Image

--- a/src/features/CourtCaseList/tags/LockedByTag.tsx
+++ b/src/features/CourtCaseList/tags/LockedByTag.tsx
@@ -1,4 +1,4 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Tag } from "govuk-react"
 import Image from "next/image"
 import { createUseStyles } from "react-jss"
@@ -47,7 +47,7 @@ const LockedByTag: React.FC<{ lockedBy?: string | null; unlockPath?: string }> =
 }) => {
   const classes = useStyles()
   return (
-    <If isRendered={!!props.lockedBy}>
+    <ConditionalRender isRendered={!!props.lockedBy}>
       <Tag backgroundColor={tagBlue} color={textBlue} className={`locked-by-tag ${classes.LockedByTag}`}>
         <div className={classes.LockedByTag}>
           <Image
@@ -66,7 +66,7 @@ const LockedByTag: React.FC<{ lockedBy?: string | null; unlockPath?: string }> =
           )}
         </div>
       </Tag>
-    </If>
+    </ConditionalRender>
   )
 }
 

--- a/src/features/CourtCaseList/tags/NotesTag.tsx
+++ b/src/features/CourtCaseList/tags/NotesTag.tsx
@@ -5,7 +5,7 @@ import Note from "services/entities/Note"
 const NotesTag: React.FC<{ notes: Note[] }> = (props: { notes: Note[] }) => {
   const userNotes = props.notes ? props.notes.filter((note) => note.userId !== "System").length : 0
   return (
-    <If condition={!!userNotes}>
+    <If isRendered={!!userNotes}>
       <Tag tint="BLUE">{userNotes}</Tag>
     </If>
   )

--- a/src/features/CourtCaseList/tags/NotesTag.tsx
+++ b/src/features/CourtCaseList/tags/NotesTag.tsx
@@ -1,13 +1,13 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Tag } from "govuk-react"
 import Note from "services/entities/Note"
 
 const NotesTag: React.FC<{ notes: Note[] }> = (props: { notes: Note[] }) => {
   const userNotes = props.notes ? props.notes.filter((note) => note.userId !== "System").length : 0
   return (
-    <If isRendered={!!userNotes}>
+    <ConditionalRender isRendered={!!userNotes}>
       <Tag tint="BLUE">{userNotes}</Tag>
-    </If>
+    </ConditionalRender>
   )
 }
 

--- a/src/features/CourtCaseList/tags/ResolvedTag.tsx
+++ b/src/features/CourtCaseList/tags/ResolvedTag.tsx
@@ -1,13 +1,13 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { useCustomStyles } from "../../../../styles/customStyles"
 
 const ResolvedTag: React.FC<{ isResolved: boolean }> = (props: { isResolved: boolean }) => {
   const classes = useCustomStyles()
 
   return (
-    <If isRendered={props.isResolved}>
+    <ConditionalRender isRendered={props.isResolved}>
       <span className={`moj-badge moj-badge--grey ${classes["margin-top-bottom"]}`}>{"Resolved"}</span>
-    </If>
+    </ConditionalRender>
   )
 }
 

--- a/src/features/CourtCaseList/tags/ResolvedTag.tsx
+++ b/src/features/CourtCaseList/tags/ResolvedTag.tsx
@@ -5,7 +5,7 @@ const ResolvedTag: React.FC<{ isResolved: boolean }> = (props: { isResolved: boo
   const classes = useCustomStyles()
 
   return (
-    <If condition={props.isResolved}>
+    <If isRendered={props.isResolved}>
       <span className={`moj-badge moj-badge--grey ${classes["margin-top-bottom"]}`}>{"Resolved"}</span>
     </If>
   )

--- a/src/features/CourtCaseList/tags/UrgentTag.tsx
+++ b/src/features/CourtCaseList/tags/UrgentTag.tsx
@@ -1,10 +1,10 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Tag } from "govuk-react"
 
 const UrgentTag: React.FC<{ isUrgent: boolean }> = (props: { isUrgent: boolean }) => (
-  <If isRendered={props.isUrgent}>
+  <ConditionalRender isRendered={props.isUrgent}>
     <Tag tint="RED">{"Urgent"}</Tag>
-  </If>
+  </ConditionalRender>
 )
 
 export default UrgentTag

--- a/src/features/CourtCaseList/tags/UrgentTag.tsx
+++ b/src/features/CourtCaseList/tags/UrgentTag.tsx
@@ -2,7 +2,7 @@ import If from "components/If"
 import { Tag } from "govuk-react"
 
 const UrgentTag: React.FC<{ isUrgent: boolean }> = (props: { isUrgent: boolean }) => (
-  <If condition={props.isUrgent}>
+  <If isRendered={props.isUrgent}>
     <Tag tint="RED">{"Urgent"}</Tag>
   </If>
 )

--- a/src/features/CourtCaseLock/CourtCaseLock.tsx
+++ b/src/features/CourtCaseLock/CourtCaseLock.tsx
@@ -1,4 +1,4 @@
-import If from "components/If"
+import ConditionalRender from "components/ConditionalRender"
 import { Button, ErrorSummary, Paragraph } from "govuk-react"
 import { useRouter } from "next/router"
 import CourtCase from "services/entities/CourtCase"
@@ -19,13 +19,13 @@ const CourtCaseLock: React.FC<Props> = ({ courtCase, lockedByAnotherUser }) => {
 
   return (
     <>
-      <If isRendered={lockedByAnotherUser}>
+      <ConditionalRender isRendered={lockedByAnotherUser}>
         <ErrorSummary heading="Case locked by another user" />
-      </If>
-      <If isRendered={isLocked}>
+      </ConditionalRender>
+      <ConditionalRender isRendered={isLocked}>
         <Paragraph>{`Trigger locked by: ${courtCase.triggerLockedByUsername}`}</Paragraph>
         <Paragraph>{`Error locked by: ${courtCase.errorLockedByUsername}`}</Paragraph>
-      </If>
+      </ConditionalRender>
       <form method="POST" action={lockCourtCasePath}>
         <Button buttonColour="#1d70b8">{lockButtonTitle}</Button>
       </form>

--- a/src/features/CourtCaseLock/CourtCaseLock.tsx
+++ b/src/features/CourtCaseLock/CourtCaseLock.tsx
@@ -19,10 +19,10 @@ const CourtCaseLock: React.FC<Props> = ({ courtCase, lockedByAnotherUser }) => {
 
   return (
     <>
-      <If condition={lockedByAnotherUser}>
+      <If isRendered={lockedByAnotherUser}>
         <ErrorSummary heading="Case locked by another user" />
       </If>
-      <If condition={isLocked}>
+      <If isRendered={isLocked}>
         <Paragraph>{`Trigger locked by: ${courtCase.triggerLockedByUsername}`}</Paragraph>
         <Paragraph>{`Error locked by: ${courtCase.errorLockedByUsername}`}</Paragraph>
       </If>

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -28,5 +28,8 @@ export const useCustomStyles = createUseStyles({
     "&:link": {
       color: "white"
     }
+  },
+  hidden: {
+    display: "none"
   }
 })


### PR DESCRIPTION
- add cy tests for the bugs in [BICAWS-2616](https://dsdmoj.atlassian.net/browse/BICAWS-2616)
- fix the bugs in [BICAWS-2616](https://dsdmoj.atlassian.net/browse/BICAWS-2616)
- create a `ConditionalDisplay` component to `display: none` on `children`
- rename `If` component to `ConditionalRender` to distinguish it from `ConditionalDisplay`
- add `dispatch` after choosing `custom date range` option that removes the previously selected date
- add an optional prop `hideChildren` to `ExpandingFilters`, based on its value, the children are either not rendered or not displayed
- create a custom `hidden` class that applies CSS `display: none` property


[BICAWS-2616]: https://dsdmoj.atlassian.net/browse/BICAWS-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BICAWS-2616]: https://dsdmoj.atlassian.net/browse/BICAWS-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ