### PR TITLE
BICAWS-2713: Bug: Changing court date selection doesn't change selected filters

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -4,6 +4,7 @@ import hashedPassword from "../../fixtures/hashedPassword"
 import a11yConfig from "../../support/a11yConfig"
 import { confirmFiltersAppliedContains, exactMatch } from "../../support/helpers"
 import logAccessibilityViolations from "../../support/logAccessibilityViolations"
+import { filterByDateRange } from "./filterChips.cy"
 
 function visitBasePathAndShowFilters() {
   cy.visit("/bichard")
@@ -130,8 +131,7 @@ describe("Case list", () => {
 
     it("Should remove the selection of the date range when it's been changed to the custom date range", () => {
       visitBasePathAndShowFilters()
-      cy.get("#date-range").click()
-      cy.get("#date-range-yesterday").click()
+      filterByDateRange("#date-range-yesterday")
       cy.get("#date-range-yesterday").should("be.checked")
       cy.get("#custom-date-range").click()
       cy.get("#date-range").click()
@@ -144,8 +144,7 @@ describe("Case list", () => {
       cy.get("#date-from").type("2022-01-01")
       cy.get("#date-to").type("2022-12-31")
       cy.get("#custom-date-range").should("be.checked")
-      cy.get("#date-range").click()
-      cy.get("#date-range-yesterday").click()
+      filterByDateRange("#date-range-yesterday")
       cy.get("#date-range").should("be.checked")
       cy.get("#date-range-yesterday").should("be.checked")
     })
@@ -156,8 +155,7 @@ describe("Case list", () => {
       cy.get("#date-range").should("not.be.checked")
       cy.get("#custom-date-range").should("not.be.checked")
       // #date-range-yesterday selected, #date-range is checked
-      cy.get("#date-range").click()
-      cy.get("#date-range-yesterday").click()
+      filterByDateRange("#date-range-yesterday")
       cy.get("#date-range").should("be.checked")
       cy.get("#custom-date-range").should("not.be.checked")
       // #custom-date-range, ##custom-date-range is checked
@@ -375,8 +373,7 @@ describe("Case list", () => {
       visitBasePathAndShowFilters()
 
       // Tests for "Today"
-      cy.get("#date-range").click()
-      cy.get("#date-range-today").click()
+      filterByDateRange("#date-range-yesterday")
       cy.get("button#search").click()
 
       cy.get("tr").not(":first").should("have.length", 1)
@@ -392,8 +389,7 @@ describe("Case list", () => {
 
       // Tests for "yesterday"
       cy.get("button#filter-button").click()
-      cy.get("#date-range").click()
-      cy.get("#date-range-yesterday").click()
+      filterByDateRange("#date-range-yesterday")
       cy.get("button#search").click()
 
       cy.get("tr").not(":first").should("have.length", 1)

--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -373,7 +373,7 @@ describe("Case list", () => {
       visitBasePathAndShowFilters()
 
       // Tests for "Today"
-      filterByDateRange("#date-range-yesterday")
+      filterByDateRange("#date-range-today")
       cy.get("button#search").click()
 
       cy.get("tr").not(":first").should("have.length", 1)

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -6,7 +6,7 @@ export function removeFilterChip() {
   cy.get(".moj-filter__tag").should("not.exist")
 }
 
-function filterByDateRange(dateRangeId: string) {
+export function filterByDateRange(dateRangeId: string) {
   cy.get("#date-range").click()
   cy.get(dateRangeId).click()
 }

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -109,7 +109,7 @@ describe("Case list", () => {
         cy.get(".moj-filter__tag").contains("This month").should("not.exist")
       })
 
-      it.only("Should remove the date range filter chip when custom date range is selected", () => {
+      it("Should remove the date range filter chip when custom date range is selected", () => {
         cy.get("#filter-button").click()
         cy.get("#date-range").click()
         cy.get("#date-range-today").click()
@@ -140,7 +140,7 @@ describe("Case list", () => {
         confirmFiltersAppliedContains("01/01/2022 - 31/12/2022")
       })
 
-      it.only("Should remove custom date range filter chip when custom date filter is selected", () => {
+      it("Should remove custom date range filter chip when custom date filter is selected", () => {
         cy.get("button#filter-button").click()
         cy.get("#custom-date-range").click()
         cy.get("#date-from").click().type("2022-01-01")

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -11,7 +11,7 @@ export function filterByDateRange(dateRangeId: string) {
   cy.get(dateRangeId).click()
 }
 
-function filterByCustomDateRange(dateFrom: string, dateTo: string) {
+const filterByCustomDateRange = (dateFrom: string, dateTo: string) => {
   cy.get("#custom-date-range").click()
   cy.get("#date-from").click().type(dateFrom)
   cy.get("#date-to").click().type(dateTo)

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -11,6 +11,12 @@ export function filterByDateRange(dateRangeId: string) {
   cy.get(dateRangeId).click()
 }
 
+function filterByCustomDateRange(dateFrom: string, dateTo: string) {
+  cy.get("#custom-date-range").click()
+  cy.get("#date-from").click().type(dateFrom)
+  cy.get("#date-to").click().type(dateTo)
+}
+
 describe("Case list", () => {
   context("When filters applied", () => {
     before(() => {
@@ -117,9 +123,7 @@ describe("Case list", () => {
         cy.get("#filter-button").click()
         filterByDateRange("#date-range-today")
 
-        cy.get("#custom-date-range").click()
-        cy.get("#date-from").click().type("2022-01-01")
-        cy.get("#date-to").click().type("2022-12-31")
+        filterByCustomDateRange("2022-01-01", "2022-12-31")
 
         cy.get(".govuk-heading-s").contains("Date range").should("not.exist")
         cy.get(".moj-filter__tag").contains("Today").should("not.exist")
@@ -131,9 +135,7 @@ describe("Case list", () => {
     describe("Custom Date range", () => {
       it("Should allow you to add custom date range filter chip", () => {
         cy.get("button#filter-button").click()
-        cy.get("#custom-date-range").click()
-        cy.get("#date-from").click().type("2022-01-01")
-        cy.get("#date-to").click().type("2022-12-31")
+        filterByCustomDateRange("2022-01-01", "2022-12-31")
         cy.get(".govuk-heading-m").contains("Selected filters").should("exist")
         cy.get(".govuk-heading-s").contains("Custom date range").should("exist")
         cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022")
@@ -145,9 +147,7 @@ describe("Case list", () => {
 
       it("Should remove custom date range filter chip when custom date filter is selected", () => {
         cy.get("button#filter-button").click()
-        cy.get("#custom-date-range").click()
-        cy.get("#date-from").click().type("2022-01-01")
-        cy.get("#date-to").click().type("2022-12-31")
+        filterByCustomDateRange("2022-01-01", "2022-12-31")
         cy.get(".govuk-heading-m").contains("Selected filters").should("exist")
         cy.get(".govuk-heading-s").contains("Custom date range").should("exist")
         cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022")

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -158,6 +158,10 @@ describe("Case list", () => {
         cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("not.exist")
         cy.get(".govuk-heading-s").contains("Date range").should("exist")
         cy.get(".moj-filter__tag").contains("Today").should("exist")
+
+        cy.get("#custom-date-range").click()
+        cy.get("#date-from").invoke("val").should("be.empty")
+        cy.get("#date-to").invoke("val").should("be.empty")
       })
 
       it.skip("Should apply the 'Custom date filter' filter chips then remove this chips to the original state", () => {

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -108,6 +108,21 @@ describe("Case list", () => {
         cy.get(".moj-filter__tag").contains("Last week").should("not.exist")
         cy.get(".moj-filter__tag").contains("This month").should("not.exist")
       })
+
+      it.only("Should remove the date range filter chip when custom date range is selected", () => {
+        cy.get("#filter-button").click()
+        cy.get("#date-range").click()
+        cy.get("#date-range-today").click()
+
+        cy.get("#custom-date-range").click()
+        cy.get("#date-from").click().type("2022-01-01")
+        cy.get("#date-to").click().type("2022-12-31")
+
+        cy.get(".govuk-heading-s").contains("Date range").should("not.exist")
+        cy.get(".moj-filter__tag").contains("Today").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Custom date range").should("exist")
+        cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("exist")
+      })
     })
 
     describe("Custom Date range", () => {
@@ -123,6 +138,24 @@ describe("Case list", () => {
 
         cy.get(".govuk-heading-m").contains("Applied filters").should("exist")
         confirmFiltersAppliedContains("01/01/2022 - 31/12/2022")
+      })
+
+      it.only("Should remove custom date range filter chip when custom date filter is selected", () => {
+        cy.get("button#filter-button").click()
+        cy.get("#custom-date-range").click()
+        cy.get("#date-from").click().type("2022-01-01")
+        cy.get("#date-to").click().type("2022-12-31")
+        cy.get(".govuk-heading-m").contains("Selected filters").should("exist")
+        cy.get(".govuk-heading-s").contains("Custom date range").should("exist")
+        cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022")
+
+        cy.get("#date-range").click()
+        cy.get("#date-range-today").click()
+
+        cy.get(".govuk-heading-s").contains("Custom date range").should("not.exist")
+        cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("not.exist")
+        cy.get(".govuk-heading-s").contains("Date range").should("exist")
+        cy.get(".moj-filter__tag").contains("Today").should("exist")
       })
 
       it.skip("Should apply the 'Custom date filter' filter chips then remove this chips to the original state", () => {

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -6,6 +6,11 @@ export function removeFilterChip() {
   cy.get(".moj-filter__tag").should("not.exist")
 }
 
+function filterByDateRange(dateRangeId: string) {
+  cy.get("#date-range").click()
+  cy.get(dateRangeId).click()
+}
+
 describe("Case list", () => {
   context("When filters applied", () => {
     before(() => {
@@ -97,8 +102,7 @@ describe("Case list", () => {
       it("Should allow you to add 'today' as the date range filter chip", () => {
         // Shows filters and clicks date range followed by today's date
         cy.get("#filter-button").click()
-        cy.get("#date-range").click()
-        cy.get("#date-range-today").click()
+        filterByDateRange("#date-range-today")
 
         // Shows the correct heading 'Today' and checks that the others are not visible
         cy.get(".govuk-heading-s").contains("Date range").should("exist")
@@ -111,8 +115,7 @@ describe("Case list", () => {
 
       it("Should remove the date range filter chip when custom date range is selected", () => {
         cy.get("#filter-button").click()
-        cy.get("#date-range").click()
-        cy.get("#date-range-today").click()
+        filterByDateRange("#date-range-today")
 
         cy.get("#custom-date-range").click()
         cy.get("#date-from").click().type("2022-01-01")
@@ -149,8 +152,7 @@ describe("Case list", () => {
         cy.get(".govuk-heading-s").contains("Custom date range").should("exist")
         cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022")
 
-        cy.get("#date-range").click()
-        cy.get("#date-range-today").click()
+        filterByDateRange("#date-range-today")
 
         cy.get(".govuk-heading-s").contains("Custom date range").should("not.exist")
         cy.get(".moj-filter__tag").contains("01/01/2022 - 31/12/2022").should("not.exist")
@@ -297,8 +299,8 @@ describe("Case list", () => {
         // Open filters and build filter chip query
         cy.get("#filter-button").click()
         cy.get(".govuk-checkboxes__item").contains("Triggers").click()
-        cy.get("#date-range").click()
-        cy.get("#date-range-last-week").click()
+
+        filterByDateRange("#date-range-last-week")
         cy.get("#non-urgent").click()
 
         // Check that relevant chips and headers are present on screen

--- a/src/components/CustomDateInput/DateInput.tsx
+++ b/src/components/CustomDateInput/DateInput.tsx
@@ -4,10 +4,10 @@ import { FilterAction } from "types/CourtCaseFilter"
 interface Props {
   dateType: "from" | "to"
   dispatch: Dispatch<FilterAction>
-  defaultValue: string
+  value: string
 }
 
-const DateInput: React.FC<Props> = ({ dateType, dispatch, defaultValue }: Props) => {
+const DateInput: React.FC<Props> = ({ dateType, dispatch, value }: Props) => {
   const actionType = dateType === "from" ? "customDateFrom" : "customDateTo"
   return (
     <div className="govuk-form-group">
@@ -19,7 +19,7 @@ const DateInput: React.FC<Props> = ({ dateType, dispatch, defaultValue }: Props)
         type="date"
         id={`date-${dateType}`}
         name={dateType}
-        defaultValue={defaultValue}
+        value={value}
         onChange={(event) => {
           if (Date.parse(event.target.value)) {
             dispatch({ method: "add", type: actionType, value: new Date(Date.parse(event.target.value)) })

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -80,8 +80,8 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
         />
         <div className="govuk-radios__conditional" id="conditional-custom-date-range">
           <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
-            <DateInput dateType="from" dispatch={dispatch} defaultValue={defaultDateValue(customDateFrom)} />
-            <DateInput dateType="to" dispatch={dispatch} defaultValue={defaultDateValue(customDateTo)} />
+            <DateInput dateType="from" dispatch={dispatch} value={defaultDateValue(customDateFrom)} />
+            <DateInput dateType="to" dispatch={dispatch} value={defaultDateValue(customDateTo)} />
           </div>
         </div>
       </div>

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -6,6 +6,7 @@ import type { FilterAction } from "types/CourtCaseFilter"
 import type { Dispatch } from "react"
 import DateInput from "components/CustomDateInput/DateInput"
 import { displayedDateFormat } from "utils/formattedDate"
+import getCustomDateRangeLabel from "utils/getCustomDateRangeLabel"
 
 interface Props {
   dateRange?: string | null
@@ -37,10 +38,6 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
     return ""
   }
 
-  const customDateRangeLabel = hasCustomDateRange
-    ? `${format(customDateFrom, displayedDateFormat)} - ${format(customDateTo, displayedDateFormat)}`
-    : ""
-
   return (
     <fieldset className="govuk-fieldset">
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
@@ -62,7 +59,11 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
                 value={namedDateRange}
                 label={labelForDateRange(namedDateRange)}
                 onChange={(event) => {
-                  dispatch({ method: "remove", type: "customDate", value: customDateRangeLabel })
+                  dispatch({
+                    method: "remove",
+                    type: "customDate",
+                    value: getCustomDateRangeLabel(customDateFrom, customDateTo)
+                  })
                   dispatch({ method: "add", type: "date", value: event.target.value })
                 }}
               />

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -37,6 +37,10 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
     return ""
   }
 
+  const customDateRangeLabel = hasCustomDateRange
+    ? `${format(customDateFrom, displayedDateFormat)} - ${format(customDateTo, displayedDateFormat)}`
+    : ""
+
   return (
     <fieldset className="govuk-fieldset">
       <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
@@ -57,7 +61,10 @@ const CourtDateFilterOptions: React.FC<Props> = ({ dateRange, dispatch, customDa
                 checked={dateRange === namedDateRange}
                 value={namedDateRange}
                 label={labelForDateRange(namedDateRange)}
-                onChange={(event) => dispatch({ method: "add", type: "date", value: event.target.value })}
+                onChange={(event) => {
+                  dispatch({ method: "remove", type: "customDate", value: customDateRangeLabel })
+                  dispatch({ method: "add", type: "date", value: event.target.value })
+                }}
               />
             ))}
           </div>

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -11,8 +11,8 @@ import getCustomDateRangeLabel from "utils/getCustomDateRangeLabel"
 interface Props {
   dateRange?: string | null
   dispatch: Dispatch<FilterAction>
-  customDateFrom: Date | null
-  customDateTo: Date | null
+  customDateFrom: Date | undefined
+  customDateTo: Date | undefined
 }
 
 const formatNamedDateRange = (namedDateRange: string): string => {

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -261,8 +261,8 @@ const CourtCaseFilter: React.FC<Props> = ({
               <CourtDateFilterOptions
                 dateRange={state.dateFilter.value}
                 dispatch={dispatch}
-                customDateFrom={state.customDateFrom.value ?? null}
-                customDateTo={state.customDateTo.value ?? null}
+                customDateFrom={state.customDateFrom.value ?? undefined}
+                customDateTo={state.customDateTo.value ?? undefined}
               />
             </ExpandingFilters>
           </div>

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import FilterChip from "components/FilterChip"
 import ConditionalRender from "components/ConditionalRender"
-import { format } from "date-fns"
 import { Dispatch } from "react"
 import { Filter, FilterAction, FilterState } from "types/CourtCaseFilter"
 import { anyFilterChips } from "utils/filterChips"
-import { displayedDateFormat } from "utils/formattedDate"
 import FilterChipRow from "./FilterChipRow"
+import getCustomDateRangeLabel from "utils/getCustomDateRangeLabel"
 
 interface Props {
   state: Filter
@@ -23,13 +22,7 @@ const FilterChipSection: React.FC<Props> = ({
   marginTop,
   placeholderMessage
 }: Props) => {
-  const customDateRangeLabel =
-    !!state.customDateFrom.value && !!state.customDateTo.value
-      ? `${format(state.customDateFrom.value, displayedDateFormat)} - ${format(
-          state.customDateTo.value,
-          displayedDateFormat
-        )}`
-      : ""
+  const customDateRangeLabel = getCustomDateRangeLabel(state.customDateFrom.value, state.customDateTo.value)
   return (
     <>
       <ConditionalRender isRendered={anyFilterChips(state, sectionState)}>

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -9,7 +9,7 @@ export type FilterAction =
   | { method: FilterMethod; type: "date"; value: string }
   | { method: "add"; type: "customDateFrom"; value: Date }
   | { method: "add"; type: "customDateTo"; value: Date }
-  | { method: "remove"; type: "customDate"; value: Date }
+  | { method: "remove"; type: "customDate"; value: string }
   | { method: FilterMethod; type: "locked"; value: boolean }
   | { method: FilterMethod; type: "reason"; value: Reason }
   | { method: FilterMethod; type: "caseState"; value: CaseState }

--- a/src/utils/getCustomDateRangeLabel.ts
+++ b/src/utils/getCustomDateRangeLabel.ts
@@ -1,0 +1,10 @@
+import { displayedDateFormat } from "./formattedDate"
+import { format } from "date-fns"
+
+const getCustomDateRangeLabel = (customDateFromValue: Date | undefined, customDateToValue: Date | undefined) => {
+  return !!customDateFromValue && !!customDateToValue
+    ? `${format(customDateFromValue, displayedDateFormat)} - ${format(customDateToValue, displayedDateFormat)}`
+    : ""
+}
+
+export default getCustomDateRangeLabel


### PR DESCRIPTION
* add tests to replicate the behaviour in the ticket
* fix types for `customDateFrom` and `customDateTo`
* fix the bug
* create `getCustomDateRangeLabel()` helper function
* create `filterByDateRange()` and `filterByCustomDateRange()` helper functions for cypress
* replace `defaultValue` with `value` for `DateInput`