### PR TITLE
Reusable CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,10 +138,6 @@ jobs:
       - run:
           name: Save UI docker image
           command: docker save ui > ui.tar
-      
-      # - run:
-      #     name: Generate cache key file
-      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
 
       - save_cache:
           name: Cache UI docker image
@@ -162,9 +158,6 @@ jobs:
           image: user-service
       - fetch_docker_image:
           image: nginx-auth-proxy
-      # - run:
-      #     name: Generate cache key file
-      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
       - restore_cache:
           name: Restore UI docker image from cache
           keys: 
@@ -282,9 +275,6 @@ jobs:
           image: pncemulator
       - fetch_docker_image:
           image: beanconnect
-      # - run:
-      #     name: Generate cache key file
-      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
       - restore_cache:
           name: Restore UI docker image from cache
           keys: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,13 +139,13 @@ jobs:
           name: Save UI docker image
           command: docker save ui > ui.tar
       
-      - run:
-          name: Generate cache key file
-          command: echo $CIRCLE_WORKFLOW_ID > /tmp/circle_workflow_id
+      # - run:
+      #     name: Generate cache key file
+      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
 
       - save_cache:
           name: Cache UI docker image
-          key: ui-image-{{ checksum "/tmp/circle_workflow_id" }}
+          key: ui-image-<<pipeline.git.revision>>
           paths: ui.tar
 
   cypress_e2e_test:
@@ -162,13 +162,13 @@ jobs:
           image: user-service
       - fetch_docker_image:
           image: nginx-auth-proxy
-      - run:
-          name: Generate cache key file
-          command: echo $CIRCLE_WORKFLOW_ID > /tmp/circle_workflow_id
+      # - run:
+      #     name: Generate cache key file
+      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
       - restore_cache:
           name: Restore UI docker image from cache
           keys: 
-            - ui-image-{{ checksum "/tmp/circle_workflow_id" }}
+            - ui-image-<<pipeline.git.revision>>
       - run:
           name: Load UI docker image
           command: docker load < ui.tar
@@ -282,13 +282,13 @@ jobs:
           image: pncemulator
       - fetch_docker_image:
           image: beanconnect
-      - run:
-          name: Generate cache key file
-          command: echo $CIRCLE_WORKFLOW_ID > /tmp/circle_workflow_id
+      # - run:
+      #     name: Generate cache key file
+      #     command: echo $CIRCLE_SHA1 > /tmp/commit-hash
       - restore_cache:
           name: Restore UI docker image from cache
           keys: 
-            - ui-image-{{ checksum "/tmp/circle_workflow_id" }}
+            - ui-image-<<pipeline.git.revision>>
       - run:
           name: Load UI docker image
           command: docker load < ui.tar


### PR DESCRIPTION
The recent change we made to how the pipeline builds caused an issue with workflow reruns as we were using a workflow ID to persist the docker image once it was built. This PR changes the cache key to use the git revision of the image instead.