### PR TITLE
Bicaws 2709 hide pagination

### DIFF
--- a/cypress/e2e/filter/filterChips.cy.ts
+++ b/cypress/e2e/filter/filterChips.cy.ts
@@ -423,6 +423,7 @@ describe("Case list", () => {
 
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").should("not.be.checked")
     })
+
     it("should remove applied `Locked to me` filter by clicking the filter chips ", () => {
       //removal through filter panel
       cy.get("#filter-button").click()
@@ -436,5 +437,3 @@ describe("Case list", () => {
     })
   })
 })
-
-export {}

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -56,11 +56,12 @@ describe("Case list", () => {
       cy.findByText("There are no court cases to show").should("exist")
     })
 
-    it("should not show pagination buttons when there are 0 cases", () => {
+    it.only("should not show pagination buttons when there are 0 cases", () => {
       loginAndGoToUrl()
 
       cy.findByText("Previous page").should("not.exist")
       cy.findByText("Next page").should("not.exist")
+      cy.get("#bottom-pagination-bar").should("not.exist")
     })
 
     it("should be accessible", () => {

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -64,6 +64,28 @@ describe("Case list", () => {
       cy.get("#bottom-pagination-bar").should("not.be.visible")
     })
 
+    it.only("should display 0 cases when there are no cases 'locked to me' and hide the bottom pagination bar ", () => {
+      const lockUsernames = ["Bichard02", "Bichard03", null, "A really really really long name"]
+      cy.task(
+        "insertCourtCasesWithFields",
+        lockUsernames.map((username) => ({
+          errorLockedByUsername: username,
+          triggerLockedByUsername: username,
+          orgForPoliceFilter: "011111"
+        }))
+      )
+
+      loginAndGoToUrl()
+
+      cy.get("#filter-button").click()
+      cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
+      cy.contains("Apply filters").click()
+
+      cy.findByText("Previous page").should("not.exist")
+      cy.findByText("Next page").should("not.exist")
+      cy.get("#bottom-pagination-bar").should("not.be.visible")
+    })
+
     it("should be accessible", () => {
       loginAndGoToUrl()
       cy.injectAxe()

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -56,12 +56,12 @@ describe("Case list", () => {
       cy.findByText("There are no court cases to show").should("exist")
     })
 
-    it.only("should not show pagination buttons when there are 0 cases", () => {
+    it("should not show pagination buttons when there are 0 cases", () => {
       loginAndGoToUrl()
 
       cy.findByText("Previous page").should("not.exist")
       cy.findByText("Next page").should("not.exist")
-      cy.get("#bottom-pagination-bar").should("not.exist")
+      cy.get("#bottom-pagination-bar").should("not.be.visible")
     })
 
     it("should be accessible", () => {

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -64,7 +64,7 @@ describe("Case list", () => {
       cy.get("#bottom-pagination-bar").should("not.be.visible")
     })
 
-    it.only("should display 0 cases when there are no cases 'locked to me' and hide the bottom pagination bar ", () => {
+    it("should display 0 cases when there are no cases 'locked to me' and hide the bottom pagination bar ", () => {
       const lockUsernames = ["Bichard02", "Bichard03", null, "A really really really long name"]
       cy.task(
         "insertCourtCasesWithFields",

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -24,7 +24,7 @@ const Pagination: React.FC<Props> = ({ pageNum, casesPerPage, totalCases, name }
   const classes = useStyles()
 
   return (
-    <div className={classes["pagination-bar"]}>
+    <div id={`${name}-pagination-bar`} className={classes["pagination-bar"]}>
       <PaginationResults pageNum={pageNum} casesPerPage={casesPerPage} totalCases={totalCases} />
       <CasesPerPage pageNum={pageNum} casesPerPage={casesPerPage} options={[10, 25, 50, 100]} selected={casesPerPage} />
       <PaginationNavigation pageNum={pageNum} totalPages={Math.ceil(totalCases / casesPerPage)} name={name} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import ConditionalDisplay from "components/ConditionalDisplay"
 import Layout from "components/Layout"
 import Pagination from "components/Pagination"
 import AppliedFilters from "features/CourtCaseFilters/AppliedFilters"
@@ -15,7 +16,7 @@ import getDataSource from "services/getDataSource"
 import listCourtCases from "services/listCourtCases"
 import unlockCourtCase from "services/unlockCourtCase"
 import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
-import { CaseState, Reason, QueryOrder, Urgency } from "types/CaseListQueryParams"
+import { CaseState, QueryOrder, Reason, Urgency } from "types/CaseListQueryParams"
 import { isError } from "types/Result"
 import caseStateFilters from "utils/caseStateFilters"
 import { isPost } from "utils/http"
@@ -223,7 +224,9 @@ const Home: NextPage<Props> = ({
         courtCaseList={<CourtCaseList courtCases={courtCases} order={order} currentUser={user} />}
         paginationTop={<Pagination pageNum={page} casesPerPage={casesPerPage} totalCases={totalCases} name="top" />}
         paginationBottom={
-          <Pagination pageNum={page} casesPerPage={casesPerPage} totalCases={totalCases} name="bottom" />
+          <ConditionalDisplay isDisplayed={courtCases.length > 0}>
+            <Pagination pageNum={page} casesPerPage={casesPerPage} totalCases={totalCases} name="bottom" />
+          </ConditionalDisplay>
         }
       />
     </Layout>


### PR DESCRIPTION
This PR hides the bottom pagination bar when there are 0 cases in Bichard:

- Added an ID to the pagination component to target easier in cypress
- Added some test coverage for when there is no cases and if your filter and there are no cases in that particular scenario 
