### PR TITLE
Bug fix: typing into court date fields

### DIFF
--- a/src/components/CustomDateInput/DateInput.tsx
+++ b/src/components/CustomDateInput/DateInput.tsx
@@ -19,7 +19,7 @@ const DateInput: React.FC<Props> = ({ dateType, dispatch, value }: Props) => {
         type="date"
         id={`date-${dateType}`}
         name={dateType}
-        value={value}
+        defaultValue={value}
         onChange={(event) => {
           if (Date.parse(event.target.value)) {
             dispatch({ method: "add", type: actionType, value: new Date(Date.parse(event.target.value)) })


### PR DESCRIPTION
Using the `value` instead of `defaultValue` on date input breaks the input fields when it comes to typing in a date