### PR TITLE
Clear teams tables when seeding cases

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress"
 import pgPromise from "pg-promise"
 import CourtCase from "./src/services/entities/CourtCase"
 import User from "./src/services/entities/User"
-import deleteFromTable from "./test/utils/deleteFromTable"
+import deleteFromEntity from "./test/utils/deleteFromEntity"
 import { getCourtCaseById } from "./test/utils/getCourtCaseById"
 import {
   insertCourtCasesWithFields,
@@ -60,7 +60,7 @@ export default defineConfig({
         },
 
         clearCourtCases() {
-          return deleteFromTable(CourtCase)
+          return deleteFromEntity(CourtCase)
         },
 
         insertUsers(params: { users: Partial<User>[]; userGroups?: string[] }) {

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -4,6 +4,7 @@ import Trigger from "../src/services/entities/Trigger"
 import Note from "../src/services/entities/Trigger"
 import getDataSource from "../src/services/getDataSource"
 import createDummyCase from "../test/helpers/createDummyCase"
+import deleteFromEntity from "../test/utils/deleteFromEntity"
 import deleteFromTable from "../test/utils/deleteFromTable"
 
 if (process.env.DEPLOY_NAME !== "e2e-test") {
@@ -22,9 +23,13 @@ const numCases = Math.round(Math.random() * numCasesRange) + minCases
 console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
 
 getDataSource().then(async (dataSource) => {
-  await deleteFromTable(CourtCase)
-  await deleteFromTable(Trigger)
-  await deleteFromTable(Note)
+  const entitiesToClear = [CourtCase, Trigger, Note]
+  entitiesToClear.forEach((entity) => deleteFromEntity(entity))
+
+  const tablesToClear = ["team_membership", "team_supervision", "team"]
+  tablesToClear.forEach(async (table) => {
+    await deleteFromTable(table)
+  })
 
   await Promise.all(
     new Array(numCases)

--- a/test/services/addNote.integration.test.ts
+++ b/test/services/addNote.integration.test.ts
@@ -3,7 +3,7 @@ import { DataSource } from "typeorm"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 import addNote from "../../src/services/addNote"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 import insertNotes from "services/insertNotes"
 
@@ -35,7 +35,7 @@ describe("addNote", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
     jest.resetAllMocks()
     jest.clearAllMocks()
   })

--- a/test/services/amendCourtCase.integration.test.ts
+++ b/test/services/amendCourtCase.integration.test.ts
@@ -8,7 +8,7 @@ import updateCourtCaseAho from "services/updateCourtCaseAho"
 import { DataSource } from "typeorm"
 import createForceOwner from "utils/createForceOwner"
 import getCourtCase from "../../src/services/getCourtCase"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 
 jest.mock("services/getCourtCase")
@@ -27,7 +27,7 @@ describe("amend court case", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
     jest.resetAllMocks()
     jest.clearAllMocks()
     ;(getCourtCase as jest.Mock).mockImplementation(jest.requireActual("services/getCourtCase").default)

--- a/test/services/courtCasesByVisibleForcesQuery.integration.test.ts
+++ b/test/services/courtCasesByVisibleForcesQuery.integration.test.ts
@@ -2,7 +2,7 @@ import CourtCase from "services/entities/CourtCase"
 import getDataSource from "services/getDataSource"
 import { DataSource, Repository, SelectQueryBuilder, UpdateQueryBuilder } from "typeorm"
 import { isError } from "types/Result"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 import courtCasesByVisibleForcesQuery from "../../src/services/queries/courtCasesByVisibleForcesQuery"
 
@@ -18,7 +18,7 @@ describe("courtCaseByVisibleForcesQuery", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
     repository = dataSource.getRepository(CourtCase)
     query = repository.createQueryBuilder("courtCase")
   })

--- a/test/services/getCountOfCasesByCaseAge.integration.test.ts
+++ b/test/services/getCountOfCasesByCaseAge.integration.test.ts
@@ -2,7 +2,7 @@
 import "reflect-metadata"
 import { DataSource, SelectQueryBuilder } from "typeorm"
 import MockDate from "mockdate"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 import { isError } from "../../src/types/Result"
 import CourtCase from "../../src/services/entities/CourtCase"
@@ -31,7 +31,7 @@ describe("listCourtCases", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/getCourtCase.integration.test.ts
+++ b/test/services/getCourtCase.integration.test.ts
@@ -2,7 +2,7 @@ import { DataSource } from "typeorm"
 import getDataSource from "../../src/services/getDataSource"
 import getCourtCase from "../../src/services/getCourtCase"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { isError } from "../../src/types/Result"
 import CourtCase from "../../src/services/entities/CourtCase"
 
@@ -16,7 +16,7 @@ describe("get court case", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/getCourtCaseByVisibleForce.integration.test.ts
+++ b/test/services/getCourtCaseByVisibleForce.integration.test.ts
@@ -3,7 +3,7 @@ import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 import getCourtCaseByVisibleForce from "../../src/services/getCourtCaseByVisibleForce"
 import { isError } from "../../src/types/Result"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 
 describe("getCourtCaseByVisibleForces", () => {
@@ -14,7 +14,7 @@ describe("getCourtCaseByVisibleForces", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/insertNotes.integration.test.ts
+++ b/test/services/insertNotes.integration.test.ts
@@ -2,7 +2,7 @@ import MockDate from "mockdate"
 import { DataSource } from "typeorm"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 import Note from "../../src/services/entities/Note"
 import insertNotes from "services/insertNotes"
@@ -35,7 +35,7 @@ describe("insertNote", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterEach(() => {

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -4,7 +4,7 @@ import { DataSource } from "typeorm"
 import courtCasesByVisibleForcesQuery from "services/queries/courtCasesByVisibleForcesQuery"
 import listCourtCases from "../../src/services/listCourtCases"
 import { ListCourtCaseResult } from "types/ListCourtCasesResult"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import {
   insertDummyCourtCasesWithNotes,
   insertDummyCourtCasesWithTriggers,
@@ -37,9 +37,9 @@ describe("listCourtCases", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
-    await deleteFromTable(Trigger)
-    await deleteFromTable(Note)
+    await deleteFromEntity(CourtCase)
+    await deleteFromEntity(Trigger)
+    await deleteFromEntity(Note)
   })
 
   afterAll(async () => {

--- a/test/services/resolveTrigger.integration.test.ts
+++ b/test/services/resolveTrigger.integration.test.ts
@@ -6,7 +6,7 @@ import Trigger from "../../src/services/entities/Trigger"
 import getCourtCaseByVisibleForce from "../../src/services/getCourtCaseByVisibleForce"
 import getDataSource from "../../src/services/getDataSource"
 import resolveTrigger from "../../src/services/resolveTrigger"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 import { insertTriggers, TestTrigger } from "../utils/manageTriggers"
 
@@ -20,7 +20,7 @@ describe("resolveTrigger", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/resubmitCourtCase.integration.test.ts
+++ b/test/services/resubmitCourtCase.integration.test.ts
@@ -8,7 +8,7 @@ import sendToQueue from "services/mq/sendToQueue"
 import { resubmitCourtCase } from "services/resubmitCourtCase"
 import { DataSource } from "typeorm"
 import offenceSequenceException from "../test-data/HO100302_1.json"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 
 jest.mock("services/mq/sendToQueue")
@@ -25,7 +25,7 @@ describe("resubmit court case", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
     jest.resetAllMocks()
     jest.clearAllMocks()
   })

--- a/test/services/tryToLockCourtCase.integration.test.ts
+++ b/test/services/tryToLockCourtCase.integration.test.ts
@@ -5,7 +5,7 @@ import getCourtCaseByVisibleForce from "../../src/services/getCourtCaseByVisible
 import getDataSource from "../../src/services/getDataSource"
 import tryToLockCourtCase from "../../src/services/tryToLockCourtCase"
 import { isError } from "../../src/types/Result"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 
 describe("lock court case", () => {
@@ -16,7 +16,7 @@ describe("lock court case", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/unlockCourtCase.integration.test.ts
+++ b/test/services/unlockCourtCase.integration.test.ts
@@ -4,7 +4,7 @@ import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 import unlockCourtCase from "../../src/services/unlockCourtCase"
 import { isError } from "../../src/types/Result"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases, insertCourtCasesWithFields } from "../utils/insertCourtCases"
 
 describe("lock court case", () => {
@@ -15,7 +15,7 @@ describe("lock court case", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterEach(() => {

--- a/test/services/updateCourtCaseAho.integration.test.ts
+++ b/test/services/updateCourtCaseAho.integration.test.ts
@@ -2,7 +2,7 @@ import { DataSource, UpdateResult } from "typeorm"
 import getDataSource from "../../src/services/getDataSource"
 import updateCourtCaseAho from "../../src/services/updateCourtCaseAho"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { isError } from "../../src/types/Result"
 import CourtCase from "../../src/services/entities/CourtCase"
 
@@ -16,7 +16,7 @@ describe("update court case updated hearing outcome", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterAll(async () => {

--- a/test/services/updateCourtCaseStatus.integration.test.ts
+++ b/test/services/updateCourtCaseStatus.integration.test.ts
@@ -1,7 +1,7 @@
 import { DataSource, UpdateResult } from "typeorm"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
-import deleteFromTable from "../utils/deleteFromTable"
+import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
 import updateCourtCaseStatus from "services/updateCourtCaseStatus"
 import { isError } from "services/mq/types/Result"
@@ -52,7 +52,7 @@ describe("updateCourtCaseStatus", () => {
   })
 
   beforeEach(async () => {
-    await deleteFromTable(CourtCase)
+    await deleteFromEntity(CourtCase)
   })
 
   afterEach(() => {

--- a/test/utils/deleteFromEntity.ts
+++ b/test/utils/deleteFromEntity.ts
@@ -1,0 +1,10 @@
+import getDataSource from "../../src/services/getDataSource"
+import { EntityTarget, ObjectLiteral } from "typeorm"
+
+const deleteFromEntity = async (entity: EntityTarget<ObjectLiteral>) => {
+  const dataSource = await getDataSource()
+
+  return dataSource.getRepository(entity).createQueryBuilder().delete().execute()
+}
+
+export default deleteFromEntity

--- a/test/utils/deleteFromTable.ts
+++ b/test/utils/deleteFromTable.ts
@@ -1,10 +1,8 @@
 import getDataSource from "../../src/services/getDataSource"
-import { EntityTarget, ObjectLiteral } from "typeorm"
 
-const deleteFromTable = async (entity: EntityTarget<ObjectLiteral>) => {
+const deleteFromTable = async (tableName: string) => {
   const dataSource = await getDataSource()
-
-  return dataSource.getRepository(entity).createQueryBuilder().delete().execute()
+  await dataSource.query(`TRUNCATE TABLE br7own.${tableName} CASCADE;`)
 }
 
 export default deleteFromTable


### PR DESCRIPTION
The teams tables have been causing issues with access to old bichard for some test users

Changes:
* Renamed `deleteFromTable` to `deleteFromEntity`
* Added `deleteFromTable` util function which clears a given table name
* Clear the teams related tables when seeding cases