### PR TITLE
Bug Fix: Select court cases by visible court query

### DIFF
--- a/src/services/entities/User.ts
+++ b/src/services/entities/User.ts
@@ -4,6 +4,7 @@ import type { KeyValuePair } from "types/KeyValuePair"
 import BaseEntity from "./BaseEntity"
 import delimitedPrefixedString from "./transformers/delimitedPrefixedString"
 import featureFlagTransformer from "./transformers/featureFlagTransformer"
+import delimitedString from "./transformers/delimitedString"
 
 @Entity({ name: "users" })
 export default class User extends BaseEntity {
@@ -25,10 +26,10 @@ export default class User extends BaseEntity {
   @Column({ name: "visible_forces", transformer: delimitedPrefixedString(",", "0"), type: "varchar" })
   visibleForces!: string[]
 
-  @Column({ name: "visible_courts", transformer: delimitedPrefixedString(",", "0"), type: "varchar" })
+  @Column({ name: "visible_courts", transformer: delimitedString(","), type: "varchar" })
   visibleCourts!: string[]
 
-  @Column({ name: "excluded_triggers", transformer: delimitedPrefixedString(",", "0"), type: "varchar" })
+  @Column({ name: "excluded_triggers", transformer: delimitedString(","), type: "varchar" })
   excludedTriggers!: string[]
 
   @Column({ name: "feature_flags", transformer: featureFlagTransformer, type: "jsonb" })

--- a/src/services/entities/transformers/delimitedString.test.ts
+++ b/src/services/entities/transformers/delimitedString.test.ts
@@ -1,0 +1,22 @@
+import { ValueTransformer } from "typeorm"
+import delimitedString from "./delimitedString"
+let transformer: ValueTransformer
+
+describe("delimitedString value transformer", () => {
+  beforeAll(() => {
+    transformer = delimitedString(",")
+  })
+
+  it("can transform list of values from a string into an array", () => {
+    expect(transformer.from("011,012")).toStrictEqual(["011", "012"])
+  })
+
+  it("creates an empty array when there are no values", () => {
+    expect(transformer.from("")).toStrictEqual([])
+  })
+
+  it("can transform the array back to the original value", () => {
+    expect(transformer.to(["11", "12"])).toStrictEqual("11,12")
+    expect(transformer.to([])).toStrictEqual("")
+  })
+})

--- a/src/services/entities/transformers/delimitedString.ts
+++ b/src/services/entities/transformers/delimitedString.ts
@@ -1,0 +1,8 @@
+import { ValueTransformer } from "typeorm"
+
+const delimitedString = (delimeter: string): ValueTransformer => ({
+  to: (value: string[]) => value.join(delimeter),
+  from: (value?: string) => value?.split(delimeter).filter(Boolean) ?? []
+})
+
+export default delimitedString

--- a/src/services/queries/courtCasesByVisibleCourtsQuery.ts
+++ b/src/services/queries/courtCasesByVisibleCourtsQuery.ts
@@ -13,7 +13,7 @@ const courtCasesByVisibleCourtsQuery = (
       }
 
       courts.forEach((code) => {
-        const condition = { orgForPoliceFilter: Like(`${code}%`) }
+        const condition = { courtCode: Like(`${code}%`) }
         qb.orWhere(condition)
       })
     })

