### PR TITLE
Bug fix typing into date fields

### DIFF
--- a/src/components/CustomDateInput/DateInput.tsx
+++ b/src/components/CustomDateInput/DateInput.tsx
@@ -21,9 +21,7 @@ const DateInput: React.FC<Props> = ({ dateType, dispatch, value }: Props) => {
         name={dateType}
         value={value}
         onChange={(event) => {
-          if (Date.parse(event.target.value)) {
-            dispatch({ method: "add", type: actionType, value: new Date(Date.parse(event.target.value)) })
-          }
+          dispatch({ method: "add", type: actionType, value: event.target.value })
         }}
       />
     </div>

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -1,4 +1,3 @@
-import { format, parse } from "date-fns"
 import { CaseAgeOptions } from "utils/caseAgeOptions"
 import { mapCaseAges } from "utils/validators/validateCaseAges"
 import RadioButton from "components/RadioButton/RadioButton"
@@ -52,8 +51,7 @@ const caseAgeId = (caseAge: string): string => `case-age-${caseAge.toLowerCase()
 
 const CourtDateFilterOptions: React.FC<Props> = ({ caseAges, caseAgeCounts, dispatch, dateRange }: Props) => {
   const classes = useStyles()
-  const defaultDateValue = (dateString?: string | null): string =>
-    !!dateString ? format(parse(dateString, "dd/MM/yyyy", new Date()), "yyyy-MM-dd") : ""
+  const defaultDateValue = (dateString?: string | null): string => (!!dateString ? dateString : "")
 
   return (
     <fieldset className="govuk-fieldset">
@@ -62,7 +60,7 @@ const CourtDateFilterOptions: React.FC<Props> = ({ caseAges, caseAgeCounts, disp
           name={"courtDate"}
           id={"date-range"}
           dataAriaControls={"conditional-date-range"}
-          defaultChecked={!!dateRange}
+          defaultChecked={!!dateRange?.from && !!dateRange.to}
           label={"Date range"}
           onChange={(event) => dispatch({ method: "remove", type: "caseAge", value: event.target.value as string })}
         />

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -51,7 +51,6 @@ const caseAgeId = (caseAge: string): string => `case-age-${caseAge.toLowerCase()
 
 const CourtDateFilterOptions: React.FC<Props> = ({ caseAges, caseAgeCounts, dispatch, dateRange }: Props) => {
   const classes = useStyles()
-  const defaultDateValue = (dateString?: string | null): string => (!!dateString ? dateString : "")
 
   return (
     <fieldset className="govuk-fieldset">
@@ -66,8 +65,8 @@ const CourtDateFilterOptions: React.FC<Props> = ({ caseAges, caseAgeCounts, disp
         />
         <div className="govuk-radios__conditional" id="conditional-date-range">
           <div className="govuk-radios govuk-radios--small" data-module="govuk-radios">
-            <DateInput dateType="from" dispatch={dispatch} value={defaultDateValue(dateRange?.from)} />
-            <DateInput dateType="to" dispatch={dispatch} value={defaultDateValue(dateRange?.to)} />
+            <DateInput dateType="from" dispatch={dispatch} value={dateRange?.from ?? ""} />
+            <DateInput dateType="to" dispatch={dispatch} value={dateRange?.to ?? ""} />
           </div>
         </div>
         <RadioButton

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -5,6 +5,7 @@ import { encode } from "querystring"
 import { Reason, SerializedCourtDateRange } from "types/CaseListQueryParams"
 import { caseStateLabels } from "utils/caseStateFilters"
 import { deleteQueryParam, deleteQueryParamsByName } from "utils/deleteQueryParam"
+import { formatStringDateAsDisplayedDate } from "utils/formattedDate"
 
 interface Props {
   filters: {
@@ -107,7 +108,9 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
           <ConditionalRender isRendered={!!filters.dateRange?.from && !!filters.dateRange.to}>
             <li>
               <FilterTag
-                tag={`${filters.dateRange?.from} - ${filters.dateRange?.to}`}
+                tag={`${formatStringDateAsDisplayedDate(filters.dateRange?.from)} - ${formatStringDateAsDisplayedDate(
+                  filters.dateRange?.to
+                )}`}
                 href={removeQueryParamsByName(["from", "to", "pageNum"])}
               />
             </li>

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -12,7 +12,6 @@ import { anyFilterChips } from "utils/filterChips"
 import CourtDateFilterOptions from "../../components/FilterOptions/CourtDateFilterOptions"
 import ExpandingFilters from "./ExpandingFilters"
 import FilterChipSection from "./FilterChipSection"
-import { formatDisplayedDate } from "utils/formattedDate"
 import KeyValuePair from "types/KeyValuePair"
 
 interface Props {
@@ -42,10 +41,10 @@ const reducer = (state: Filter, action: FilterAction): Filter => {
         newState.caseAgeFilter.push({ value: action.value as string, state: "Selected" })
       }
     } else if (action.type === "dateFrom") {
-      newState.dateFrom.value = formatDisplayedDate(action.value)
+      newState.dateFrom.value = action.value
       newState.dateFrom.state = "Selected"
     } else if (action.type === "dateTo") {
-      newState.dateTo.value = formatDisplayedDate(action.value)
+      newState.dateTo.value = action.value
       newState.dateTo.state = "Selected"
     } else if (action.type === "caseState") {
       newState.caseStateFilter.value = action.value
@@ -269,11 +268,7 @@ const CourtCaseFilter: React.FC<Props> = ({
                 caseAges={state.caseAgeFilter.map((slaDate) => slaDate.value as string)}
                 caseAgeCounts={caseAgeCounts}
                 dispatch={dispatch}
-                dateRange={
-                  state.dateFrom.value && state.dateTo.value
-                    ? { from: state.dateFrom.value, to: state.dateTo.value }
-                    : undefined
-                }
+                dateRange={{ from: state.dateFrom.value, to: state.dateTo.value }}
               />
             </ExpandingFilters>
           </div>

--- a/src/features/CourtCaseFilters/FilterChipSection.tsx
+++ b/src/features/CourtCaseFilters/FilterChipSection.tsx
@@ -5,6 +5,7 @@ import { Dispatch } from "react"
 import { Filter, FilterAction, FilterState } from "types/CourtCaseFilter"
 import { anyFilterChips } from "utils/filterChips"
 import FilterChipRow from "./FilterChipRow"
+import { formatStringDateAsDisplayedDate } from "utils/formattedDate"
 
 interface Props {
   state: Filter
@@ -21,7 +22,9 @@ const FilterChipSection: React.FC<Props> = ({
   marginTop,
   placeholderMessage
 }: Props) => {
-  const dateRangeLabel = `${state.dateFrom.value} - ${state.dateTo.value}`
+  const dateRangeLabel = `${formatStringDateAsDisplayedDate(state.dateFrom.value)} - ${formatStringDateAsDisplayedDate(
+    state.dateTo.value
+  )}`
   return (
     <>
       <ConditionalRender isRendered={anyFilterChips(state, sectionState)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,8 +27,8 @@ import { validateDateRange } from "utils/validators/validateDateRange"
 import { mapCaseAges } from "utils/validators/validateCaseAges"
 import { mapLockFilter } from "utils/validators/validateLockFilter"
 import { validateQueryParams } from "utils/validators/validateQueryParams"
-import { formatDisplayedDate } from "utils/formattedDate"
 import KeyValuePair from "types/KeyValuePair"
+import { formatFormInputDateString } from "utils/formattedDate"
 
 interface Props {
   user: User
@@ -167,8 +167,8 @@ export const getServerSideProps = withMultipleServerSideProps(
         caseAge: caseAges,
         dateRange: validatedDateRange
           ? {
-              from: formatDisplayedDate(validatedDateRange.from),
-              to: formatDisplayedDate(validatedDateRange.to)
+              from: formatFormInputDateString(validatedDateRange.from),
+              to: formatFormInputDateString(validatedDateRange.to)
             }
           : null,
         caseAgeCounts: caseAgeCounts,

--- a/src/services/getCountOfCasesByCaseAge.ts
+++ b/src/services/getCountOfCasesByCaseAge.ts
@@ -1,9 +1,9 @@
-import { format } from "date-fns"
 import { DataSource, IsNull, SelectQueryBuilder } from "typeorm"
 import KeyValuePair from "types/KeyValuePair"
 import PromiseResult from "types/PromiseResult"
 import { isError } from "types/Result"
 import { CaseAgeOptions } from "utils/caseAgeOptions"
+import { formatFormInputDateString } from "utils/formattedDate"
 import CourtCase from "./entities/CourtCase"
 import courtCasesByVisibleForcesQuery from "./queries/courtCasesByVisibleForcesQuery"
 
@@ -19,8 +19,8 @@ const getCountOfCasesByCaseAge = async (
 
   Object.keys(CaseAgeOptions).forEach((slaCaseAgeOption, i) => {
     const key = asKey(slaCaseAgeOption)
-    const slaDateFrom = format(CaseAgeOptions[slaCaseAgeOption]().from, "yyyy-MM-dd")
-    const slaDateTo = format(CaseAgeOptions[slaCaseAgeOption]().to, "yyyy-MM-dd")
+    const slaDateFrom = formatFormInputDateString(CaseAgeOptions[slaCaseAgeOption]().from)
+    const slaDateTo = formatFormInputDateString(CaseAgeOptions[slaCaseAgeOption]().to)
 
     const subQuery = repository
       .createQueryBuilder(key)

--- a/src/types/CaseListQueryParams.ts
+++ b/src/types/CaseListQueryParams.ts
@@ -8,8 +8,8 @@ export type CourtDateRange = {
 }
 
 export type SerializedCourtDateRange = {
-  from: string
-  to: string
+  from?: string
+  to?: string
 }
 
 export type CaseState = "Resolved" | "Unresolved and resolved" | undefined

--- a/src/types/CourtCaseFilter.ts
+++ b/src/types/CourtCaseFilter.ts
@@ -7,8 +7,8 @@ export type FilterAction =
   | { method: FilterMethod; type: "ptiurn"; value: string }
   | { method: FilterMethod; type: "urgency"; value: boolean }
   | { method: FilterMethod; type: "caseAge"; value: string }
-  | { method: "add"; type: "dateFrom"; value: Date }
-  | { method: "add"; type: "dateTo"; value: Date }
+  | { method: "add"; type: "dateFrom"; value: string }
+  | { method: "add"; type: "dateTo"; value: string }
   | { method: "remove"; type: "dateRange"; value: string }
   | { method: FilterMethod; type: "locked"; value: boolean }
   | { method: FilterMethod; type: "reason"; value: Reason }

--- a/src/utils/formattedDate.test.ts
+++ b/src/utils/formattedDate.test.ts
@@ -1,0 +1,33 @@
+import { formatDisplayedDate, formatFormInputDateString, formatStringDateAsDisplayedDate } from "./formattedDate"
+
+describe("formatDisplayedDate", () => {
+  it("can format a date in 'dd/MM/yyyy' format", () => {
+    expect(formatDisplayedDate(new Date("2023-01-01"))).toStrictEqual("01/01/2023")
+  })
+
+  it("can handle when users enter an invalid date", () => {
+    expect(formatDisplayedDate(new Date("202344444-01-01"))).toStrictEqual("")
+  })
+})
+
+describe("formatFormInputDateString", () => {
+  it("can format a date in '2023-01-01' format", () => {
+    expect(formatFormInputDateString(new Date("01/01/2023"))).toStrictEqual("2023-01-01")
+  })
+
+  it("can handle when users enter an invalid date", () => {
+    expect(formatFormInputDateString(new Date("202344444-01-01"))).toStrictEqual("")
+  })
+})
+
+describe("formatStringDateAsDisplayedDate", () => {
+  it("can convert date string 'yyyy-MM-dd' to 'dd/MM/yyyy'", () => {
+    expect(formatStringDateAsDisplayedDate("2023-01-01")).toStrictEqual("01/01/2023")
+  })
+
+  it("can handle when users enter an invalid date string", () => {
+    expect(formatStringDateAsDisplayedDate("202344444-01-01")).toStrictEqual("")
+    expect(formatStringDateAsDisplayedDate("01/01/2023")).toStrictEqual("")
+    expect(formatStringDateAsDisplayedDate("Invalid date")).toStrictEqual("")
+  })
+})

--- a/src/utils/formattedDate.ts
+++ b/src/utils/formattedDate.ts
@@ -1,5 +1,15 @@
-import { format } from "date-fns"
+import { format, isValid, parse } from "date-fns"
 
 export const displayedDateFormat = "dd/MM/yyyy"
 
-export const formatDisplayedDate = (date: Date) => format(date, displayedDateFormat)
+export const formInputDateFormat = "yyyy-MM-dd"
+
+export const formatDisplayedDate = (date: Date): string => (isValid(date) ? format(date, displayedDateFormat) : "")
+
+export const formatFormInputDateString = (date: Date): string =>
+  isValid(date) ? format(date, formInputDateFormat) : ""
+
+export const formatStringDateAsDisplayedDate = (dateString?: string | null): string => {
+  const dateStringAsDate = !!dateString && parse(dateString, formInputDateFormat, new Date())
+  return dateStringAsDate && isValid(dateStringAsDate) ? formatDisplayedDate(dateStringAsDate) : ""
+}


### PR DESCRIPTION
### Context
The date input fields were unusable with a keyboard because `on change` they are updating date ranges filter states:
A partially typed-in date range clears the date fields while typing because the component tried to parse the incomplete date range as a valid date range when rerendering the component.

### Changes
- Use string values for the date range `from` and `to` in the filter states, using the format `yyyy-MM-dd` that is used by the date input fields
- Format to the desired `dd/MM/yyyy` format where displayed to the users (filter chips)

### Limitation of cypress test
While I managed to test manually, and the issue was resolved, I couldn't find a better way of testing the keyboard input with cypress. Cypress only allows filling up the date input fields with a valid date, e.g `cy.get("#date-from").type("2022-01-01")` which wouldn't replicate the issue of having a partial date in an input field.  Is there a better way of testing this?