### PR TITLE
Fix defendant name links

### DIFF
--- a/cypress/e2e/court-cases/court-case-list/CourtCaseList.cy.ts
+++ b/cypress/e2e/court-cases/court-case-list/CourtCaseList.cy.ts
@@ -84,7 +84,7 @@ describe("Court case details", () => {
       }
     ])
 
-    newUserLogin({ user: "trigger-handler-user", groups: [UserGroup.ExceptionHandler] })
+    newUserLogin({ user: "trigger-handler-user", groups: [UserGroup.TriggerHandler] })
 
     cy.visit("/bichard")
     cy.findByText("NAME Defendant").click()

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -422,9 +422,13 @@ describe("Case list", () => {
 
       loginAndGoToUrl()
 
+      cy.findByText("Defendant Name 0")
+        .should("have.attr", "href")
+        .and("match", /\/court-cases\/\d+/)
+
       cy.findByText("Defendant Name 0").click()
 
-      cy.url().should("match", /\/court-cases\//)
+      cy.url().should("match", /\/court-cases\/\d+/)
       cy.findByText("Case details").should("exist")
 
       cy.get("#leave-and-lock, #return-to-case-list").click()

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -89,7 +89,7 @@ export const CaseDetailsRow = ({
           </ConditionalRender>
         </Table.Cell>
         <Table.Cell className={caseDetailsCellClass}>
-          <Link href={`${basePath}/court-cases/${errorId}`} id={`Case details for ${defendantName}`}>
+          <Link href={`${basePath}/court-cases/${errorId}`}>
             {defendantName}
             <br />
             <ResolvedTag isResolved={isResolved} />

--- a/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CaseDetailsRow/CaseDetailsRow.tsx
@@ -60,7 +60,6 @@ export const CaseDetailsRow = ({
   errorId,
   errorLockedByUsername,
   firstColumnClassName,
-  isCaseUnlocked,
   isResolved,
   isUrgent,
   notes,
@@ -70,16 +69,7 @@ export const CaseDetailsRow = ({
   lockTag
 }: CaseDetailsRowProps) => {
   const [showPreview, setShowPreview] = useState(true)
-
-  const { basePath, query, push } = useRouter()
-
-  const getLockCourtCasePath = (courtCaseId: string, lock: string) =>
-    `${basePath}/court-cases/${courtCaseId}?${new URLSearchParams({ ...query, lock })}`
-
-  const lockCourtCasePath = getLockCourtCasePath(String(errorId), String(!isCaseUnlocked))
-
-  const caseDetailsPath = `/court-cases/${errorId}`
-
+  const { basePath } = useRouter()
   const userNotes = filterUserNotes(notes)
   const mostRecentUserNote = getMostRecentNote(userNotes)
   const numberOfNotes = userNotes.length
@@ -90,14 +80,6 @@ export const CaseDetailsRow = ({
   const caseDetailsCellClass = !hasTriggers && showPreview ? "" : customClasses["border-bottom-none"]
   const notePreviewCellClass = !hasTriggers && !showPreview ? "" : customClasses["border-bottom-none"]
 
-  const lockAndOrViewCase = async (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    event.preventDefault()
-    if (!errorLockedByUsername) {
-      await fetch(lockCourtCasePath, { method: "POST" })
-    }
-    push(caseDetailsPath)
-  }
-
   return (
     <>
       <Table.Row className={`${classes.caseDetailsRow} ${rowClassName}`}>
@@ -107,11 +89,7 @@ export const CaseDetailsRow = ({
           </ConditionalRender>
         </Table.Cell>
         <Table.Cell className={caseDetailsCellClass}>
-          <Link
-            onClick={async (event) => lockAndOrViewCase(event)}
-            href="" // emply href enables expected mouseover behaviour
-            id={`Case details for ${defendantName}`}
-          >
+          <Link href={`${basePath}/court-cases/${errorId}`} id={`Case details for ${defendantName}`}>
             {defendantName}
             <br />
             <ResolvedTag isResolved={isResolved} />

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -38,12 +38,10 @@ export const getServerSideProps = withMultipleServerSideProps(
 
     let lockResult: UpdateResult | Error | undefined
 
-    if (isPost(req) && !!lock) {
-      if (lock === "false") {
-        lockResult = await unlockCourtCase(dataSource, +courtCaseId, currentUser, UnlockReason.TriggerAndException)
-      } else {
-        lockResult = await lockCourtCase(dataSource, +courtCaseId, currentUser)
-      }
+    if (isPost(req) && lock === "false") {
+      lockResult = await unlockCourtCase(dataSource, +courtCaseId, currentUser, UnlockReason.TriggerAndException)
+    } else {
+      lockResult = await lockCourtCase(dataSource, +courtCaseId, currentUser)
     }
 
     if (isError(lockResult)) {

--- a/src/services/updateLockStatusToLocked.ts
+++ b/src/services/updateLockStatusToLocked.ts
@@ -12,7 +12,7 @@ import EventCategory from "@moj-bichard7-developers/bichard7-next-core/dist/type
 import Feature from "types/Feature"
 
 const lock = async (
-  unlockReason: "Trigger" | "Exception",
+  lockReason: "Trigger" | "Exception",
   courtCaseRepository: Repository<CourtCase>,
   courtCaseId: number,
   user: User,
@@ -21,18 +21,18 @@ const lock = async (
   const result = await courtCaseRepository
     .createQueryBuilder()
     .update(CourtCase)
-    .set({ [unlockReason === "Exception" ? "errorLockedByUsername" : "triggerLockedByUsername"]: user.username })
+    .set({ [lockReason === "Exception" ? "errorLockedByUsername" : "triggerLockedByUsername"]: user.username })
     .andWhere({
       errorId: courtCaseId,
-      [unlockReason === "Exception" ? "errorLockedByUsername" : "triggerLockedByUsername"]: IsNull(),
-      [unlockReason === "Exception" ? "errorCount" : "triggerCount"]: MoreThan(0),
-      [unlockReason === "Exception" ? "errorStatus" : "triggerStatus"]: Not("Submitted")
+      [lockReason === "Exception" ? "errorLockedByUsername" : "triggerLockedByUsername"]: IsNull(),
+      [lockReason === "Exception" ? "errorCount" : "triggerCount"]: MoreThan(0),
+      [lockReason === "Exception" ? "errorStatus" : "triggerStatus"]: Not("Submitted")
     })
     .execute()
     .catch((error) => error)
 
   if (!result) {
-    return new Error(`Failed to lock ${unlockReason}`)
+    return new Error(`Failed to lock ${lockReason}`)
   }
 
   if (isError(result)) {
@@ -42,7 +42,7 @@ const lock = async (
   if (result.affected && result.affected > 0) {
     events.push(
       getAuditLogEvent(
-        unlockReason === "Exception" ? AuditLogEventOptions.exceptionLocked : AuditLogEventOptions.triggerLocked,
+        lockReason === "Exception" ? AuditLogEventOptions.exceptionLocked : AuditLogEventOptions.triggerLocked,
         EventCategory.information,
         AUDIT_LOG_EVENT_SOURCE,
         {

--- a/src/services/updateLockStatusToLocked.ts
+++ b/src/services/updateLockStatusToLocked.ts
@@ -29,7 +29,7 @@ const lock = async (
       [lockReason === "Exception" ? "errorStatus" : "triggerStatus"]: Not("Submitted")
     })
     .execute()
-    .catch((error) => error)
+    .catch((error) => error as Error)
 
   if (!result) {
     return new Error(`Failed to lock ${lockReason}`)

--- a/test/utils/manageUsers.ts
+++ b/test/utils/manageUsers.ts
@@ -28,10 +28,15 @@ const insertUserIntoGroup = async (emailAddress: string, groupName: string): Pro
       br7own.users_groups(
       group_id, 
       user_id
-    ) VALUES (
-      (SELECT id FROM br7own.groups WHERE name=$1 LIMIT 1),
-      (SELECT id FROM br7own.users WHERE email=$2 LIMIT 1)
-    )`,
+    )
+    SELECT G.id, U.id FROM br7own.users AS U, br7own."groups" AS G
+    WHERE
+    	G.id = (SELECT id FROM br7own.groups WHERE name=$1 LIMIT 1)
+    	AND
+    	U.id = (SELECT id FROM br7own.users WHERE email=$2 LIMIT 1)
+    	AND
+    	NOT EXISTS (SELECT * FROM br7own.users_groups AS UG WHERE UG.group_id = G.id AND UG.user_id = U.id)
+    `,
     [groupName, emailAddress]
   )
 }

--- a/test/utils/manageUsers.ts
+++ b/test/utils/manageUsers.ts
@@ -58,17 +58,12 @@ const insertUsers = async (users: User | User[], userGroups?: string[]): Promise
     return result
   }
 
-  userGroups.forEach(async (userGroup) => {
-    const group = sanitiseGroupName(userGroup)
-
-    if (Array.isArray(users)) {
-      users.forEach(async (user) => {
-        await insertUserIntoGroup(user.email, group)
-      })
-    } else {
-      await insertUserIntoGroup(users.email, group)
-    }
-  })
+  await Promise.all(
+    userGroups.flatMap((userGroup) => {
+      const group = sanitiseGroupName(userGroup)
+      return [users].flat().map((user) => insertUserIntoGroup(user.email, group))
+    })
+  )
 
   return result
 }


### PR DESCRIPTION
This PR is to:
- update the defendant name link in case list page to set the `href` correctly
- remove the defendant name link ID attribute. The attribute was not needed and the value format was invalid.
- remove the logic to lock the case on the client-side and move it to the case details page. Now when user accesses the case details page, system tries to lock the exceptions and triggers. The `lock` parameter in the query string can only be used to unlock the case via a POST request now.