### PR TITLE
Pinned cypress version due to npm update failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:file": "jest --runInBand --testPathPattern",
     "test:ui:e2e": "concurrently --kill-others --success first \"npm run start\" \"npm run cypress:run\"",
     "install:hooks": "./scripts/install-git-hooks.sh",
-    "update-deps": "ncu -u -x next && npm install",
+    "update-deps": "ncu -u -x next cypress && npm install",
     "seed-data": "ts-node ./scripts/seed-data.ts",
     "prepare": "husky install"
   },


### PR DESCRIPTION
This PR is to pin the cypress version as it causes the CI to fail, when trying to replicate locally we only get warnings about the cypress version but in the CI they are error. 

I think I will have a follow up PR that removes the pinning so we can check it out Monday when the` npm run update-deps` job runs