### PR TITLE
Show resolved triggers

### DIFF
--- a/cypress/e2e/court-cases/CourtCaseDetails.cy.ts
+++ b/cypress/e2e/court-cases/CourtCaseDetails.cy.ts
@@ -446,39 +446,6 @@ describe("Court case details", () => {
     cy.get(".moj-tab-panel-triggers").contains("There are no triggers for this case.")
   })
 
-  it("should display a message when all triggers are resolved", () => {
-    cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
-    const triggers: TestTrigger[] = [
-      {
-        triggerId: 0,
-        triggerCode: "TRPR0010",
-        status: "Resolved",
-        createdAt: new Date("2022-07-09T10:22:34.000Z"),
-        resolvedAt: new Date("2022-07-09T12:22:34.000Z"),
-        resolvedBy: "Bichard01"
-      },
-      {
-        triggerId: 1,
-        triggerCode: "TRPR0015",
-        status: "Resolved",
-        createdAt: new Date("2022-07-09T10:22:34.000Z"),
-        resolvedAt: new Date("2022-07-09T12:22:34.000Z"),
-        resolvedBy: "Bichard01"
-      }
-    ]
-    cy.task("insertTriggers", { caseId: 0, triggers })
-
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
-
-    cy.get(".moj-tab-panel-triggers").should("be.visible")
-    cy.get(".moj-tab-panel-exceptions").should("not.be.visible")
-
-    cy.get(".moj-tab-panel-triggers .moj-trigger-row").should("not.exist")
-    cy.get(".moj-tab-panel-triggers").contains("All triggers have been resolved.")
-  })
-
   it("should select all triggers when select all link is clicked", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
     const triggers: TestTrigger[] = [
@@ -667,6 +634,26 @@ describe("Court case details", () => {
       .contains("More information")
       .should("exist")
       .should("have.attr", "href", "/help/bichard-functionality/exceptions/resolution.html#HO100302")
+  })
+
+  it("should show a complete badge for triggers which have been resolved", () => {
+    cy.task("insertCourtCasesWithFields", [
+      { orgForPoliceFilter: "01", hearingOutcome: DummyHO100302Aho.hearingOutcomeXml }
+    ])
+    const trigger: TestTrigger = {
+      triggerId: 0,
+      triggerCode: "TRPR0001",
+      status: "Resolved",
+      createdAt: new Date(),
+      resolvedAt: new Date(),
+      resolvedBy: "Bichard01"
+    }
+    cy.task("insertTriggers", { caseId: 0, triggers: [trigger] })
+
+    cy.login("bichard01@example.com", "password")
+    cy.visit("/bichard/court-cases/0")
+
+    cy.get("#triggers span").contains("Complete").should("exist")
   })
 })
 

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -15,7 +15,6 @@ interface Props<TValue> {
 
 const useStyles = createUseStyles({
   Checkbox: {
-    display: "inline-block",
     "& span:before": {
       width: "30px",
       height: "30px"
@@ -45,7 +44,7 @@ export default function Checkbox<TValue extends ValueType>({
       value={value}
       checked={checked}
       onChange={onChange}
-      className={`${classes.Checkbox} ${className} moj-checkbox`}
+      className={`${classes.Checkbox} ${className} moj-checkbox govuk-!-display-inline-block`}
     >
       {children}
     </GovUkCheckbox>

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -145,6 +145,7 @@ const CourtCaseDetails: React.FC<Props> = ({ courtCase, aho, lockedByAnotherUser
               </Table.Cell>
             </Table.Row>
           </Table>
+
           <ConditionalRender isRendered={triggersVisible && (courtCase?.triggers?.length ?? 0) > 0}>
             <Heading as="h2" size="MEDIUM">
               {"Triggers"}

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -38,8 +38,10 @@ const useStyles = createUseStyles({
 
 const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: Props) => {
   const triggerDefinition = getTriggerDefinition(trigger.triggerCode)
-  const checkBoxId = `trigger_${trigger.triggerId}`
   const [showHelpBox, setShowHelpBox] = useState(false)
+
+  const checkBoxId = `trigger_${trigger.triggerId}`
+  const isResolved = trigger.status === "Resolved"
 
   const classes = useStyles()
 
@@ -62,12 +64,16 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
           <p>{triggerDefinition?.description}</p>
         </GridCol>
         <GridCol setWidth="70px" className="checkbox-column">
-          <Checkbox
-            id={checkBoxId}
-            value={trigger.triggerId}
-            checked={selectedTriggerIds.includes(trigger.triggerId)}
-            onChange={setTriggerSelection}
-          />
+          {isResolved ? (
+            <span className="moj-badge moj-badge--green">{"Complete"}</span>
+          ) : (
+            <Checkbox
+              id={checkBoxId}
+              value={trigger.triggerId}
+              checked={selectedTriggerIds.includes(trigger.triggerId)}
+              onChange={setTriggerSelection}
+            />
+          )}
         </GridCol>
       </GridRow>
       <GridRow>

--- a/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/Trigger.tsx
@@ -17,39 +17,34 @@ interface Props {
 }
 
 const useStyles = createUseStyles({
-  triggerRow: {
-    "& .trigger-details-column": {
-      "& .trigger-code": {
-        fontWeight: "bold"
-      }
-    },
-    "& .checkbox-column": {
-      textAlign: "right",
-      "& .moj-checkbox": {
-        marginRight: "9px"
-      }
-    }
+  triggerCode: {
+    fontWeight: "bold"
   },
   cjsResultCode: {
     fontSize: "16px",
     lineHeight: "1.25"
+  },
+  triggerCheckbox: {
+    position: "absolute",
+    right: "22px"
   }
 })
+
+const TriggerCompleteBadge = () => <span className="moj-badge moj-badge--green">{"Complete"}</span>
 
 const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: Props) => {
   const triggerDefinition = getTriggerDefinition(trigger.triggerCode)
   const [showHelpBox, setShowHelpBox] = useState(false)
+  const classes = useStyles()
 
   const checkBoxId = `trigger_${trigger.triggerId}`
   const isResolved = trigger.status === "Resolved"
 
-  const classes = useStyles()
-
   return (
     <div key={trigger.triggerId}>
-      <GridRow className={`${classes.triggerRow} moj-trigger-row`}>
+      <GridRow className="moj-trigger-row">
         <GridCol className="trigger-details-column">
-          <label className="trigger-code" htmlFor={checkBoxId}>
+          <label className={`trigger-code ${classes.triggerCode}`} htmlFor={checkBoxId}>
             {trigger.shortTriggerCode}
           </label>
           {trigger.triggerItemIdentity !== undefined && (
@@ -63,16 +58,18 @@ const Trigger = ({ trigger, onClick, selectedTriggerIds, setTriggerSelection }: 
           )}
           <p>{triggerDefinition?.description}</p>
         </GridCol>
-        <GridCol setWidth="70px" className="checkbox-column">
+        <GridCol>
           {isResolved ? (
-            <span className="moj-badge moj-badge--green">{"Complete"}</span>
+            <TriggerCompleteBadge />
           ) : (
-            <Checkbox
-              id={checkBoxId}
-              value={trigger.triggerId}
-              checked={selectedTriggerIds.includes(trigger.triggerId)}
-              onChange={setTriggerSelection}
-            />
+            <div className={classes.triggerCheckbox}>
+              <Checkbox
+                id={checkBoxId}
+                value={trigger.triggerId}
+                checked={selectedTriggerIds.includes(trigger.triggerId)}
+                onChange={setTriggerSelection}
+              />
+            </div>
           )}
         </GridCol>
       </GridRow>

--- a/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -5,6 +5,7 @@ import ActionLink from "components/ActionLink"
 import { ChangeEvent, useState } from "react"
 import type NavigationHandler from "types/NavigationHandler"
 import Trigger from "./Trigger"
+import { sortBy } from "lodash"
 
 interface Props {
   courtCase: CourtCase
@@ -26,7 +27,7 @@ const useStyles = createUseStyles({
 const TriggersList = ({ courtCase, onNavigate }: Props) => {
   const classes = useStyles()
   const [selectedTriggerIds, setSelectedTriggerIds] = useState<number[]>([])
-  const unresolvedTriggers = courtCase.triggers.filter((trigger) => !trigger.resolvedBy)
+  const triggers = sortBy(courtCase.triggers, "triggerItemIdentity")
 
   const setTriggerSelection = ({ target: checkbox }: ChangeEvent<HTMLInputElement>) => {
     const triggerId = parseInt(checkbox.value, 10)
@@ -48,16 +49,15 @@ const TriggersList = ({ courtCase, onNavigate }: Props) => {
 
   return (
     <>
-      {unresolvedTriggers.length === 0 && courtCase.triggers.length > 0 && "All triggers have been resolved."}
-      {unresolvedTriggers.length === 0 && courtCase.triggers.length === 0 && "There are no triggers for this case."}
-      {unresolvedTriggers.length > 0 && (
+      {triggers.length === 0 && "There are no triggers for this case."}
+      {triggers.length > 0 && (
         <GridRow className={classes.selectAllRow}>
           <GridCol>
             <ActionLink onClick={selectAll}>{"Select all"}</ActionLink>
           </GridCol>
         </GridRow>
       )}
-      {unresolvedTriggers.map((trigger, index) => (
+      {triggers.map((trigger, index) => (
         <Trigger
           key={index}
           trigger={trigger}


### PR DESCRIPTION
This PR:
* Shows all triggers on the case details page, not just unresolved ones
* Shows a "Complete" badge next to resolved triggers 
* Sorts case triggers when showing them, so that they are always displayed in a consistent manner
* Adds cypress e2e test for complete badge
* Uses the gov.uk layout class for displaying a checkbox as an inline block, this plays nicer with other GDS layout components

![Screenshot 2023-05-26 at 12 53 56](https://github.com/ministryofjustice/bichard7-next-ui/assets/7249529/ab9c01b9-9567-4db2-88b7-4d79a09683cb)
