### PR TITLE
BICAWS-2712: 🐛  filter chips not removing on `cases allocated to me`

### DIFF
--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -392,9 +392,9 @@ describe("Case list", () => {
       })
     })
 
-    it("Should display the 'Locked to me' filter chip when selected", () => {
+    it.only("Should display the 'Locked to me' filter chip when selected", () => {
       cy.get("#filter-button").click()
-      cy.get(".govuk-checkboxes__item").contains("View cases allocated to me").click()
+      cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
 
       // Check if the correct heading and filter label are applied
       cy.get(".govuk-heading-s").contains("My cases").should("exist")
@@ -413,15 +413,15 @@ describe("Case list", () => {
       cy.get("#my-cases-filter").should("not.be.checked")
     })
 
-    it("Should apply the 'Locked to me' filter chips then remove this chips to the original state", () => {
+    it.only("Should apply the 'Locked to me' filter chips then remove this chips to the original state", () => {
       cy.get("#filter-button").click()
-      cy.get(".govuk-checkboxes__item").contains("View cases allocated to me").click()
+      cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
 
-      // Removal by clicking filter chip 
+      // Removal by clicking filter chip
       cy.get(".govuk-heading-s").contains("My cases").should("exist")
       cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist").trigger("click")
 
-      cy.get(".govuk-checkboxes__item").contains("View cases allocated to me").should("not.be.checked")
+      cy.get(".govuk-checkboxes__item").contains("View cases locked to me").should("not.be.checked")
     })
   })
 })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -417,6 +417,7 @@ describe("Case list", () => {
       cy.get("#filter-button").click()
       cy.get(".govuk-checkboxes__item").contains("View cases allocated to me").click()
 
+      // Removal by clicking filter chip 
       cy.get(".govuk-heading-s").contains("My cases").should("exist")
       cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist").trigger("click")
 

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -392,7 +392,7 @@ describe("Case list", () => {
       })
     })
 
-    it.only("Should display the 'Locked to me' filter chip when selected", () => {
+    it("Should display the 'Locked to me' filter chip when selected", () => {
       cy.get("#filter-button").click()
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
 
@@ -402,18 +402,18 @@ describe("Case list", () => {
 
       // Check if the filter chip is applied to the "Filters applied" section at the top of the case list
       cy.contains("Apply filters").click()
-      cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist")
+      cy.get(".moj-filter-tags").children().contains("Cases locked to me").should("exist")
       cy.get("#filter-button").contains("Show filter").click()
       cy.get("#my-cases-filter").should("be.checked")
 
-      // Clears filter chip and check the checkbox is deselected
+      // Clears filter chip using `Clear filters` button and check the checkbox is deselected
       cy.contains("Hide filter").click()
       cy.contains("Clear filters").click()
       cy.get("#filter-button").contains("Show filter").click()
       cy.get("#my-cases-filter").should("not.be.checked")
     })
 
-    it.only("Should apply the 'Locked to me' filter chips then remove this chips to the original state", () => {
+    it("Should select the 'Locked to me' filter chip then remove this chip to the original state", () => {
       cy.get("#filter-button").click()
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
 
@@ -422,6 +422,17 @@ describe("Case list", () => {
       cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist").trigger("click")
 
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").should("not.be.checked")
+    })
+    it.only("should remove applied `Locked to me` filter by clicking the filter chips ", () => {
+      //removal through filter panel
+      cy.get("#filter-button").click()
+      cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
+      cy.contains("Apply filters").click()
+      cy.get("#filter-button").click()
+      cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist").trigger("click")
+      cy.contains("Apply filters").click()
+
+      cy.get(".moj-filter-tags").children().contains("Cases locked to me").should("not.exist")
     })
   })
 })

--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -423,7 +423,7 @@ describe("Case list", () => {
 
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").should("not.be.checked")
     })
-    it.only("should remove applied `Locked to me` filter by clicking the filter chips ", () => {
+    it("should remove applied `Locked to me` filter by clicking the filter chips ", () => {
       //removal through filter panel
       cy.get("#filter-button").click()
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
@@ -432,7 +432,7 @@ describe("Case list", () => {
       cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist").trigger("click")
       cy.contains("Apply filters").click()
 
-      cy.get(".moj-filter-tags").children().contains("Cases locked to me").should("not.exist")
+      cy.contains("Cases locked to me").should("not.exist")
     })
   })
 })

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -290,7 +290,7 @@ const CourtCaseFilter: React.FC<Props> = ({
                     name="myCases"
                     type="checkbox"
                     value={"true"}
-                    checked={state.myCasesFilter.value}
+                    checked={!!state.myCasesFilter.value}
                     onChange={(event: ChangeEvent<HTMLInputElement>) => {
                       dispatch({
                         method: "add",

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -300,7 +300,7 @@ const CourtCaseFilter: React.FC<Props> = ({
                     }}
                   ></input>
                   <label className="govuk-label govuk-checkboxes__label" htmlFor="my-cases-filter">
-                    {"View cases allocated to me"}
+                    {"View cases locked to me"}
                   </label>
                 </div>
               </div>


### PR DESCRIPTION
Bug fix to remove query params from by removing the `cases locked to me` filter chip from the filter panel. 

Co-authored-by: joe-fol <joe.folkard@madetech.com>