### PR TITLE
BICAWS-2220 Mark a case as manually resolved

### DIFF
--- a/cypress/e2e/court-cases/manuallyResolve.cy.ts
+++ b/cypress/e2e/court-cases/manuallyResolve.cy.ts
@@ -1,0 +1,118 @@
+import User from "services/entities/User"
+import hashedPassword from "../../fixtures/hashedPassword"
+
+describe("Manually resolve a case", () => {
+  const defaultUsers: Partial<User>[] = Array.from(Array(2)).map((_value, idx) => {
+    return {
+      username: `Bichard0${idx}`,
+      visibleForces: [`0${idx}`],
+      forenames: "Bichard Test User",
+      surname: `0${idx}`,
+      email: `bichard0${idx}@example.com`,
+      password: hashedPassword
+    }
+  })
+
+  before(() => {
+    cy.task("clearUsers")
+    cy.task("insertUsers", { users: defaultUsers, userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"] })
+  })
+
+  beforeEach(() => {
+    cy.task("clearCourtCases")
+  })
+
+  it("should be able to resolve a case which is visible and locked by the user", () => {
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        errorCount: 1,
+        triggerCount: 0,
+        errorLockedByUsername: "Bichard01",
+        triggerLockedByUsername: "Bichard01"
+      }
+    ])
+    cy.login("bichard01@example.com", "password")
+
+    cy.visit("/bichard")
+
+    cy.findByText("NAME Defendant").click()
+
+    cy.get("button").contains("Mark As Manually Resolved").click()
+    cy.get("H2").should("have.text", "Resolve Case")
+    cy.findByText("Case Details").should("have.attr", "href", "/bichard/court-cases/0")
+
+    cy.get('select[name="reason"]').select("PNCRecordIsAccurate")
+    cy.get("button").contains("Resolve").click()
+
+    cy.get("H1").should("have.text", "Case details")
+
+    cy.contains("Notes").click()
+    const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
+    cy.contains(dateTimeRegex)
+    cy.contains("Bichard01: Portal Action: Record Manually Resolved. Reason: PNCRecordIsAccurate. Reason Text:")
+  })
+
+  it("should prompt the user to enter resolution details if the reason is Reallocated", () => {
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        errorCount: 1,
+        triggerCount: 0,
+        errorLockedByUsername: "Bichard01",
+        triggerLockedByUsername: "Bichard01"
+      }
+    ])
+    cy.login("bichard01@example.com", "password")
+
+    cy.visit("/bichard")
+
+    cy.findByText("NAME Defendant").click()
+
+    cy.get("button").contains("Mark As Manually Resolved").click()
+    cy.get("H2").should("have.text", "Resolve Case")
+    cy.findByText("Case Details").should("have.attr", "href", "/bichard/court-cases/0")
+
+    cy.get('select[name="reason"]').select("Reallocated")
+    cy.get("button").contains("Resolve").click()
+
+    cy.contains("Reason text is required").should("be.visible")
+
+    cy.get("textarea").type("Some reason text")
+    cy.get("button").contains("Resolve").click()
+
+    cy.get("H1").should("have.text", "Case details")
+
+    cy.contains("Notes").click()
+    const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
+    cy.contains(dateTimeRegex)
+    cy.contains(
+      "Bichard01: Portal Action: Record Manually Resolved. Reason: Reallocated. Reason Text: Some reason text"
+    )
+  })
+
+  it("should return 404 for a case that this user can not see", () => {
+    cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "02" }])
+    cy.login("bichard01@example.com", "password")
+
+    cy.request({
+      failOnStatusCode: false,
+      url: "/bichard/court-cases/0/resolve"
+    }).then((response) => {
+      expect(response.status).to.eq(404)
+    })
+  })
+
+  it("should return 404 for a case that does not exist", () => {
+    cy.login("bichard01@example.com", "password")
+
+    cy.request({
+      failOnStatusCode: false,
+      url: "/court-cases/1/notes/resolve"
+    }).then((response) => {
+      expect(response.status).to.eq(404)
+    })
+  })
+})
+
+export {}

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -182,6 +182,9 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
           <ConditionalRender isRendered={!lockedByAnotherUser}>
             <LinkButton href="reallocate">{"Reallocate Case"}</LinkButton>
           </ConditionalRender>
+          <ConditionalRender isRendered={!lockedByAnotherUser}>
+            <LinkButton href="resolve">{"Mark As Manually Resolved"}</LinkButton>
+          </ConditionalRender>
         </GridCol>
         <GridCol setWidth={sideBarWidth}>
           <TriggersAndExceptions courtCase={courtCase} aho={aho} onNavigate={handleNavigation} />

