### PR TITLE
Triggers contextual help box

### DIFF
--- a/cypress/component/NotePreview.cy.tsx
+++ b/cypress/component/NotePreview.cy.tsx
@@ -1,19 +1,5 @@
 import Note from "services/entities/Note"
 import { NotePreview } from "../../src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton"
-import PreviewButton from "../../src/components/PreviewButton"
-
-describe("NotePreviewButton", () => {
-  it("shows the default down chevron with the label 'preview'", () => {
-    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={true} />)
-    cy.get(".govuk-accordion-nav__chevron--down").should("exist")
-    cy.get(".govuk-accordion-nav__chevron").should("exist")
-  })
-
-  it("shows the default up chevron with the label 'hide'", () => {
-    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={false} />)
-    cy.get(".govuk-accordion-nav__chevron").should("exist")
-  })
-})
 
 describe("NotePreview", () => {
   it("should show the full text when note length is 100 characters", () => {

--- a/cypress/component/NotePreview.cy.tsx
+++ b/cypress/component/NotePreview.cy.tsx
@@ -1,16 +1,16 @@
 import Note from "services/entities/Note"
 import { NotePreview } from "../../src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton"
-import { HideButton, PreviewButton } from "../../src/components/PreviewButton"
+import PreviewButton from "../../src/components/PreviewButton"
 
 describe("NotePreviewButton", () => {
   it("shows the default down chevron with the label 'preview'", () => {
-    cy.mount(<PreviewButton />)
+    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={true} />)
     cy.get(".govuk-accordion-nav__chevron--down").should("exist")
     cy.get(".govuk-accordion-nav__chevron").should("exist")
   })
 
   it("shows the default up chevron with the label 'hide'", () => {
-    cy.mount(<HideButton />)
+    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={false} />)
     cy.get(".govuk-accordion-nav__chevron").should("exist")
   })
 })

--- a/cypress/component/NotePreview.cy.tsx
+++ b/cypress/component/NotePreview.cy.tsx
@@ -1,9 +1,6 @@
 import Note from "services/entities/Note"
-import {
-  HideButton,
-  PreviewButton,
-  NotePreview
-} from "../../src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton"
+import { NotePreview } from "../../src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton"
+import { HideButton, PreviewButton } from "../../src/components/PreviewButton"
 
 describe("NotePreviewButton", () => {
   it("shows the default down chevron with the label 'preview'", () => {

--- a/cypress/component/PreviewButton.cy.tsx
+++ b/cypress/component/PreviewButton.cy.tsx
@@ -1,0 +1,16 @@
+import PreviewButton from "../../src/components/PreviewButton"
+
+describe("PreviewButton", () => {
+  it("shows the preview button with a down pointing chevron when hidden", () => {
+    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={true} />)
+    cy.get(".govuk-accordion-nav__chevron--down").should("exist")
+    cy.get(".govuk-accordion-nav__chevron").should("exist")
+    cy.get(".govuk-accordion__show-all-text").should("have.text", "Preview")
+  })
+
+  it("shows the preview button with an up pointing chevron when expanded", () => {
+    cy.mount(<PreviewButton previewLabel="Preview" onClick={() => {}} showPreview={false} />)
+    cy.get(".govuk-accordion-nav__chevron").should("exist")
+    cy.get(".govuk-accordion__show-all-text").should("have.text", "Hide")
+  })
+})

--- a/cypress/e2e/court-cases/caseDetails.cy.ts
+++ b/cypress/e2e/court-cases/caseDetails.cy.ts
@@ -632,7 +632,7 @@ describe("Case details", () => {
     cy.get("h3").should("have.text", "Case information")
   })
 
-  it.only("should show contextual help for a trigger when the accordion button is clicked", () => {
+  it("should show contextual help for a trigger when the accordion button is clicked", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
     const trigger: TestTrigger = {
       triggerId: 0,

--- a/cypress/e2e/court-cases/caseDetails.cy.ts
+++ b/cypress/e2e/court-cases/caseDetails.cy.ts
@@ -631,6 +631,46 @@ describe("Case details", () => {
       .click()
     cy.get("h3").should("have.text", "Case information")
   })
+
+  it.only("should show contextual help for a trigger when the accordion button is clicked", () => {
+    cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
+    const trigger: TestTrigger = {
+      triggerId: 0,
+      triggerCode: "TRPR0001",
+      status: "Unresolved",
+      createdAt: new Date()
+    }
+    cy.task("insertTriggers", { caseId: 0, triggers: [trigger] })
+
+    cy.login("bichard01@example.com", "password")
+    cy.visit("/bichard/court-cases/0")
+
+    cy.get(".triggers-help-preview").should("have.text", "More information")
+    cy.get(".triggers-help-preview").click()
+
+    cy.get(".triggers-help-preview").should("have.text", "Hide")
+    cy.get(".triggers-help h3").should("contain.text", "PNC screen to update")
+    cy.get(".triggers-help p").should("have.text", "Driver Disqualification")
+    cy.get(".triggers-help h3").should("contain.text", "CJS result code")
+    cy.get(".triggers-help li").should("contain.text", "3028 Disqualification limited to")
+    cy.get(".triggers-help li").should("contain.text", "3030 Driving license restored with effect from")
+    cy.get(".triggers-help li").should(
+      "contain.text",
+      "3050 Reduced Disqualification from Driving after Completing Course"
+    )
+    cy.get(".triggers-help li").should(
+      "contain.text",
+      "3051 Reduced Disqualification from Driving - special reasons or mitigating circumstances"
+    )
+    cy.get(".triggers-help li").should("contain.text", "3070 Disqualified from Driving - Obligatory")
+    cy.get(".triggers-help li").should("contain.text", "3071 Disqualified from Driving - Discretionary")
+    cy.get(".triggers-help li").should("contain.text", "3072 Disqualified from Driving - Points (Totting)")
+    cy.get(".triggers-help li").should("contain.text", "3073 Disqualified from Driving until Ordinary Test Passed")
+    cy.get(".triggers-help li").should("contain.text", "3074 Disqualified from Driving until Extended Test Passed")
+    cy.get(".triggers-help li").should("contain.text", "3094 Disqualified from Driving non motoring offence")
+    cy.get(".triggers-help li").should("contain.text", "3095 Disqualified from Driving - vehicle used in Crime")
+    cy.get(".triggers-help li").should("contain.text", "3096 Interim Disqualification from Driving")
+  })
 })
 
 export {}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react"
+import { createUseStyles } from "react-jss"
+import { gdsLightGrey } from "utils/colours"
+
+const useStyles = createUseStyles({
+  previewContainer: {
+    backgroundColor: gdsLightGrey,
+    borderLeft: "5px solid #b1b4b6",
+    padding: "15px 20px"
+  }
+})
+
+interface PreviewProps {
+  children: ReactNode
+}
+
+export const Preview = ({ children }: PreviewProps) => {
+  const classes = useStyles()
+  return (
+    <>
+      <div className={classes.previewContainer}>{children}</div>
+    </>
+  )
+}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -12,13 +12,14 @@ const useStyles = createUseStyles({
 
 interface PreviewProps {
   children: ReactNode
+  className?: string
 }
 
-export const Preview = ({ children }: PreviewProps) => {
+export const Preview = ({ children, className }: PreviewProps) => {
   const classes = useStyles()
   return (
     <>
-      <div className={classes.previewContainer}>{children}</div>
+      <div className={classes.previewContainer + (className ? ` ${className}` : "")}>{children}</div>
     </>
   )
 }

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -1,0 +1,17 @@
+export const PreviewButton = () => {
+  return (
+    <>
+      <span className="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span>
+      <span className="govuk-accordion__show-all-text">{"Preview"}</span>
+    </>
+  )
+}
+
+export const HideButton = () => {
+  return (
+    <>
+      <span className="govuk-accordion-nav__chevron"></span>
+      <span className="govuk-accordion__show-all-text">{"Hide"}</span>
+    </>
+  )
+}

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -1,13 +1,15 @@
-export const PreviewButton = () => {
+import { Dispatch, SetStateAction } from "react"
+
+const Preview = (props: { label: string }) => {
   return (
     <>
       <span className="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span>
-      <span className="govuk-accordion__show-all-text">{"Preview"}</span>
+      <span className="govuk-accordion__show-all-text">{props.label}</span>
     </>
   )
 }
 
-export const HideButton = () => {
+const Hide = () => {
   return (
     <>
       <span className="govuk-accordion-nav__chevron"></span>
@@ -15,3 +17,26 @@ export const HideButton = () => {
     </>
   )
 }
+
+interface PreviewButtonProps {
+  showPreview: boolean
+  onClick: Dispatch<SetStateAction<boolean>>
+  previewLabel: string
+}
+
+const PreviewButton = ({ showPreview, onClick, previewLabel }: PreviewButtonProps) => {
+  return (
+    <button
+      type="button"
+      className="govuk-accordion__show-all"
+      style={{ marginBottom: "0px" }}
+      onClick={() => {
+        onClick(!showPreview)
+      }}
+    >
+      {showPreview ? <Preview label={previewLabel} /> : <Hide />}
+    </button>
+  )
+}
+
+export default PreviewButton

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -22,13 +22,14 @@ interface PreviewButtonProps {
   showPreview: boolean
   onClick: Dispatch<SetStateAction<boolean>>
   previewLabel: string
+  className?: string
 }
 
-const PreviewButton = ({ showPreview, onClick, previewLabel }: PreviewButtonProps) => {
+const PreviewButton = ({ showPreview, onClick, previewLabel, className }: PreviewButtonProps) => {
   return (
     <button
       type="button"
-      className="govuk-accordion__show-all"
+      className={"govuk-accordion__show-all" + (className ? ` ${className}` : "")}
       style={{ marginBottom: "0px" }}
       onClick={() => {
         onClick(!showPreview)

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -5,7 +5,8 @@ import ActionLink from "components/ActionLink"
 import getTriggerInfo from "utils/getTriggerInfo"
 import PreviewButton from "components/PreviewButton"
 import { default as TriggerEntity } from "services/entities/Trigger"
-import { ChangeEvent } from "react"
+import { ChangeEvent, useState } from "react"
+import ConditionalRender from "components/ConditionalRender"
 
 interface Props {
   trigger: TriggerEntity
@@ -33,7 +34,7 @@ const useStyles = createUseStyles({
 const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: Props) => {
   const triggerInfo = getTriggerInfo(trigger.triggerCode)
   const checkBoxId = `trigger_${trigger.triggerId}`
-  // const [showHelpBox, setShowHelpBox] = useState(false)
+  const [showHelpBox, setShowHelpBox] = useState(false)
 
   const classes = useStyles()
 
@@ -65,7 +66,14 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
         </GridCol>
       </GridRow>
       <GridRow>
-        <PreviewButton showPreview={true} previewLabel="More information" onClick={() => {}} />
+        <>
+          <PreviewButton
+            showPreview={!showHelpBox}
+            previewLabel="More information"
+            onClick={() => setShowHelpBox(!showHelpBox)}
+          />
+          <ConditionalRender isRendered={showHelpBox}></ConditionalRender>
+        </>
       </GridRow>
     </div>
   )

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -7,6 +7,7 @@ import PreviewButton from "components/PreviewButton"
 import { default as TriggerEntity } from "services/entities/Trigger"
 import { ChangeEvent, useState } from "react"
 import ConditionalRender from "components/ConditionalRender"
+import { Preview } from "components/Preview"
 
 interface Props {
   trigger: TriggerEntity
@@ -66,14 +67,16 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
         </GridCol>
       </GridRow>
       <GridRow>
-        <>
-          <PreviewButton
-            showPreview={!showHelpBox}
-            previewLabel="More information"
-            onClick={() => setShowHelpBox(!showHelpBox)}
-          />
-          <ConditionalRender isRendered={showHelpBox}></ConditionalRender>
-        </>
+        <PreviewButton
+          showPreview={!showHelpBox}
+          previewLabel="More information"
+          onClick={() => setShowHelpBox(!showHelpBox)}
+        />
+      </GridRow>
+      <GridRow>
+        <ConditionalRender isRendered={showHelpBox}>
+          <Preview>{"Details"}</Preview>
+        </ConditionalRender>
       </GridRow>
     </div>
   )

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -1,0 +1,74 @@
+import { GridCol, GridRow } from "govuk-react"
+import { createUseStyles } from "react-jss"
+import Checkbox from "components/Checkbox"
+import ActionLink from "components/ActionLink"
+import getTriggerInfo from "utils/getTriggerInfo"
+import PreviewButton from "components/PreviewButton"
+import { default as TriggerEntity } from "services/entities/Trigger"
+import { ChangeEvent } from "react"
+
+interface Props {
+  trigger: TriggerEntity
+  onClick: (index: number | undefined) => void
+  selectedTriggerIds: number[]
+  setTriggerSelection: (event: ChangeEvent<HTMLInputElement>) => void
+}
+
+const useStyles = createUseStyles({
+  triggerRow: {
+    "& .trigger-details-column": {
+      "& .trigger-code": {
+        fontWeight: "bold"
+      }
+    },
+    "& .checkbox-column": {
+      textAlign: "right",
+      "& .moj-checkbox": {
+        marginRight: "9px"
+      }
+    }
+  }
+})
+
+const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: Props) => {
+  const triggerInfo = getTriggerInfo(trigger.triggerCode)
+  const checkBoxId = `trigger_${trigger.triggerId}`
+  // const [showHelpBox, setShowHelpBox] = useState(false)
+
+  const classes = useStyles()
+
+  return (
+    <div key={trigger.triggerId}>
+      <GridRow className={`${classes.triggerRow} moj-trigger-row`}>
+        <GridCol className="trigger-details-column">
+          <label className="trigger-code" htmlFor={checkBoxId}>
+            {trigger.shortTriggerCode}
+          </label>
+          {trigger.triggerItemIdentity !== undefined && (
+            <>
+              {" / "}
+              <ActionLink onClick={() => onClick(trigger.triggerItemIdentity)}>
+                {"Offence "}
+                {trigger.triggerItemIdentity + 1}
+              </ActionLink>
+            </>
+          )}
+          <p>{triggerInfo?.description}</p>
+        </GridCol>
+        <GridCol setWidth="70px" className="checkbox-column">
+          <Checkbox
+            id={checkBoxId}
+            value={trigger.triggerId}
+            checked={selectedTriggerIds.includes(trigger.triggerId)}
+            onChange={setTriggerSelection}
+          />
+        </GridCol>
+      </GridRow>
+      <GridRow>
+        <PreviewButton showPreview={true} previewLabel="More information" onClick={() => {}} />
+      </GridRow>
+    </div>
+  )
+}
+
+export default Trigger

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -73,6 +73,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
       <GridRow>
         <GridCol>
           <PreviewButton
+            className="triggers-help-preview"
             showPreview={!showHelpBox}
             previewLabel="More information"
             onClick={() => setShowHelpBox(!showHelpBox)}
@@ -82,7 +83,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
       <GridRow>
         <GridCol>
           <ConditionalRender isRendered={showHelpBox}>
-            <Preview>
+            <Preview className="triggers-help">
               <Heading as="h3" size="SMALL">
                 {"PNC screen to update"}
               </Heading>

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -2,12 +2,12 @@ import { GridCol, GridRow } from "govuk-react"
 import { createUseStyles } from "react-jss"
 import Checkbox from "components/Checkbox"
 import ActionLink from "components/ActionLink"
-import getTriggerInfo from "utils/getTriggerInfo"
 import PreviewButton from "components/PreviewButton"
 import { default as TriggerEntity } from "services/entities/Trigger"
 import { ChangeEvent, useState } from "react"
 import ConditionalRender from "components/ConditionalRender"
 import { Preview } from "components/Preview"
+import getTriggerDefinition from "utils/getTriggerDefinition"
 
 interface Props {
   trigger: TriggerEntity
@@ -33,7 +33,7 @@ const useStyles = createUseStyles({
 })
 
 const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: Props) => {
-  const triggerInfo = getTriggerInfo(trigger.triggerCode)
+  const triggerDefinition = getTriggerDefinition(trigger.triggerCode)
   const checkBoxId = `trigger_${trigger.triggerId}`
   const [showHelpBox, setShowHelpBox] = useState(false)
 
@@ -55,7 +55,7 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
               </ActionLink>
             </>
           )}
-          <p>{triggerInfo?.description}</p>
+          <p>{triggerDefinition?.description}</p>
         </GridCol>
         <GridCol setWidth="70px" className="checkbox-column">
           <Checkbox

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -1,4 +1,4 @@
-import { GridCol, GridRow } from "govuk-react"
+import { GridCol, GridRow, Heading, Paragraph } from "govuk-react"
 import { createUseStyles } from "react-jss"
 import Checkbox from "components/Checkbox"
 import ActionLink from "components/ActionLink"
@@ -29,6 +29,10 @@ const useStyles = createUseStyles({
         marginRight: "9px"
       }
     }
+  },
+  cjsResultCode: {
+    fontSize: "16px",
+    lineHeight: "1.25"
   }
 })
 
@@ -75,7 +79,19 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
       </GridRow>
       <GridRow>
         <ConditionalRender isRendered={showHelpBox}>
-          <Preview>{"Details"}</Preview>
+          <Preview>
+            <Heading as="h3" size="SMALL">
+              {"PNC screen to update"}
+            </Heading>
+            <Paragraph supportingText={true}>{triggerDefinition?.pncScreenToUpdate ?? "Trigger not found"}</Paragraph>
+            <Heading as="h3" size="SMALL">
+              {"CJS result code"}
+            </Heading>
+            <div
+              className={classes.cjsResultCode}
+              dangerouslySetInnerHTML={{ __html: triggerDefinition?.cjsResultCode ?? "" }}
+            ></div>
+          </Preview>
         </ConditionalRender>
       </GridRow>
     </div>

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -71,28 +71,32 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
         </GridCol>
       </GridRow>
       <GridRow>
-        <PreviewButton
-          showPreview={!showHelpBox}
-          previewLabel="More information"
-          onClick={() => setShowHelpBox(!showHelpBox)}
-        />
+        <GridCol>
+          <PreviewButton
+            showPreview={!showHelpBox}
+            previewLabel="More information"
+            onClick={() => setShowHelpBox(!showHelpBox)}
+          />
+        </GridCol>
       </GridRow>
       <GridRow>
-        <ConditionalRender isRendered={showHelpBox}>
-          <Preview>
-            <Heading as="h3" size="SMALL">
-              {"PNC screen to update"}
-            </Heading>
-            <Paragraph supportingText={true}>{triggerDefinition?.pncScreenToUpdate ?? "Trigger not found"}</Paragraph>
-            <Heading as="h3" size="SMALL">
-              {"CJS result code"}
-            </Heading>
-            <div
-              className={classes.cjsResultCode}
-              dangerouslySetInnerHTML={{ __html: triggerDefinition?.cjsResultCode ?? "" }}
-            ></div>
-          </Preview>
-        </ConditionalRender>
+        <GridCol>
+          <ConditionalRender isRendered={showHelpBox}>
+            <Preview>
+              <Heading as="h3" size="SMALL">
+                {"PNC screen to update"}
+              </Heading>
+              <Paragraph supportingText={true}>{triggerDefinition?.pncScreenToUpdate ?? "Trigger not found"}</Paragraph>
+              <Heading as="h3" size="SMALL">
+                {"CJS result code"}
+              </Heading>
+              <div
+                className={classes.cjsResultCode}
+                dangerouslySetInnerHTML={{ __html: triggerDefinition?.cjsResultCode ?? "" }}
+              ></div>
+            </Preview>
+          </ConditionalRender>
+        </GridCol>
       </GridRow>
     </div>
   )

--- a/src/features/CourtCaseDetails/Sidebar/Triggers.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Triggers.tsx
@@ -6,6 +6,7 @@ import ActionLink from "components/ActionLink"
 import { ChangeEvent, useState } from "react"
 import getTriggerDefinition from "utils/getTriggerDefinition"
 import type NavigationHandler from "types/NavigationHandler"
+import PreviewButton from "components/PreviewButton"
 
 interface Props {
   courtCase: CourtCase
@@ -76,31 +77,36 @@ const Triggers = ({ courtCase, onNavigate }: Props) => {
         const checkBoxId = `trigger_${trigger.triggerId}`
 
         return (
-          <GridRow key={trigger.triggerId} className={`${classes.triggerRow} moj-trigger-row`}>
-            <GridCol className="trigger-details-column">
-              <label className="trigger-code" htmlFor={checkBoxId}>
-                {trigger.shortTriggerCode}
-              </label>
-              {trigger.triggerItemIdentity !== undefined && (
-                <>
-                  {" / "}
-                  <ActionLink onClick={() => handleClick(trigger.triggerItemIdentity)}>
-                    {"Offence "}
-                    {trigger.triggerItemIdentity + 1}
-                  </ActionLink>
-                </>
-              )}
-              <p>{triggerDefinition?.description}</p>
-            </GridCol>
-            <GridCol setWidth="70px" className="checkbox-column">
-              <Checkbox
-                id={checkBoxId}
-                value={trigger.triggerId}
-                checked={selectedTriggerIds.includes(trigger.triggerId)}
-                onChange={setTriggerSelection}
-              />
-            </GridCol>
-          </GridRow>
+          <div key={trigger.triggerId}>
+            <GridRow className={`${classes.triggerRow} moj-trigger-row`}>
+              <GridCol className="trigger-details-column">
+                <label className="trigger-code" htmlFor={checkBoxId}>
+                  {trigger.shortTriggerCode}
+                </label>
+                {trigger.triggerItemIdentity !== undefined && (
+                  <>
+                    {" / "}
+                    <ActionLink onClick={() => handleClick(trigger.triggerItemIdentity)}>
+                      {"Offence "}
+                      {trigger.triggerItemIdentity + 1}
+                    </ActionLink>
+                  </>
+                )}
+                <p>{triggerInfo?.description}</p>
+              </GridCol>
+              <GridCol setWidth="70px" className="checkbox-column">
+                <Checkbox
+                  id={checkBoxId}
+                  value={trigger.triggerId}
+                  checked={selectedTriggerIds.includes(trigger.triggerId)}
+                  onChange={setTriggerSelection}
+                />
+              </GridCol>
+            </GridRow>
+            <GridRow>
+              <PreviewButton showPreview={true} previewLabel="More information" onClick={() => {}} />
+            </GridRow>
+          </div>
         )
       })}
     </>

--- a/src/features/CourtCaseDetails/Sidebar/TriggersAndExceptions.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersAndExceptions.tsx
@@ -2,7 +2,7 @@ import { Tabs } from "govuk-react"
 import { useState } from "react"
 import { createUseStyles } from "react-jss"
 import CourtCase from "../../../services/entities/CourtCase"
-import Triggers from "./Triggers"
+import TriggersList from "./TriggersList"
 import Exceptions from "./Exceptions"
 import type { AnnotatedHearingOutcome } from "@moj-bichard7-developers/bichard7-next-core/build/src/types/AnnotatedHearingOutcome"
 import type NavigationHandler from "types/NavigationHandler"
@@ -44,7 +44,7 @@ const TriggersAndExceptions = ({ courtCase, aho, onNavigate }: Props) => {
           >{`Exceptions`}</Tabs.Tab>
         </Tabs.List>
         <Tabs.Panel id="triggers" selected={selectedTab === "triggers"} className="moj-tab-panel-triggers">
-          <Triggers courtCase={courtCase} onNavigate={onNavigate} />
+          <TriggersList courtCase={courtCase} onNavigate={onNavigate} />
         </Tabs.Panel>
         <Tabs.Panel id="exceptions" selected={selectedTab === "exceptions"} className="moj-tab-panel-exceptions">
           <Exceptions aho={aho} onNavigate={onNavigate} />

--- a/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -38,7 +38,7 @@ const useStyles = createUseStyles({
   }
 })
 
-const Triggers = ({ courtCase, onNavigate }: Props) => {
+const TriggersList = ({ courtCase, onNavigate }: Props) => {
   const classes = useStyles()
   const [selectedTriggerIds, setSelectedTriggerIds] = useState<number[]>([])
   const unresolvedTriggers = courtCase.triggers.filter((trigger) => !trigger.resolvedBy)
@@ -75,6 +75,7 @@ const Triggers = ({ courtCase, onNavigate }: Props) => {
       {unresolvedTriggers.map((trigger) => {
         const triggerDefinition = getTriggerDefinition(trigger.triggerCode)
         const checkBoxId = `trigger_${trigger.triggerId}`
+        // const [showHelpBox, setShowHelpBox] = useState(false)
 
         return (
           <div key={trigger.triggerId}>
@@ -113,4 +114,4 @@ const Triggers = ({ courtCase, onNavigate }: Props) => {
   )
 }
 
-export default Triggers
+export default TriggersList

--- a/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -1,12 +1,10 @@
 import { GridCol, GridRow } from "govuk-react"
 import CourtCase from "../../../services/entities/CourtCase"
 import { createUseStyles } from "react-jss"
-import Checkbox from "components/Checkbox"
 import ActionLink from "components/ActionLink"
 import { ChangeEvent, useState } from "react"
-import getTriggerDefinition from "utils/getTriggerDefinition"
 import type NavigationHandler from "types/NavigationHandler"
-import PreviewButton from "components/PreviewButton"
+import Trigger from "./Trigger"
 
 interface Props {
   courtCase: CourtCase
@@ -21,19 +19,6 @@ const useStyles = createUseStyles({
       fontSize: "16px",
       marginRight: "10px",
       marginBottom: "16px"
-    }
-  },
-  triggerRow: {
-    "& .trigger-details-column": {
-      "& .trigger-code": {
-        fontWeight: "bold"
-      }
-    },
-    "& .checkbox-column": {
-      textAlign: "right",
-      "& .moj-checkbox": {
-        marginRight: "9px"
-      }
     }
   }
 })
@@ -72,44 +57,15 @@ const TriggersList = ({ courtCase, onNavigate }: Props) => {
           </GridCol>
         </GridRow>
       )}
-      {unresolvedTriggers.map((trigger) => {
-        const triggerDefinition = getTriggerDefinition(trigger.triggerCode)
-        const checkBoxId = `trigger_${trigger.triggerId}`
-        // const [showHelpBox, setShowHelpBox] = useState(false)
-
-        return (
-          <div key={trigger.triggerId}>
-            <GridRow className={`${classes.triggerRow} moj-trigger-row`}>
-              <GridCol className="trigger-details-column">
-                <label className="trigger-code" htmlFor={checkBoxId}>
-                  {trigger.shortTriggerCode}
-                </label>
-                {trigger.triggerItemIdentity !== undefined && (
-                  <>
-                    {" / "}
-                    <ActionLink onClick={() => handleClick(trigger.triggerItemIdentity)}>
-                      {"Offence "}
-                      {trigger.triggerItemIdentity + 1}
-                    </ActionLink>
-                  </>
-                )}
-                <p>{triggerInfo?.description}</p>
-              </GridCol>
-              <GridCol setWidth="70px" className="checkbox-column">
-                <Checkbox
-                  id={checkBoxId}
-                  value={trigger.triggerId}
-                  checked={selectedTriggerIds.includes(trigger.triggerId)}
-                  onChange={setTriggerSelection}
-                />
-              </GridCol>
-            </GridRow>
-            <GridRow>
-              <PreviewButton showPreview={true} previewLabel="More information" onClick={() => {}} />
-            </GridRow>
-          </div>
-        )
-      })}
+      {unresolvedTriggers.map((trigger, index) => (
+        <Trigger
+          key={index}
+          trigger={trigger}
+          onClick={() => handleClick(trigger.triggerItemIdentity)}
+          selectedTriggerIds={selectedTriggerIds}
+          setTriggerSelection={setTriggerSelection}
+        />
+      ))}
     </>
   )
 }

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -71,7 +71,7 @@ export const CaseDetailsRow = ({
   rowClassName,
   unlockPath
 }: CaseDetailsRowProps) => {
-  const [showPreview, setShowPreview] = useState(false)
+  const [showPreview, setShowPreview] = useState(true)
 
   const { basePath } = useRouter()
   const caseDetailsPath = (id: number) => `${basePath}/court-cases/${id}`
@@ -124,7 +124,7 @@ export const CaseDetailsRow = ({
           {<CaseUnlockedTag isCaseUnlocked={isCaseUnlocked} />}
         </Table.Cell>
       </Table.Row>
-      {numberOfNotes != 0 && !!showPreview && (
+      {numberOfNotes != 0 && !showPreview && (
         <Table.Row className={classes.notesRow}>
           <Table.Cell
             className={`${cellClassName} ${firstColumnClassName} ${customClasses["top-padding-none"]}`}

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
@@ -1,19 +1,10 @@
 import { truncate } from "lodash"
 import ConditionalRender from "../../../../components/ConditionalRender"
 import { Dispatch, SetStateAction } from "react"
-import { createUseStyles } from "react-jss"
-import { gdsLightGrey } from "../../../../utils/colours"
 import { validateMostRecentNoteDate } from "./CourtCaseListEntryHelperFunction"
 import type Note from "../../../../services/entities/Note"
 import PreviewButton from "../../../../components/PreviewButton"
-
-const useStyles = createUseStyles({
-  notePreviewContainer: {
-    backgroundColor: gdsLightGrey,
-    borderLeft: "5px solid #b1b4b6",
-    padding: "15px 20px"
-  }
-})
+import { Preview } from "components/Preview"
 
 interface NotePreviewProps {
   latestNote: Note
@@ -27,17 +18,14 @@ interface NotePreviewButtonProps {
 }
 
 export const NotePreview = ({ latestNote, numberOfNotes }: NotePreviewProps) => {
-  const classes = useStyles()
   const displayDate = validateMostRecentNoteDate(latestNote)
   return (
-    <>
-      <div className={classes.notePreviewContainer}>
-        <p className="govuk-body govuk-!-font-weight-bold">
-          {numberOfNotes > 1 ? `Most recent note added ${displayDate}` : `Note added ${displayDate}`}
-        </p>
-        <p>{truncate(latestNote?.noteText, { length: 103 })}</p>
-      </div>
-    </>
+    <Preview>
+      <p className="govuk-body govuk-!-font-weight-bold">
+        {numberOfNotes > 1 ? `Most recent note added ${displayDate}` : `Note added ${displayDate}`}
+      </p>
+      <p>{truncate(latestNote?.noteText, { length: 103 })}</p>
+    </Preview>
   )
 }
 

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
@@ -5,12 +5,9 @@ import { createUseStyles } from "react-jss"
 import { gdsLightGrey } from "../../../../utils/colours"
 import { validateMostRecentNoteDate } from "./CourtCaseListEntryHelperFunction"
 import type Note from "../../../../services/entities/Note"
-import { HideButton, PreviewButton } from "../../../../components/PreviewButton"
+import PreviewButton from "../../../../components/PreviewButton"
 
 const useStyles = createUseStyles({
-  buttonContainer: {
-    width: "97px"
-  },
   notePreviewContainer: {
     backgroundColor: gdsLightGrey,
     borderLeft: "5px solid #b1b4b6",
@@ -44,24 +41,12 @@ export const NotePreview = ({ latestNote, numberOfNotes }: NotePreviewProps) => 
   )
 }
 
-
 export const NotePreviewButton: React.FC<NotePreviewButtonProps> = (props: NotePreviewButtonProps) => {
-  const classes = useStyles()
-
   return (
     <>
       <ConditionalRender isRendered={props.numberOfNotes > 0}>
         {props.numberOfNotes > 1 ? `${props.numberOfNotes} notes` : `${props.numberOfNotes} note`}
-        <div className={classes.buttonContainer}>
-          <button
-            type="button"
-            className="govuk-accordion__show-all"
-            style={{ marginBottom: "0px" }}
-            onClick={() => props.setShowPreview(!props.previewState)}
-          >
-            {!props.previewState ? <PreviewButton /> : <HideButton />}
-          </button>
-        </div>
+        <PreviewButton showPreview={props.previewState} onClick={props.setShowPreview} previewLabel="Preview" />
       </ConditionalRender>
     </>
   )

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
@@ -5,6 +5,7 @@ import { createUseStyles } from "react-jss"
 import { gdsLightGrey } from "../../../../utils/colours"
 import { validateMostRecentNoteDate } from "./CourtCaseListEntryHelperFunction"
 import type Note from "../../../../services/entities/Note"
+import { HideButton, PreviewButton } from "../../../../components/PreviewButton"
 
 const useStyles = createUseStyles({
   buttonContainer: {
@@ -43,22 +44,7 @@ export const NotePreview = ({ latestNote, numberOfNotes }: NotePreviewProps) => 
   )
 }
 
-export const PreviewButton = () => {
-  return (
-    <>
-      <span className="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span>
-      <span className="govuk-accordion__show-all-text">{"Preview"}</span>
-    </>
-  )
-}
-export const HideButton = () => {
-  return (
-    <>
-      <span className="govuk-accordion-nav__chevron"></span>
-      <span className="govuk-accordion__show-all-text">{"Hide"}</span>
-    </>
-  )
-}
+
 export const NotePreviewButton: React.FC<NotePreviewButtonProps> = (props: NotePreviewButtonProps) => {
   const classes = useStyles()
 


### PR DESCRIPTION
This PR:
* Adds a contextual help box to triggers, collapsed by default
* Moves hide and show buttons into a `PreviewButton` component
* Adds a `Preview` component for the grey box
* Adds cypress component tests for `PreviewButton`
* Adds cypress e2e tests for showing contextual help for a trigger
* Moves the logic for displaying triggers on the case details page from `TriggersList` to a separate `Trigger` component

Screenshot:
![Screenshot 2023-04-28 at 13 29 05](https://user-images.githubusercontent.com/7249529/235147575-d491d513-7d05-4f77-9517-fd44c1da82d3.png)
