### PR TITLE
Pass the court case instead of id to reduce unnecessary queries

### DIFF
--- a/src/services/reallocateCourtCaseToForce.ts
+++ b/src/services/reallocateCourtCaseToForce.ts
@@ -13,10 +13,10 @@ import {
   AuditLogEventOptions
 } from "@moj-bichard7-developers/bichard7-next-core/dist/types/AuditLogEvent"
 import storeAuditLogEvents from "./storeAuditLogEvents"
-import getCourtCase from "./getCourtCase"
 import getAuditLogEvent from "@moj-bichard7-developers/bichard7-next-core/dist/lib/auditLog/getAuditLogEvent"
 import EventCategory from "@moj-bichard7-developers/bichard7-next-core/dist/types/EventCategory"
 import { AUDIT_LOG_EVENT_SOURCE } from "../config"
+import getCourtCaseByOrganisationUnit from "./getCourtCaseByOrganisationUnit"
 
 const reallocateCourtCaseToForce = async (
   dataSource: DataSource | EntityManager,
@@ -31,7 +31,7 @@ const reallocateCourtCaseToForce = async (
   return dataSource.transaction("SERIALIZABLE", async (entityManager): Promise<UpdateResult | Error> => {
     const events: AuditLogEvent[] = []
 
-    const courtCase = await getCourtCase(entityManager, courtCaseId)
+    const courtCase = await getCourtCaseByOrganisationUnit(entityManager, courtCaseId, user)
 
     if (isError(courtCase)) {
       throw courtCase
@@ -48,7 +48,7 @@ const reallocateCourtCaseToForce = async (
     query = courtCasesByOrganisationUnitQuery(query, user) as UpdateQueryBuilder<CourtCase>
     query.andWhere("error_id = :id", { id: courtCaseId })
 
-    const amendResult = await amendCourtCase(entityManager, { forceOwner: forceCode }, courtCaseId, user)
+    const amendResult = await amendCourtCase(entityManager, { forceOwner: forceCode }, courtCase, user)
 
     if (isError(amendResult)) {
       throw amendResult

--- a/src/services/reallocateCourtCaseToForce.ts
+++ b/src/services/reallocateCourtCaseToForce.ts
@@ -95,7 +95,7 @@ const reallocateCourtCaseToForce = async (
 
     const unlockResult = await updateLockStatusToUnlocked(
       entityManager,
-      +courtCaseId,
+      courtCase,
       user,
       UnlockReason.TriggerAndException,
       events

--- a/src/services/resolveCourtCase.ts
+++ b/src/services/resolveCourtCase.ts
@@ -27,7 +27,7 @@ const resolveCourtCase = async (
 
     const unlockResult = await updateLockStatusToUnlocked(
       entityManager,
-      courtCase.errorId,
+      courtCase,
       user,
       UnlockReason.TriggerAndException,
       events

--- a/src/services/resubmitCourtCase.ts
+++ b/src/services/resubmitCourtCase.ts
@@ -60,7 +60,7 @@ const resubmitCourtCase = async (
           throw addNoteResult
         }
 
-        const statusResult = await updateCourtCaseStatus(entityManager, +courtCaseId, "Error", "Submitted", user)
+        const statusResult = await updateCourtCaseStatus(entityManager, courtCase, "Error", "Submitted", user)
 
         if (isError(statusResult)) {
           return statusResult

--- a/src/services/unlockCourtCase.ts
+++ b/src/services/unlockCourtCase.ts
@@ -26,7 +26,7 @@ const unlockCourtCase = async (
       throw new Error("Failed to unlock: Case not found")
     }
 
-    const unlockResult = await updateLockStatusToUnlocked(entityManager, courtCaseId, user, unlockReason, events)
+    const unlockResult = await updateLockStatusToUnlocked(entityManager, courtCase, user, unlockReason, events)
 
     if (isError(unlockResult)) {
       throw unlockResult

--- a/test/services/reallocateCourtCaseToForce.integration.test.ts
+++ b/test/services/reallocateCourtCaseToForce.integration.test.ts
@@ -209,7 +209,7 @@ describe("reallocate court case to another force", () => {
       } as Partial<User> as User
 
       const result = await reallocateCourtCaseToForce(dataSource, courtCaseId, user, "06").catch((error) => error)
-      expect(result).toEqual(Error(`Failed to get court case`))
+      expect(result).toEqual(Error(`Failed to reallocate: Case not found`))
 
       const record = await dataSource.getRepository(CourtCase).findOne({ where: { errorId: courtCaseId } })
       const actualCourtCase = record as CourtCase

--- a/test/services/resubmitCourtCase.integration.test.ts
+++ b/test/services/resubmitCourtCase.integration.test.ts
@@ -37,8 +37,8 @@ describe("resubmit court case", () => {
   it("Should resubmit a court case with no updates", async () => {
     // set up court case in the right format to insert into the db
     const inputCourtCase = await getDummyCourtCase({
-      errorLockedByUsername: null,
-      triggerLockedByUsername: null,
+      errorLockedByUsername: userName,
+      triggerLockedByUsername: userName,
       errorCount: 1,
       errorStatus: "Unresolved",
       triggerCount: 1,
@@ -85,7 +85,7 @@ describe("resubmit court case", () => {
   it("Should resubmit a court case with updates to Court Offence Sequence Number", async () => {
     // set up court case in the right format to insert into the db
     const inputCourtCase = await getDummyCourtCase({
-      errorLockedByUsername: null,
+      errorLockedByUsername: userName,
       triggerLockedByUsername: null,
       errorCount: 1,
       errorStatus: "Unresolved",
@@ -163,7 +163,7 @@ describe("resubmit court case", () => {
 
     // set up court case in the right format to insert into the db
     const inputCourtCase = await getDummyCourtCase({
-      errorLockedByUsername: null,
+      errorLockedByUsername: userName,
       triggerLockedByUsername: null,
       errorCount: 1,
       errorStatus: "Unresolved",

--- a/test/services/unlockCourtCase.integration.test.ts
+++ b/test/services/unlockCourtCase.integration.test.ts
@@ -13,6 +13,7 @@ import updateLockStatusToUnlocked from "services/updateLockStatusToUnlocked"
 import storeAuditLogEvents from "services/storeAuditLogEvents"
 import UnlockReason from "types/UnlockReason"
 import axios from "axios"
+import getCourtCase from "../../src/services/getCourtCase"
 
 jest.mock("services/updateLockStatusToUnlocked")
 jest.mock("services/storeAuditLogEvents")
@@ -88,6 +89,8 @@ describe("unlock court case", () => {
         }
       ]
 
+      const expectedToCallWithCourtCase = await getCourtCase(dataSource, lockedCourtCase.errorId)
+
       await unlockCourtCase(dataSource, lockedCourtCase.errorId, user, UnlockReason.TriggerAndException).catch(
         (error) => error
       )
@@ -95,7 +98,7 @@ describe("unlock court case", () => {
       expect(updateLockStatusToUnlocked).toHaveBeenCalledTimes(1)
       expect(updateLockStatusToUnlocked).toHaveBeenCalledWith(
         expect.any(Object),
-        lockedCourtCase.errorId,
+        expectedToCallWithCourtCase,
         user,
         UnlockReason.TriggerAndException,
         expectedAuditLogEvents

--- a/test/services/updateCourtCaseStatus.integration.test.ts
+++ b/test/services/updateCourtCaseStatus.integration.test.ts
@@ -41,7 +41,7 @@ const insertRecord = async (
     })
   ]
 
-  await insertCourtCases(existingCourtCasesDbObjects)
+  return insertCourtCases(existingCourtCasesDbObjects)
 }
 
 describe("updateCourtCaseStatus", () => {
@@ -63,20 +63,12 @@ describe("updateCourtCaseStatus", () => {
     await dataSource.destroy()
   })
 
-  it("Should not update if the case doesn't exist", async () => {
-    const nonExistentCase = 9999
-    const result = await updateCourtCaseStatus(dataSource, nonExistentCase, "Error", "Submitted", testUser)
-
-    expect((result as UpdateResult).raw).toHaveLength(0)
-    expect((result as UpdateResult).affected).toBe(0)
-  })
-
   describe("Updating error status", () => {
     it("Should not update the case if its locked by another user", async () => {
       const errorLockedByUsername = "Another User"
-      await insertRecord(errorLockedByUsername)
+      const [courtCase] = await insertRecord(errorLockedByUsername)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Submitted", testUser)
 
       expect((result as UpdateResult).raw).toHaveLength(0)
       expect((result as UpdateResult).affected).toBe(0)
@@ -85,9 +77,9 @@ describe("updateCourtCaseStatus", () => {
     it("Should not update the case if the current error status is not set", async () => {
       const errorLockedByUsername = testUser.username
       const triggerLockedByUsername = testUser.username
-      await insertRecord(errorLockedByUsername, triggerLockedByUsername, null, null)
+      const [courtCase] = await insertRecord(errorLockedByUsername, triggerLockedByUsername, null, null)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Submitted", testUser)
 
       expect((result as UpdateResult).raw).toHaveLength(0)
       expect((result as UpdateResult).affected).toBe(0)
@@ -95,9 +87,9 @@ describe("updateCourtCaseStatus", () => {
 
     it("can updates the case when its not locked and error status is not null", async () => {
       const errorStatus = "Unresolved"
-      await insertRecord(null, null, errorStatus, null)
+      const [courtCase] = await insertRecord(null, null, errorStatus, null)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Submitted", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -116,9 +108,9 @@ describe("updateCourtCaseStatus", () => {
     it("Should update the case when its locked by the user and error status is not null", async () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Unresolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, null)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, null)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Submitted", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -137,9 +129,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Unresolved"
       const triggerStatus = "Unresolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -158,9 +150,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Unresolved"
       const triggerStatus = null
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -179,9 +171,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Unresolved"
       const triggerStatus = "Resolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Error", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -199,9 +191,9 @@ describe("updateCourtCaseStatus", () => {
     it("Should not update the case if the current trigger status is not set", async () => {
       const errorLockedByUsername = testUser.username
       const triggerLockedByUsername = testUser.username
-      await insertRecord(errorLockedByUsername, triggerLockedByUsername, null, null)
+      const [courtCase] = await insertRecord(errorLockedByUsername, triggerLockedByUsername, null, null)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Submitted", testUser)
 
       expect((result as UpdateResult).raw).toHaveLength(0)
       expect((result as UpdateResult).affected).toBe(0)
@@ -209,9 +201,9 @@ describe("updateCourtCaseStatus", () => {
 
     it("Should update trigger status when its not locked and trigger status is not null", async () => {
       const triggerStatus = "Unresolved"
-      await insertRecord(null, null, null, triggerStatus)
+      const [courtCase] = await insertRecord(null, null, null, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Submitted", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -229,9 +221,9 @@ describe("updateCourtCaseStatus", () => {
       const triggerLockedByUsername = testUser.username
       const triggerStatus = "Unresolved"
 
-      await insertRecord(null, triggerLockedByUsername, null, triggerStatus)
+      const [courtCase] = await insertRecord(null, triggerLockedByUsername, null, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Submitted", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Submitted", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -251,9 +243,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Unresolved"
       const triggerStatus = "Unresolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -273,9 +265,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = null
       const triggerStatus = "Unresolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult
@@ -296,9 +288,9 @@ describe("updateCourtCaseStatus", () => {
       const errorLockedByUsername = testUser.username
       const errorStatus = "Resolved"
       const triggerStatus = "Unresolved"
-      await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
+      const [courtCase] = await insertRecord(errorLockedByUsername, null, errorStatus, triggerStatus)
 
-      const result = await updateCourtCaseStatus(dataSource, 0, "Trigger", "Resolved", testUser)
+      const result = await updateCourtCaseStatus(dataSource, courtCase, "Trigger", "Resolved", testUser)
       expect(isError(result)).toBe(false)
 
       const updateResult = result as UpdateResult

--- a/test/services/updateLockStatusToUnlocked.integration.test.ts
+++ b/test/services/updateLockStatusToUnlocked.integration.test.ts
@@ -455,21 +455,20 @@ describe("Unlock court case", () => {
       expectError,
       expectedEvents
     }) => {
-      const courtCase = {
-        errorLockedByUsername: exceptionLockedBy,
-        triggerLockedByUsername: triggerLockedBy,
-        orgForPoliceFilter: "36FPA ",
-        errorId: 1
-      }
-
-      const anotherCourtCase = {
-        errorLockedByUsername: exceptionLockedBy,
-        triggerLockedByUsername: triggerLockedBy,
-        orgForPoliceFilter: "36FPA ",
-        errorId: 2
-      }
-
-      await insertCourtCasesWithFields([courtCase, anotherCourtCase])
+      const [courtCase, anotherCourtCase] = await insertCourtCasesWithFields([
+        {
+          errorLockedByUsername: exceptionLockedBy,
+          triggerLockedByUsername: triggerLockedBy,
+          orgForPoliceFilter: "36FPA ",
+          errorId: 1
+        },
+        {
+          errorLockedByUsername: exceptionLockedBy,
+          triggerLockedByUsername: triggerLockedBy,
+          orgForPoliceFilter: "36FPA ",
+          errorId: 2
+        }
+      ])
 
       const user = {
         username: "current user",
@@ -485,7 +484,7 @@ describe("Unlock court case", () => {
       } as Partial<User> as User
 
       const events: AuditLogEvent[] = []
-      const result = await updateLockStatusToUnlocked(dataSource.manager, courtCase.errorId, user, unlockReason, events)
+      const result = await updateLockStatusToUnlocked(dataSource.manager, courtCase, user, unlockReason, events)
 
       if (expectError) {
         expect(isError(result)).toBe(true)
@@ -516,11 +515,12 @@ describe("Unlock court case", () => {
         .spyOn(UpdateQueryBuilder.prototype, "execute")
         .mockRejectedValue(Error("Failed to update record with some error"))
 
-      const lockedCourtCase = await getDummyCourtCase({
-        errorLockedByUsername: "dummy",
-        triggerLockedByUsername: "dummy"
-      })
-      await insertCourtCases(lockedCourtCase)
+      const [lockedCourtCase] = await insertCourtCases(
+        await getDummyCourtCase({
+          errorLockedByUsername: "dummy",
+          triggerLockedByUsername: "dummy"
+        })
+      )
 
       const user = {
         username: "dummy username",
@@ -533,7 +533,7 @@ describe("Unlock court case", () => {
       const events: AuditLogEvent[] = []
       const result = await updateLockStatusToUnlocked(
         dataSource.manager,
-        lockedCourtCase.errorId,
+        lockedCourtCase,
         user,
         UnlockReason.TriggerAndException,
         events


### PR DESCRIPTION
Previously the court case was retrieved twice when a transaction called another function that needed the case