--- a/test/services/courtCasesByOrganisationUnitFilterQuery.integration.test.ts
+++ b/test/services/courtCasesByOrganisationUnitFilterQuery.integration.test.ts
@@ -65,7 +65,7 @@ describe("courtCasesByOrganisationUnitQuery", () => {
       visibleCourts: ["13BR", "14AT"]
     }
     await insertCourtCasesWithFields(
-      expectedOrgCodes.concat(otherOrgCodes).map((orgCode) => ({ orgForPoliceFilter: orgCode }))
+      expectedOrgCodes.concat(otherOrgCodes).map((orgCode) => ({ orgForPoliceFilter: orgCode, courtCode: orgCode }))
     )
 
     const result = await (courtCasesByOrganisationUnitQuery(query, user as User) as SelectQueryBuilder<CourtCase>)
@@ -76,6 +76,7 @@ describe("courtCasesByOrganisationUnitQuery", () => {
     const cases = result as CourtCase[]
     expect(cases).toHaveLength(4)
     expect(cases.map((c) => c.orgForPoliceFilter)).toEqual(expect.arrayContaining(expectedOrgCodes))
+    expect(cases.map((c) => c.courtCode)).toEqual(expect.arrayContaining(expectedOrgCodes))
   })
 
   it("should update visible cases when its an update query", async () => {
@@ -86,7 +87,7 @@ describe("courtCasesByOrganisationUnitQuery", () => {
       visibleCourts: ["13BR"]
     }
     await insertCourtCasesWithFields(
-      expectedOrgCodes.concat(otherOrgCodes).map((orgCode) => ({ orgForPoliceFilter: orgCode }))
+      expectedOrgCodes.concat(otherOrgCodes).map((orgCode) => ({ orgForPoliceFilter: orgCode, courtCode: orgCode }))
     )
 
     const updateQuery = query.update(CourtCase)

--- a/test/services/courtCasesByVisibleCourtsQuery.integration.test.ts
+++ b/test/services/courtCasesByVisibleCourtsQuery.integration.test.ts
@@ -28,8 +28,8 @@ describe("courtCasesByVisibleCourtsQuery", () => {
   })
 
   it("should return a list of cases when the court code is an exact match", async () => {
-    const orgCodes = ["3", "36", "36AAAA"]
-    await insertCourtCasesWithFields(orgCodes.map((orgCode) => ({ orgForPoliceFilter: orgCode })))
+    const courtCodes = ["3", "36", "36AAAA"]
+    await insertCourtCasesWithFields(courtCodes.map((courtCode) => ({ courtCode: courtCode })))
 
     const result = await (courtCasesByVisibleCourtsQuery(query, ["36AAAA"]) as SelectQueryBuilder<CourtCase>)
       .getMany()
@@ -40,15 +40,15 @@ describe("courtCasesByVisibleCourtsQuery", () => {
 
     expect(cases).toHaveLength(1)
     expect(cases[0].errorId).toEqual(2)
-    expect(cases[0].orgForPoliceFilter).toEqual("36AAAA")
+    expect(cases[0].courtCode).toEqual("36AAAA")
   })
 
   it("should show cases for all courts visible to a user where the beginning of the code matches", async () => {
-    const orgCodesForVisibleCourts = ["36F   ", "36FP  ", "13GH  ", "13GHA "]
-    const otherOrgCodes = ["36", "13", "12LK"]
+    const courtCodesForVisibleCourts = ["36F   ", "36FP  ", "13GH  ", "13GHA "]
+    const otherCourtCodes = ["36", "13", "12LK"]
 
     await insertCourtCasesWithFields(
-      orgCodesForVisibleCourts.concat(otherOrgCodes).map((orgCode) => ({ orgForPoliceFilter: orgCode }))
+      courtCodesForVisibleCourts.concat(otherCourtCodes).map((courtCode) => ({ courtCode: courtCode }))
     )
 
     const result = await (courtCasesByVisibleCourtsQuery(query, ["36F", "13GH"]) as SelectQueryBuilder<CourtCase>)
@@ -60,13 +60,13 @@ describe("courtCasesByVisibleCourtsQuery", () => {
 
     expect(cases).toHaveLength(4)
 
-    expect(cases.map((c) => c.orgForPoliceFilter)).toEqual(expect.arrayContaining(orgCodesForVisibleCourts))
+    expect(cases.map((c) => c.courtCode)).toEqual(expect.arrayContaining(courtCodesForVisibleCourts))
     expect(cases.map((c) => c.errorId)).toEqual(expect.arrayContaining([0, 1, 2, 3]))
   })
 
   it("should show no cases to a user with no visible courts", async () => {
-    const orgCodesForNoVisibleCases = ["36", "36F", "36FP", "36FPA"]
-    await insertCourtCasesWithFields(orgCodesForNoVisibleCases.map((orgCode) => ({ orgForPoliceFilter: orgCode })))
+    const courtCodesForNoVisibleCases = ["36", "36F", "36FP", "36FPA"]
+    await insertCourtCasesWithFields(courtCodesForNoVisibleCases.map((courtCode) => ({ courtCode: courtCode })))
 
     const result = await (courtCasesByVisibleCourtsQuery(query, []) as SelectQueryBuilder<CourtCase>)
       .getMany()
@@ -79,8 +79,8 @@ describe("courtCasesByVisibleCourtsQuery", () => {
   })
 
   it("should update visible cases when its an update query", async () => {
-    const orgCodesForVisibleCourts = ["013", "013A", "013B", "014"]
-    await insertCourtCasesWithFields(orgCodesForVisibleCourts.map((orgCode) => ({ orgForPoliceFilter: orgCode })))
+    const courtCodesForVisibleCourts = ["013", "013A", "013B", "014"]
+    await insertCourtCasesWithFields(courtCodesForVisibleCourts.map((courtCode) => ({ courtCode: courtCode })))
 
     const updateQuery = query.update(CourtCase)
 


### PR DESCRIPTION
Found and fixed 2 bugs while working on the e2e tests:
- The value transformer in the user entity reused the `delimitedPrefixedString` value transformer for `visible_courts` and `excluded_triggers`, causing the first character to be trimmed off for courtCodes or trigger codes
- `courtCasesByVisibleCourtsQuery` checks the court code from `user.visibleCourts` field against `orgForPoliceFilter` instead of `courtCode`