### PR TITLE
Display the note preview button underneath the count

### DIFF
--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/NotePreviewButton.tsx
@@ -33,7 +33,7 @@ export const NotePreviewButton: React.FC<NotePreviewButtonProps> = (props: NoteP
   return (
     <>
       <ConditionalRender isRendered={props.numberOfNotes > 0}>
-        {props.numberOfNotes > 1 ? `${props.numberOfNotes} notes` : `${props.numberOfNotes} note`}
+        <div>{props.numberOfNotes > 1 ? `${props.numberOfNotes} notes` : `${props.numberOfNotes} note`}</div>
         <PreviewButton showPreview={props.previewState} onClick={props.setShowPreview} previewLabel="Preview" />
       </ConditionalRender>
     </>


### PR DESCRIPTION
Previously, this was displaying the two inline on wider layouts:

![Screenshot 2023-05-02 at 15 05 38](https://user-images.githubusercontent.com/7249529/235691348-f50a00f5-7e56-4c12-897b-0a6f803a22e3.png)

By putting the label in it's own element, it displays inline with the preview button on all widths:

![Screenshot 2023-05-02 at 15 05 23](https://user-images.githubusercontent.com/7249529/235691441-9bf2df02-7fdd-462e-a491-d381d60b3e2f.png)
