### PR TITLE
Fix styling issues on the case list page

### DIFF
--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -125,7 +125,7 @@ export const CaseDetailsRow = ({
         </Table.Cell>
       </Table.Row>
       {numberOfNotes != 0 && !showPreview && (
-        <Table.Row className={classes.notesRow}>
+        <Table.Row className={`${classes.notesRow} ${rowClassName}`}>
           <Table.Cell
             className={`${cellClassName} ${firstColumnClassName} ${customClasses["top-padding-none"]}`}
           ></Table.Cell>

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -23,7 +23,7 @@ import { useCustomStyles } from "../../../../../styles/customStyles"
 
 interface CaseDetailsRowProps {
   canCurrentUserUnlockCase: string | boolean | null | undefined
-  cellClassName: string
+  hasTriggers: boolean
   courtDate: Date | null
   courtName: string
   defendantName: string | null
@@ -55,7 +55,7 @@ const useStyles = createUseStyles({
 
 export const CaseDetailsRow = ({
   canCurrentUserUnlockCase,
-  cellClassName,
+  hasTriggers,
   courtDate,
   courtName,
   defendantName,
@@ -84,38 +84,41 @@ export const CaseDetailsRow = ({
   const classes = useStyles()
   const customClasses = useCustomStyles()
 
+  const caseDetailsCellClass = !hasTriggers && showPreview ? "" : customClasses["border-bottom-none"]
+  const notePreviewCellClass = !hasTriggers && !showPreview ? "" : customClasses["border-bottom-none"]
+
   return (
     <>
       <Table.Row className={`${classes.caseDetailsRow} ${rowClassName}`}>
-        <Table.Cell className={`${cellClassName} ${firstColumnClassName}`}>
+        <Table.Cell className={`${caseDetailsCellClass} ${firstColumnClassName}`}>
           <ConditionalRender isRendered={!!errorLockedByUsername}>
             <Image src={LOCKED_ICON_URL} width={20} height={20} alt="Lock icon" />
           </ConditionalRender>
         </Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>
           <Link href={caseDetailsPath(errorId)} id={`Case details for ${defendantName}`}>
             {defendantName}
             <br />
             <ResolvedTag isResolved={isResolved} />
           </Link>
         </Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>
           <DateTime date={courtDate} dateFormat={displayedDateFormat} />
         </Table.Cell>
-        <Table.Cell className={cellClassName}>{courtName}</Table.Cell>
-        <Table.Cell className={cellClassName}>{ptiurn}</Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>{courtName}</Table.Cell>
+        <Table.Cell className={caseDetailsCellClass}>{ptiurn}</Table.Cell>
+        <Table.Cell className={caseDetailsCellClass}>
           <UrgentTag isUrgent={isUrgent} />
         </Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>
           <NotePreviewButton previewState={showPreview} setShowPreview={setShowPreview} numberOfNotes={numberOfNotes} />
         </Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>
           {Object.keys(exceptions).map((exception, exceptionId) => {
             return <SingleException key={exceptionId} exception={exception} exceptionCounter={exceptions[exception]} />
           })}
         </Table.Cell>
-        <Table.Cell className={cellClassName}>
+        <Table.Cell className={caseDetailsCellClass}>
           {canCurrentUserUnlockCase ? (
             <LockedByTag lockedBy={errorLockedByUsername} unlockPath={unlockPath} />
           ) : (
@@ -125,19 +128,19 @@ export const CaseDetailsRow = ({
         </Table.Cell>
       </Table.Row>
       {numberOfNotes != 0 && !showPreview && (
-        <Table.Row className={`${classes.notesRow} ${rowClassName}`}>
+        <Table.Row className={`${rowClassName}`}>
           <Table.Cell
-            className={`${cellClassName} ${firstColumnClassName} ${customClasses["top-padding-none"]}`}
+            className={`${notePreviewCellClass} ${firstColumnClassName} ${customClasses["top-padding-none"]}`}
           ></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`}></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`}></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`}></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`}></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`}></Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`} colSpan={2}>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`}></Table.Cell>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`}></Table.Cell>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`}></Table.Cell>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`}></Table.Cell>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`}></Table.Cell>
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`} colSpan={2}>
             <NotePreview latestNote={mostRecentUserNote} numberOfNotes={numberOfNotes} />
           </Table.Cell>
-          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`} />
+          <Table.Cell className={`${notePreviewCellClass} ${customClasses["top-padding-none"]}`} />
         </Table.Row>
       )}
     </>

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -137,7 +137,7 @@ export const CaseDetailsRow = ({
           <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`} colSpan={2}>
             <NotePreview latestNote={mostRecentUserNote} numberOfNotes={numberOfNotes} />
           </Table.Cell>
-          <Table.Cell />
+          <Table.Cell className={`${cellClassName} ${customClasses["top-padding-none"]}`} />
         </Table.Row>
       )}
     </>

--- a/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
@@ -56,7 +56,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
     <>
       <CaseDetailsRow
         canCurrentUserUnlockCase={errorLockedByUsername && canUnlockCase(errorLockedByUsername)}
-        cellClassName={hasTriggers ? classes["border-bottom-none"] : ""}
+        hasTriggers={hasTriggers}
         courtDate={courtDate}
         courtName={courtName}
         defendantName={defendantName}

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -84,6 +84,7 @@ const listCourtCases = async (
     query.addOrderBy("courtCase.ptiurn")
   }
 
+  // Filters
   if (defendantName) {
     const defendantNameLike = { defendantName: ILike(`%${defendantName}%`) }
     query.andWhere(defendantNameLike)

--- a/test/helpers/createDummyCase.ts
+++ b/test/helpers/createDummyCase.ts
@@ -37,7 +37,7 @@ export default async (
   const isResolved = randomBoolean()
   const resolutionStatus = isResolved ? "Resolved" : "Unresolved"
   const resolutionDate = isResolved ? randomDate(caseDate, dateTo || new Date()) : null
-  const triggers = createDummyTriggers(dataSource, caseId, caseDate)
+  const triggers = createDummyTriggers(dataSource, caseId, caseDate, isResolved)
   const hasTriggers = triggers.length > 0
   const notes = createDummyNotes(dataSource, caseId, triggers, isResolved)
   const { errorReport, errorReason, exceptionCount } = createDummyExceptions()

--- a/test/helpers/createDummyTriggers.ts
+++ b/test/helpers/createDummyTriggers.ts
@@ -43,7 +43,7 @@ const triggerFrequency = {
 const totalFrequency = Object.values(triggerFrequency).reduce((a, b) => a + b, 0)
 const probs = Object.values(triggerFrequency).map((freq) => freq / totalFrequency)
 
-export default (dataSource: DataSource, errorId: number, creationDate: Date): Trigger[] => {
+export default (dataSource: DataSource, errorId: number, creationDate: Date, isResolved?: boolean): Trigger[] => {
   const numTriggers = Math.min(Math.round(exponential(2) * 2), 5) + 1
   const triggerCodes = sample(Object.keys(triggerFrequency), {
     size: numTriggers,
@@ -52,7 +52,7 @@ export default (dataSource: DataSource, errorId: number, creationDate: Date): Tr
   })
 
   return triggerCodes.map((triggerCode, idx) => {
-    const status = createResolutionStatus()
+    const status = isResolved ? "Resolved" : createResolutionStatus()
     return dataSource.getRepository(Trigger).create({
       errorId,
       triggerCode: triggerCode,


### PR DESCRIPTION
This PR:
* Removes the bottom border from the last column in the note preview row
* Prevents resolved cases from being generated with unresolved triggers
  * This was causing some cases to show up with the "resolved" badge when only unresolved cases should be shown
* Fixes the note preview row to use the same background colour as the rest of the case