### PR TITLE
Bicaws-2972: Display window.confirm when user has unsaved note

### DIFF
--- a/cypress/e2e/court-cases/court-case-details/CourtCaseDetails.Notes.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/CourtCaseDetails.Notes.cy.ts
@@ -267,6 +267,23 @@ describe("Court case details", () => {
     clickTab("Notes")
     cy.findByText("Case has no notes.").should("exist")
   })
+
+  it("Should show a confirmation box if user clicks back with unsaved note", () => {
+    cy.on("window:confirm", () => false)
+    insertTriggers()
+    loginAndGoToNotes()
+
+    cy.get("textarea").type("Dummy note")
+
+    cy.go("back")
+
+    cy.get("H3").contains("Notes")
+    cy.get("textarea")
+      .invoke("val")
+      .then((value) => {
+        expect(value).to.equal("Dummy note")
+      })
+  })
 })
 
 export {}

--- a/src/features/CourtCaseDetails/Tabs/Panels/Notes/AddNoteForm.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/Notes/AddNoteForm.tsx
@@ -2,6 +2,7 @@ import ConditionalRender from "components/ConditionalRender"
 import { MAX_NOTE_LENGTH } from "config"
 import { Button, FormGroup, HintText, Label, TextArea } from "govuk-react"
 import { FormEvent, FormEventHandler, useState } from "react"
+import { useLeavePageConfirmation } from "hooks/useLeavePageConfimation"
 
 interface Props {
   lockedByAnotherUser: boolean
@@ -11,6 +12,8 @@ const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser }: Props) => {
   const [noteRemainingLength, setNoteRemainingLength] = useState(MAX_NOTE_LENGTH)
   const [isFormValid, setIsFormValid] = useState(true)
   const showError = !isFormValid && noteRemainingLength === MAX_NOTE_LENGTH
+
+  useLeavePageConfirmation(noteRemainingLength !== MAX_NOTE_LENGTH)
 
   const handleOnNoteChange: FormEventHandler<HTMLTextAreaElement> = (event) => {
     setNoteRemainingLength(MAX_NOTE_LENGTH - event.currentTarget.value.length)

--- a/src/hooks/useLeavePageConfimation.ts
+++ b/src/hooks/useLeavePageConfimation.ts
@@ -1,0 +1,95 @@
+import SingletonRouter, { Router } from "next/router"
+import { useEffect } from "react"
+
+const defaultConfirmationDialog = async (msg?: string) => window.confirm(msg)
+
+/**
+ * Implimentation from https://gist.github.com/codeBelt/8564fa4d9a5719708198b0cddadaca3b
+ */
+export const useLeavePageConfirmation = (
+  shouldPreventLeaving: boolean,
+  message = "Changes you made may not be saved.",
+  confirmationDialog: (msg?: string) => Promise<boolean> = defaultConfirmationDialog
+) => {
+  useEffect(() => {
+    // @ts-ignore because "change" is private in Next.js
+    if (!SingletonRouter.router?.change) {
+      return
+    }
+
+    // @ts-ignore because "change" is private in Next.js
+    const originalChangeFunction = SingletonRouter.router.change
+    const originalOnBeforeUnloadFunction = window.onbeforeunload
+
+    /*
+     * Modifying the window.onbeforeunload event stops the browser tab/window from
+     * being closed or refreshed. Since it is not possible to alter the close or reload
+     * alert message, an empty string is passed to trigger the alert and avoid confusion
+     * about the option to modify the message.
+     */
+    if (shouldPreventLeaving) {
+      window.onbeforeunload = () => ""
+    } else {
+      window.onbeforeunload = originalOnBeforeUnloadFunction
+    }
+
+    /*
+     * Overriding the router.change function blocks Next.js route navigations
+     * and disables the browser's back and forward buttons. This opens up the
+     * possibility to use the window.confirm alert instead.
+     */
+    if (shouldPreventLeaving) {
+      // @ts-ignore because "change" is private in Next.js
+      SingletonRouter.router.change = async (...args) => {
+        const [historyMethod, , as] = args
+        // @ts-ignore because "state" is private in Next.js
+        const currentUrl = SingletonRouter.router?.state.asPath.split("?")[0]
+        const changedUrl = as.split("?")[0]
+        const hasNavigatedAwayFromPage = currentUrl !== changedUrl
+        const wasBackOrForwardBrowserButtonClicked = historyMethod === "replaceState"
+        let confirmed = false
+
+        if (hasNavigatedAwayFromPage) {
+          confirmed = await confirmationDialog(message)
+        }
+
+        if (confirmed) {
+          // @ts-ignore because "change" is private in Next.js
+          Router.prototype.change.apply(SingletonRouter.router, args)
+        } else if (wasBackOrForwardBrowserButtonClicked && hasNavigatedAwayFromPage) {
+          /*
+           * The URL changes even if the user clicks "false" to navigate away from the page.
+           * It is necessary to update it to reflect the current URL.
+           */
+          // @ts-ignore because "state" is private in Next.js
+          await SingletonRouter.router?.push(SingletonRouter.router?.state.asPath)
+
+          /*
+           * @todo
+           *   I attempted to determine if the user clicked the forward or back button on the browser,
+           *   but was unable to find a solution after several hours of effort. As a result, I temporarily
+           *   hardcoded it to assume the back button was clicked, since that is the most common scenario.
+           *   However, this may cause issues with the URL if the forward button is actually clicked.
+           *   I hope that a solution can be found in the future.
+           */
+          const browserDirection = "back"
+
+          if (browserDirection === "back") {
+            history.go(1)
+          } else {
+            history.go(-1)
+          }
+        }
+      }
+    }
+
+    /*
+     * When the component is unmounted, the original change function is assigned back.
+     */
+    return () => {
+      // @ts-ignore because "change" is private in Next.js
+      SingletonRouter.router.change = originalChangeFunction
+      window.onbeforeunload = originalOnBeforeUnloadFunction
+    }
+  }, [shouldPreventLeaving, message, confirmationDialog])
+}


### PR DESCRIPTION
### When returning to case list with unsaved note
![Screenshot 2023-07-21 at 13 16 58](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/4f1be559-3a98-4d8e-b6f0-5f7d563ce265)

### When clicking browser back button with unsaved note
![Screenshot 2023-07-21 at 13 17 17](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/45b99ae3-cdc3-4230-abce-3e09c6b5cbf0)

I ended using a custom react hook from [here](https://gist.github.com/codeBelt/8564fa4d9a5719708198b0cddadaca3b), with a few changes to make it compatible with our eslint configuration. 

I was able to add a test for to confirm that `window.choice` is invoked when clicking the browser back button. I was not able to find a way to hook into the `window.onbeforeunload` function from cypress. All of the examples/workarounds I found were concerned with preventing the function from causing tests to hang. This does not seem to be an issue anymore, as the default behaviour of Cypress is to click confirm on any prompts it receives. Ideally, I would like to find a way to configure cypress to click cancel on the `onbeforeunload` prompt, and then assert that the note input is still rendered with the correct value. 

