### PR TITLE
Remove PNC Errors tab

### DIFF
--- a/cypress/e2e/court-cases/court-case-details/CourtCaseDetails.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/CourtCaseDetails.cy.ts
@@ -99,8 +99,6 @@ describe("Court case details", () => {
     cy.get("H3").contains("Offences")
     clickTab("Notes")
     cy.get("H3").contains("Notes")
-    clickTab("PNC errors")
-    cy.get("H3").contains("PNC errors")
   })
 
   it("Should display the content of the Defendant tab", () => {

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -114,7 +114,7 @@ const CourtCaseDetails: React.FC<Props> = ({
           setActiveTab(tab)
           updateQueryString({ tab, offence: null })
         }}
-        tabs={["Defendant", "Hearing", "Case", "Offences", "Notes", "PNC errors"]}
+        tabs={["Defendant", "Hearing", "Case", "Offences", "Notes"]}
         width={contentWidth}
       />
 
@@ -151,10 +151,6 @@ const CourtCaseDetails: React.FC<Props> = ({
 
           <ConditionalRender isRendered={activeTab === "Notes"}>
             <Notes notes={courtCase.notes} lockedByAnotherUser={errorLockedByAnotherUser} />
-          </ConditionalRender>
-
-          <ConditionalRender isRendered={activeTab === "PNC errors"}>
-            <CourtCaseDetailsPanel heading={"PNC errors"}>{""}</CourtCaseDetailsPanel>
           </ConditionalRender>
 
           <ConditionalRender isRendered={!lockedByAnotherUser}>

--- a/src/types/CaseDetailsTab.ts
+++ b/src/types/CaseDetailsTab.ts
@@ -1,3 +1,3 @@
-type CaseDetailsTab = "Defendant" | "Hearing" | "Case" | "Offences" | "Notes" | "PNC errors"
+type CaseDetailsTab = "Defendant" | "Hearing" | "Case" | "Offences" | "Notes"
 
 export default CaseDetailsTab


### PR DESCRIPTION
PNC errors are going to be shown in the exceptions panel

The E2E tests are failing where they check the PNC errors tab, https://github.com/ministryofjustice/bichard7-next-tests/pull/400 updates the tests