### PR TITLE
Use styling instead of nbsp for no-wrap on exceptions

### DIFF
--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
@@ -1,10 +1,16 @@
+import styled from "styled-components"
+
 interface SingleExceptionProps {
   exception: string
   exceptionCounter: number
 }
 
+const SingleExceptionWrapper = styled.span`
+  white-space: nowrap;
+`
+
 export const SingleException = ({ exception, exceptionCounter }: SingleExceptionProps) => (
-  <span className="single-exception">
+  <SingleExceptionWrapper className="single-exception">
     {exception} <b>{exceptionCounter > 1 ? `(${exceptionCounter})` : ""}</b>
-  </span>
+  </SingleExceptionWrapper>
 )

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
@@ -5,9 +5,6 @@ interface SingleExceptionProps {
 
 export const SingleException = ({ exception, exceptionCounter }: SingleExceptionProps) => (
   <span className="single-exception">
-    <span className="code">{exception}</span>
-    <span className="counter">
-      <b> {exceptionCounter > 1 ? `(${exceptionCounter})` : ""}</b>
-    </span>
+    {exception} <b>{exceptionCounter > 1 ? `(${exceptionCounter})` : ""}</b>
   </span>
 )

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
@@ -4,9 +4,10 @@ interface SingleExceptionProps {
 }
 
 export const SingleException = ({ exception, exceptionCounter }: SingleExceptionProps) => (
-  <span>
-    {exception}
-    <b>&nbsp;{exceptionCounter > 1 ? `(${exceptionCounter})` : ""}</b>
-    <br />
+  <span className="single-exception">
+    <span className="code">{exception}</span>
+    <span className="counter">
+      <b> {exceptionCounter > 1 ? `(${exceptionCounter})` : ""}</b>
+    </span>
   </span>
 )

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/SingleException.tsx
@@ -5,7 +5,7 @@ interface SingleExceptionProps {
   exceptionCounter: number
 }
 
-const SingleExceptionWrapper = styled.span`
+const SingleExceptionWrapper = styled.div`
   white-space: nowrap;
 `
 


### PR DESCRIPTION
`&nbsp;` was causing issues with equivalence for E2E tests, this removes that as a solution and uses a styled component instead.