--- a/src/pages/court-cases/[courtCaseId]/resolve.tsx
+++ b/src/pages/court-cases/[courtCaseId]/resolve.tsx
@@ -1,0 +1,149 @@
+import Layout from "components/Layout"
+import { withAuthentication, withMultipleServerSideProps } from "middleware"
+import type { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from "next"
+import { ParsedUrlQuery } from "querystring"
+import CourtCase from "services/entities/CourtCase"
+import User from "services/entities/User"
+import getDataSource from "services/getDataSource"
+import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
+import { BackLink, Button, FormGroup, Heading, Select, TextArea } from "govuk-react"
+import { useRouter } from "next/router"
+import parseFormData from "utils/parseFormData"
+import { isPost } from "utils/http"
+import getCourtCaseByOrganisationUnit from "services/getCourtCaseByOrganisationUnit"
+import { isError } from "types/Result"
+import ConditionalRender from "components/ConditionalRender"
+import { ResolutionReasonKey, ResolutionReasons } from "types/ManualResolution"
+import resolveCourtCase from "services/resolveCourtCase"
+import redirectTo from "utils/redirectTo"
+import { validateManualResolution } from "utils/validators/validateManualResolution"
+
+export const getServerSideProps = withMultipleServerSideProps(
+  withAuthentication,
+  async (context: GetServerSidePropsContext<ParsedUrlQuery>): Promise<GetServerSidePropsResult<Props>> => {
+    const { currentUser, query, req } = context as AuthenticationServerSidePropsContext
+    const { courtCaseId } = query as { courtCaseId: string }
+
+    const dataSource = await getDataSource()
+    const courtCase = await getCourtCaseByOrganisationUnit(dataSource, +courtCaseId, currentUser)
+
+    if (!courtCase) {
+      return {
+        notFound: true
+      }
+    }
+
+    if (isError(courtCase)) {
+      console.error(courtCase)
+      throw courtCase
+    }
+
+    const props: Props = {
+      user: currentUser.serialize(),
+      courtCase: courtCase.serialize(),
+      lockedByAnotherUser: courtCase.isLockedByAnotherUser(currentUser.username)
+    }
+
+    if (isPost(req)) {
+      const { reason, reasonText } = (await parseFormData(req)) as { reason: string; reasonText: string }
+      const validation = validateManualResolution({ reason: reason as ResolutionReasonKey, reasonText })
+
+      if (validation.error) {
+        return {
+          props: {
+            ...props,
+            reasonTextError: validation.error,
+            selectedReason: reason as ResolutionReasonKey
+          }
+        }
+      }
+
+      const reallocateResult = await resolveCourtCase(
+        dataSource,
+        courtCase.errorId,
+        { reason: reason as ResolutionReasonKey, reasonText: reasonText ?? "" },
+        currentUser
+      )
+      if (isError(reallocateResult)) {
+        throw reallocateResult
+      } else {
+        return redirectTo(`/court-cases/${courtCase.errorId}`)
+      }
+    }
+
+    return { props }
+  }
+)
+
+interface Props {
+  user: User
+  courtCase: CourtCase
+  lockedByAnotherUser: boolean
+  reasonTextError?: string
+  selectedReason?: ResolutionReasonKey
+}
+
+const ResolveCourtCasePage: NextPage<Props> = ({
+  courtCase,
+  user,
+  lockedByAnotherUser,
+  selectedReason,
+  reasonTextError
+}: Props) => {
+  const { basePath } = useRouter()
+
+  return (
+    <>
+      <Layout user={user}>
+        <Heading as="h1" size="LARGE" aria-label="Resolve Case">
+          <title>{"Resolve Case | Bichard7"}</title>
+          <meta name="description" content="Resolve Case| Bichard7" />
+        </Heading>
+        <BackLink href={`${basePath}/court-cases/${courtCase.errorId}`} onClick={function noRefCheck() {}}>
+          {"Case Details"}
+        </BackLink>
+        <Heading as="h2" size="MEDIUM">
+          {"Resolve Case"}
+        </Heading>
+        <ConditionalRender isRendered={lockedByAnotherUser}>{"Case is locked by another user."}</ConditionalRender>
+        <ConditionalRender isRendered={!lockedByAnotherUser}>
+          <form method="POST" action="#">
+            <FormGroup>
+              <Select
+                input={{
+                  name: "reason"
+                }}
+                label="Select a reason"
+              >
+                {Object.keys(ResolutionReasons).map((reason) => {
+                  return (
+                    <option selected={selectedReason === reason} key={reason} value={reason}>
+                      {ResolutionReasons[reason as ResolutionReasonKey]}
+                    </option>
+                  )
+                })}
+              </Select>
+              <TextArea
+                input={{
+                  name: "reasonText"
+                }}
+                meta={{
+                  error: reasonTextError,
+                  touched: !!reasonTextError
+                }}
+              >
+                {"Resolution details"}
+              </TextArea>
+            </FormGroup>
+
+            <Button id="Resolve" type="submit">
+              {"Resolve"}
+            </Button>
+          </form>
+        </ConditionalRender>
+      </Layout>
+    </>
+  )
+}
+
+export default ResolveCourtCasePage

--- a/src/services/resolveCourtCase.ts
+++ b/src/services/resolveCourtCase.ts
@@ -39,6 +39,15 @@ const resolveCourtCase = async (
       queryParams.resolutionTimestamp = resolutionTimestamp
     }
 
+    query.set(queryParams)
+    query.where({ errorId: courtCaseId, errorLockedByUsername: resolver })
+
+    const queryResult = await query.execute()
+
+    if (queryResult.affected === 0) {
+      return new Error("Failed to resolve case")
+    }
+
     const unlockResult = await unlockCourtCase(entityManager, +courtCaseId, user)
 
     if (isError(unlockResult)) {
@@ -59,10 +68,7 @@ const resolveCourtCase = async (
       throw addNoteResult
     }
 
-    query.set(queryParams)
-    query.where("error_id = :id", { id: courtCaseId })
-
-    return query.execute()?.catch((error: Error) => error)
+    return queryResult
   })
   if (isError(updateResult)) {
     throw updateResult

--- a/src/services/resolveCourtCase.ts
+++ b/src/services/resolveCourtCase.ts
@@ -7,6 +7,7 @@ import unlockCourtCase from "./unlockCourtCase"
 import insertNotes from "./insertNotes"
 import Trigger from "./entities/Trigger"
 import courtCasesByOrganisationUnitQuery from "./queries/courtCasesByOrganisationUnitQuery"
+import { validateManualResolution } from "utils/validators/validateManualResolution"
 
 const resolveCourtCase = async (
   dataSource: DataSource,
@@ -15,6 +16,12 @@ const resolveCourtCase = async (
   user: User
 ): Promise<UpdateResult | Error> => {
   const updateResult = dataSource.transaction("SERIALIZABLE", async (entityManager): Promise<UpdateResult | Error> => {
+    const resolutionError = validateManualResolution(resolution).error
+
+    if (resolutionError) {
+      return new Error(resolutionError)
+    }
+
     const courtCaseRepository = entityManager.getRepository(CourtCase)
     const triggersResolved =
       (

--- a/src/services/resolveCourtCase.ts
+++ b/src/services/resolveCourtCase.ts
@@ -1,4 +1,4 @@
-import { DataSource, Not, UpdateQueryBuilder, UpdateResult } from "typeorm"
+import { DataSource, MoreThan, Not, UpdateQueryBuilder, UpdateResult } from "typeorm"
 import { isError } from "types/Result"
 import User from "./entities/User"
 import { ManualResolution } from "types/ManualResolution"
@@ -50,7 +50,12 @@ const resolveCourtCase = async (
     }
 
     query.set(queryParams)
-    query.andWhere({ errorId: courtCaseId, errorLockedByUsername: resolver })
+    query.andWhere({
+      errorId: courtCaseId,
+      errorLockedByUsername: resolver,
+      errorCount: MoreThan(0),
+      errorStatus: "Unresolved"
+    })
 
     const queryResult = await query.execute()
 

--- a/src/services/resolveCourtCase.ts
+++ b/src/services/resolveCourtCase.ts
@@ -1,0 +1,58 @@
+import { DataSource, UpdateResult } from "typeorm"
+import { isError } from "types/Result"
+import User from "./entities/User"
+import { ManualResolution } from "types/ManualResolution"
+import CourtCase from "./entities/CourtCase"
+import unlockCourtCase from "./unlockCourtCase"
+import insertNotes from "./insertNotes"
+
+const resolveCourtCase = async (
+  dataSource: DataSource,
+  courtCaseId: number,
+  resolution: ManualResolution,
+  user: User
+): Promise<UpdateResult | Error> => {
+  const updateResult = dataSource.transaction("SERIALIZABLE", async (entityManager): Promise<UpdateResult | Error> => {
+    const courtCaseRepository = entityManager.getRepository(CourtCase)
+    const resolver = user.username
+    const resolutionTimestamp = new Date()
+
+    const query = courtCaseRepository.createQueryBuilder().update(CourtCase)
+    query.set({
+      errorStatus: "Resolved",
+      errorResolvedBy: resolver,
+      errorResolvedTimestamp: resolutionTimestamp,
+      resolutionTimestamp: resolutionTimestamp
+    })
+    query.andWhere("error_id = :id", { id: courtCaseId })
+
+    const unlockResult = await unlockCourtCase(entityManager, +courtCaseId, user)
+
+    if (isError(unlockResult)) {
+      throw unlockResult
+    }
+
+    const addNoteResult = await insertNotes(entityManager, [
+      {
+        noteText:
+          `${resolver}: Portal Action: Record Manually Resolved.` +
+          ` Reason: ${resolution.reason}. Reason Text: ${resolution.reasonText}`,
+        errorId: courtCaseId,
+        userId: "System"
+      }
+    ])
+
+    if (isError(addNoteResult)) {
+      throw addNoteResult
+    }
+
+    return query.execute()?.catch((error: Error) => error)
+  })
+  if (isError(updateResult)) {
+    throw updateResult
+  }
+
+  return updateResult
+}
+
+export default resolveCourtCase

--- a/src/types/ManualResolution.ts
+++ b/src/types/ManualResolution.ts
@@ -1,0 +1,21 @@
+type ResolutionReasonKeys =
+  | "UpdatedDisposal"
+  | "UpdatedRemand"
+  | "UpdatedDisposalAndRemand"
+  | "PNCRecordIsAccurate"
+  | "NonRecordable"
+  | "Reallocated"
+
+export const ResolutionReasons: Record<ResolutionReasonKeys, string> = {
+  UpdatedDisposal: "Updated disposal(s) manually on PNC",
+  UpdatedRemand: "Updated remand(s) manually on PNC",
+  UpdatedDisposalAndRemand: "Updated disposal(s) and remand(s) manually on PNC",
+  PNCRecordIsAccurate: "PNC record already has accurate results",
+  NonRecordable: "Hearing outcome is non-recordable - no PNC update required",
+  Reallocated: "Passed to another force/area/prosecutor/dept (specify below)"
+}
+
+export type ManualResolution = {
+  reason: keyof typeof ResolutionReasons
+  reasonText?: string
+}

--- a/src/types/ManualResolution.ts
+++ b/src/types/ManualResolution.ts
@@ -1,4 +1,4 @@
-type ResolutionReasonKeys =
+export type ResolutionReasonKey =
   | "UpdatedDisposal"
   | "UpdatedRemand"
   | "UpdatedDisposalAndRemand"
@@ -6,7 +6,7 @@ type ResolutionReasonKeys =
   | "NonRecordable"
   | "Reallocated"
 
-export const ResolutionReasons: Record<ResolutionReasonKeys, string> = {
+export const ResolutionReasons: Record<ResolutionReasonKey, string> = {
   UpdatedDisposal: "Updated disposal(s) manually on PNC",
   UpdatedRemand: "Updated remand(s) manually on PNC",
   UpdatedDisposalAndRemand: "Updated disposal(s) and remand(s) manually on PNC",

--- a/src/utils/validators/validateManualResolution.test.ts
+++ b/src/utils/validators/validateManualResolution.test.ts
@@ -1,0 +1,19 @@
+import { ManualResolution } from "types/ManualResolution"
+import { validateManualResolution } from "./validateManualResolution"
+
+describe("validateManualResolution", () => {
+  it.each([
+    { input: { reason: "PNCRecordIsAccurate" } as ManualResolution, expected: { valid: true } },
+    {
+      input: { reason: "Reallocated", reasonText: undefined } as ManualResolution,
+      expected: { valid: false, error: "Reason text is required" }
+    },
+    {
+      input: { reason: "Reallocated", reasonText: "" } as ManualResolution,
+      expected: { valid: false, error: "Reason text is required" }
+    },
+    { input: { reason: "Reallocated", reasonText: "Should be valid" } as ManualResolution, expected: { valid: true } }
+  ])("test validateManualResolution with '$input' returns '$expected'", ({ input, expected }) => {
+    expect(validateManualResolution(input)).toEqual(expected)
+  })
+})

--- a/src/utils/validators/validateManualResolution.ts
+++ b/src/utils/validators/validateManualResolution.ts
@@ -1,0 +1,9 @@
+import { ManualResolution } from "types/ManualResolution"
+
+export const validateManualResolution = (manualResolution: ManualResolution): { valid: boolean; error?: string } => {
+  if (manualResolution.reason === "Reallocated" && !manualResolution.reasonText) {
+    return { valid: false, error: "Reason text is required" }
+  }
+
+  return { valid: true }
+}

--- a/test/services/resolveCourtCase.integration.test.ts
+++ b/test/services/resolveCourtCase.integration.test.ts
@@ -61,21 +61,21 @@ describe("resolveCourtCase", () => {
     await dataSource.destroy()
   })
 
+  it("should call cases by organisation unit query", async () => {
+    await resolveCourtCase(
+      dataSource,
+      0,
+      {
+        reason: "NonRecordable"
+      },
+      user
+    )
+
+    expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledTimes(1)
+    expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledWith(expect.any(Object), user)
+  })
+
   describe("When there aren't any unresolved triggers", () => {
-    it("should call cases by organisation unit query", async () => {
-      await resolveCourtCase(
-        dataSource,
-        0,
-        {
-          reason: "NonRecordable"
-        },
-        user
-      )
-
-      expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledTimes(1)
-      expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledWith(expect.any(Object), user)
-    })
-
     it("Should resolve a case and populate a resolutionTimestamp", async () => {
       await insertCourtCasesWithFields([
         {

--- a/test/services/resolveCourtCase.integration.test.ts
+++ b/test/services/resolveCourtCase.integration.test.ts
@@ -206,7 +206,7 @@ describe("resolveCourtCase", () => {
       expect(courtCases[0].errorStatus).toEqual("Unresolved")
     })
 
-    it("Should not resolve a case when the error is locked by another user", async () => {
+    it("Should not resolve a case when the case is locked by another user", async () => {
       const anotherUser = "Another User"
       await insertCourtCasesWithFields([
         {

--- a/test/services/resolveCourtCase.integration.test.ts
+++ b/test/services/resolveCourtCase.integration.test.ts
@@ -1,0 +1,101 @@
+import User from "services/entities/User"
+import { DataSource } from "typeorm"
+import { isError } from "types/Result"
+import CourtCase from "../../src/services/entities/CourtCase"
+import getCourtCaseByOrganisationUnit from "../../src/services/getCourtCaseByOrganisationUnit"
+import getDataSource from "../../src/services/getDataSource"
+import resolveCourtCase from "../../src/services/resolveCourtCase"
+import deleteFromEntity from "../utils/deleteFromEntity"
+import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
+import { differenceInMilliseconds } from "date-fns"
+import { ManualResolution } from "types/ManualResolution"
+
+jest.setTimeout(100000)
+
+describe("resolveCourtCase", () => {
+  let dataSource: DataSource
+  const visibleForce = "36"
+  const resolverUsername = "Resolver User"
+
+  beforeAll(async () => {
+    dataSource = await getDataSource()
+  })
+
+  beforeEach(async () => {
+    await deleteFromEntity(CourtCase)
+  })
+
+  afterAll(async () => {
+    await dataSource.destroy()
+  })
+
+  describe("Mark court case as manually resolved", () => {
+    it("Should resolve a case when there are no unresolved triggers", async () => {
+      const user = {
+        visibleCourts: [],
+        visibleForces: [visibleForce],
+        username: resolverUsername,
+        canLockExceptions: true,
+        canLockTriggers: true
+      } as Partial<User> as User
+
+      await insertCourtCasesWithFields([
+        {
+          errorLockedByUsername: resolverUsername,
+          triggerLockedByUsername: resolverUsername,
+          orgForPoliceFilter: visibleForce
+        }
+      ])
+
+      const resolution: ManualResolution = {
+        reason: "NonRecordable",
+        reasonText: ""
+      }
+
+      const beforeCourtCaseResult = await getCourtCaseByOrganisationUnit(dataSource, 0, user)
+      expect(isError(beforeCourtCaseResult)).toBeFalsy()
+      expect(beforeCourtCaseResult).not.toBeNull()
+      const beforeCourtCase = beforeCourtCaseResult as CourtCase
+      expect(beforeCourtCase.errorStatus).toEqual("Unresolved")
+      expect(beforeCourtCase.errorLockedByUsername).toEqual(resolverUsername)
+      expect(beforeCourtCase.triggerLockedByUsername).toEqual(resolverUsername)
+      expect(beforeCourtCase.errorResolvedBy).toBeNull()
+      expect(beforeCourtCase.errorResolvedTimestamp).toBeNull()
+      expect(beforeCourtCase.resolutionTimestamp).toBeNull()
+
+      const result = await resolveCourtCase(dataSource, 0, resolution, user)
+
+      expect(isError(result)).toBeFalsy()
+
+      const afterCourtCaseResult = await getCourtCaseByOrganisationUnit(dataSource, 0, user)
+      expect(isError(afterCourtCaseResult)).toBeFalsy()
+      expect(afterCourtCaseResult).not.toBeNull()
+      const afterCourtCase = afterCourtCaseResult as CourtCase
+
+      // Resolves the error
+      expect(afterCourtCase.errorStatus).toEqual("Resolved")
+      // Unlocks the case
+      expect(afterCourtCase.errorLockedByUsername).toBeNull()
+      expect(afterCourtCase.triggerLockedByUsername).toBeNull()
+      // Sets resolver user
+      expect(afterCourtCase.errorResolvedBy).toEqual(resolverUsername)
+
+      // Sets the timestamps
+      expect(afterCourtCase.errorResolvedTimestamp).not.toBeNull()
+      expect(afterCourtCase.resolutionTimestamp).not.toBeNull()
+      // When there are no unresolved triggers the resolution time stamp also set
+      expect(afterCourtCase.errorResolvedTimestamp).toEqual(afterCourtCase.resolutionTimestamp)
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const timeSinceCaseTriggersResolved = differenceInMilliseconds(new Date(), afterCourtCase.errorResolvedTimestamp!)
+      expect(timeSinceCaseTriggersResolved).toBeGreaterThanOrEqual(0)
+
+      // Creates a system note
+      expect(afterCourtCase.notes[0].userId).toEqual("System")
+      expect(afterCourtCase.notes[0].noteText).toEqual(
+        `${resolverUsername}: Portal Action: Record Manually Resolved.` +
+          ` Reason: ${resolution.reason}. Reason Text: ${resolution.reasonText}`
+      )
+    })
+  })
+})

--- a/test/services/resolveCourtCase.integration.test.ts
+++ b/test/services/resolveCourtCase.integration.test.ts
@@ -86,7 +86,8 @@ describe("resolveCourtCase", () => {
       ])
 
       const resolution: ManualResolution = {
-        reason: "NonRecordable"
+        reason: "NonRecordable",
+        reasonText: "Some description"
       }
 
       const beforeCourtCaseResult = await getCourtCaseByOrganisationUnit(dataSource, 0, user)
@@ -229,6 +230,39 @@ describe("resolveCourtCase", () => {
       const afterCourtCase = afterCourtCaseResult as CourtCase
 
       expectToBeUnresolved(afterCourtCase)
+    })
+
+    it("Should return the error when the resolution reason is 'Reallocated' but reasonText is not provided", async () => {
+      await insertCourtCasesWithFields([
+        {
+          errorLockedByUsername: resolverUsername,
+          triggerLockedByUsername: resolverUsername,
+          orgForPoliceFilter: visibleForce
+        }
+      ])
+
+      let result = await resolveCourtCase(
+        dataSource,
+        0,
+        {
+          reason: "Reallocated",
+          reasonText: undefined
+        },
+        user
+      )
+      expect(isError(result)).toBeTruthy()
+      expect((result as Error).message).toEqual("Reason text is required")
+
+      result = await resolveCourtCase(
+        dataSource,
+        0,
+        {
+          reason: "Reallocated",
+          reasonText: "Text provided"
+        },
+        user
+      )
+      expect(isError(result)).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
### Context
Implement the “Mark As Manually Resolved” functionality in the new UI. The focus of this ticket is functionality rather than a polished UX.

### Changes
- Capture the logic of [marking a case as manually resolved](https://github.com/ministryofjustice/bichard7-next/blob/main/bichard-backend/src/main/java/uk/gov/ocjr/mtu/br7/errorlistdialogue/actions/ConfirmMarkAsResolvedAction.java#L82)
- Add a placeholder resolve page and cypress tests(should be updated once we have a design)

### Next steps:
- Add audit log messages when a case is manually resolved(Old bichard pushes messages to GENERAL_EVENT_QUEUE). There is a ticket to [add audit logs to the new UI](https://dsdmoj.atlassian.net/browse/BICAWS-2777)
- Finalise the UI and update cypress tests