### PR TITLE
Updated build-script to reference 2023 image

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-readonly DOCKER_REFERENCE="nginx-nodejs-supervisord"
+readonly DOCKER_REFERENCE="nginx-nodejs-2023-supervisord"
 
 function has_local_image() {
   IMAGES=$(docker images --filter=reference="${DOCKER_REFERENCE}:*" -q | wc -l)


### PR DESCRIPTION
Currently docker-build script is referencing the old `nginx-nodejs-supervisord` image.

This PR is to point it to the 2023 version.
