### PR TITLE
Bicaws-2704: Bottom justify column headings

### DIFF
--- a/src/features/CourtCaseFilters/ColumnHeading.tsx
+++ b/src/features/CourtCaseFilters/ColumnHeading.tsx
@@ -13,11 +13,6 @@ const useStyles = createUseStyles({
     display: "inline-block",
     verticalAlign: "bottom",
     marginBottom: "7px"
-  },
-  icon: {
-    display: "inline-block",
-    paddingLeft: "2px",
-    verticalAlign: "bottom"
   }
 })
 

--- a/src/features/CourtCaseFilters/ColumnHeading.tsx
+++ b/src/features/CourtCaseFilters/ColumnHeading.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import { ReactNode } from "react"
 import { createUseStyles } from "react-jss"
 

--- a/src/features/CourtCaseFilters/ColumnHeading.tsx
+++ b/src/features/CourtCaseFilters/ColumnHeading.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import { ReactNode } from "react"
+import { createUseStyles } from "react-jss"
+
+const useStyles = createUseStyles({
+  container: {
+    width: "fit-content",
+    display: "flex",
+    alignItems: "flex-end"
+  },
+  content: {
+    display: "inline-block",
+    verticalAlign: "bottom",
+    marginBottom: "7px"
+  },
+  icon: {
+    display: "inline-block",
+    paddingLeft: "2px",
+    verticalAlign: "bottom"
+  }
+})
+
+interface Props {
+  children?: ReactNode
+}
+
+const ColumnHeading: React.FC<Props> = ({ children }) => {
+  const classes = useStyles()
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.content}>{children}</div>
+    </div>
+  )
+}
+
+export default ColumnHeading

--- a/src/features/CourtCaseFilters/ColumnOrderIcons.tsx
+++ b/src/features/CourtCaseFilters/ColumnOrderIcons.tsx
@@ -7,14 +7,18 @@ import { blue } from "../../utils/colours"
 const useStyles = createUseStyles({
   container: {
     width: "fit-content",
-    display: "flex"
+    display: "flex",
+    alignItems: "flex-end"
   },
   content: {
-    display: "inline-block"
+    display: "inline-block",
+    verticalAlign: "bottom",
+    marginBottom: "7px"
   },
   icon: {
     display: "inline-block",
-    paddingLeft: "2px"
+    paddingLeft: "2px",
+    verticalAlign: "bottom"
   }
 })
 

--- a/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
+++ b/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
@@ -18,7 +18,7 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
   return (
     <Table.Row>
       <Table.Cell></Table.Cell>
-      <Table.CellHeader setWidth={"178px"}>
+      <Table.CellHeader className={classes["table-column-header-cell"]} setWidth={"178px"}>
         <ColumnOrderIcons columnName={"defendantName"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link
             className={classes["table-column-header-link"]}
@@ -29,35 +29,35 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader setWidth={"115px"}>
+      <Table.CellHeader className={classes["table-column-header-cell"]} setWidth={"115px"}>
         <ColumnOrderIcons columnName={"courtDate"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("courtDate")} id="court-date-sort">
             {"Court date"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader>
+      <Table.CellHeader className={classes["table-column-header-cell"]}>
         <ColumnOrderIcons columnName={"courtName"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("courtName")} id="court-name-sort">
             {"Court name"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader>
+      <Table.CellHeader className={classes["table-column-header-cell"]}>
         <ColumnOrderIcons columnName={"ptiurn"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("ptiurn")} id="ptiurn-sort">
             {"PTIURN"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader>
+      <Table.CellHeader className={classes["table-column-header-cell"]}>
         <ColumnOrderIcons columnName={"isUrgent"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("isUrgent")} id="is-urgent-sort">
             {"Urgent"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader>
+      <Table.CellHeader className={classes["table-column-header-cell"]}>
         <ColumnOrderIcons columnName={"notes"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("notes")} id="notes-sort">
             {"Notes"}

--- a/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
+++ b/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import type { QueryOrder } from "types/CaseListQueryParams"
 
 import { useCustomStyles } from "../../../styles/customStyles"
+import ColumnHeading from "features/CourtCaseFilters/ColumnHeading"
 
 interface CourtCaseListTableHeaderProps {
   order: QueryOrder
@@ -64,7 +65,9 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
-      <Table.CellHeader>{"Reason"}</Table.CellHeader>
+      <Table.CellHeader className={classes["table-column-header-cell"]}>
+        <ColumnHeading>{"Reason"}</ColumnHeading>
+      </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"lockedBy"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link className={classes["table-column-header-link"]} href={orderByParams("lockedBy")} id="locked-by-sort">

--- a/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
+++ b/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
@@ -3,12 +3,15 @@ import { Link, Table } from "govuk-react"
 import { useRouter } from "next/router"
 import type { QueryOrder } from "types/CaseListQueryParams"
 
+import { useCustomStyles } from "../../../styles/customStyles"
+
 interface CourtCaseListTableHeaderProps {
   order: QueryOrder
 }
 
 export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProps) => {
   const { basePath, query } = useRouter()
+  const classes = useCustomStyles()
 
   const orderByParams = (orderBy: string) => `${basePath}/?${new URLSearchParams({ ...query, orderBy, order })}`
 
@@ -17,42 +20,46 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
       <Table.Cell></Table.Cell>
       <Table.CellHeader setWidth={"178px"}>
         <ColumnOrderIcons columnName={"defendantName"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("defendantName")} id="defendant-name-sort">
+          <Link
+            className={classes["table-column-header-link"]}
+            href={orderByParams("defendantName")}
+            id="defendant-name-sort"
+          >
             {"Defendant name"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader setWidth={"115px"}>
         <ColumnOrderIcons columnName={"courtDate"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("courtDate")} id="court-date-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("courtDate")} id="court-date-sort">
             {"Court date"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"courtName"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("courtName")} id="court-name-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("courtName")} id="court-name-sort">
             {"Court name"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"ptiurn"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("ptiurn")} id="ptiurn-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("ptiurn")} id="ptiurn-sort">
             {"PTIURN"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"isUrgent"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("isUrgent")} id="is-urgent-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("isUrgent")} id="is-urgent-sort">
             {"Urgent"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"notes"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("notes")} id="notes-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("notes")} id="notes-sort">
             {"Notes"}
           </Link>
         </ColumnOrderIcons>
@@ -60,7 +67,7 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
       <Table.CellHeader>{"Reason"}</Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"lockedBy"} currentOrder={query.order} orderBy={query.orderBy}>
-          <Link href={orderByParams("lockedBy")} id="locked-by-sort">
+          <Link className={classes["table-column-header-link"]} href={orderByParams("lockedBy")} id="locked-by-sort">
             {"Locked by"}
           </Link>
         </ColumnOrderIcons>

--- a/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
+++ b/src/features/CourtCaseList/CourtCaseListTableHeader.tsx
@@ -18,21 +18,21 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
       <Table.CellHeader setWidth={"178px"}>
         <ColumnOrderIcons columnName={"defendantName"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link href={orderByParams("defendantName")} id="defendant-name-sort">
-            {"Defendant Name"}
+            {"Defendant name"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader setWidth={"115px"}>
         <ColumnOrderIcons columnName={"courtDate"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link href={orderByParams("courtDate")} id="court-date-sort">
-            {"Court Date"}
+            {"Court date"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"courtName"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link href={orderByParams("courtName")} id="court-name-sort">
-            {"Court Name"}
+            {"Court name"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>
@@ -61,7 +61,7 @@ export const CourtCaseListTableHeader = ({ order }: CourtCaseListTableHeaderProp
       <Table.CellHeader>
         <ColumnOrderIcons columnName={"lockedBy"} currentOrder={query.order} orderBy={query.orderBy}>
           <Link href={orderByParams("lockedBy")} id="locked-by-sort">
-            {"Locked By"}
+            {"Locked by"}
           </Link>
         </ColumnOrderIcons>
       </Table.CellHeader>

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -9,6 +9,7 @@ const textSecondary = "#505a5f"
 const blue = "#1D70B8"
 const yellow = "#FFDD00"
 const gdsBlack = "#0b0c0c"
+const gdsLink = "#1d70b8"
 
 export {
   darkGrey,
@@ -21,5 +22,6 @@ export {
   textBlue,
   yellow,
   textSecondary,
-  gdsBlack
+  gdsBlack,
+  gdsLink
 }

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -9,7 +9,6 @@ const textSecondary = "#505a5f"
 const blue = "#1D70B8"
 const yellow = "#FFDD00"
 const gdsBlack = "#0b0c0c"
-const gdsLink = "#1d70b8"
 
 export {
   darkGrey,
@@ -22,6 +21,5 @@ export {
   textBlue,
   yellow,
   textSecondary,
-  gdsBlack,
-  gdsLink
+  gdsBlack
 }

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -1,5 +1,5 @@
 import { createUseStyles } from "react-jss"
-import { darkGrey, blue, tagBlue, textBlue, yellow, lightGrey, gdsGrey, gdsBlack, gdsLink } from "../src/utils/colours"
+import { darkGrey, blue, tagBlue, textBlue, yellow, lightGrey, gdsGrey, gdsBlack } from "../src/utils/colours"
 
 export const useCustomStyles = createUseStyles({
   "button--tag": {
@@ -114,16 +114,16 @@ export const useCustomStyles = createUseStyles({
   },
 
   "table-column-header-link": {
-    color: gdsLink,
+    color: blue,
 
     "&:active": {
-      color: gdsLink
+      color: blue
     },
     "&:visited": {
-      color: gdsLink
+      color: blue
     },
     "&:hover": {
-      color: gdsLink
+      color: blue
     }
   },
 

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -1,5 +1,5 @@
 import { createUseStyles } from "react-jss"
-import { darkGrey, blue, tagBlue, textBlue, yellow, lightGrey, gdsGrey, gdsBlack } from "../src/utils/colours"
+import { darkGrey, blue, tagBlue, textBlue, yellow, lightGrey, gdsGrey, gdsBlack, gdsLink } from "../src/utils/colours"
 
 export const useCustomStyles = createUseStyles({
   "button--tag": {
@@ -111,5 +111,19 @@ export const useCustomStyles = createUseStyles({
   },
   "no-margin-bottom": {
     marginBottom: 0
+  },
+
+  "table-column-header-link": {
+    color: gdsLink,
+
+    "&:active": {
+      color: gdsLink
+    },
+    "&:visited": {
+      color: gdsLink
+    },
+    "&:hover": {
+      color: gdsLink
+    }
   }
 })

--- a/styles/customStyles.ts
+++ b/styles/customStyles.ts
@@ -125,5 +125,10 @@ export const useCustomStyles = createUseStyles({
     "&:hover": {
       color: gdsLink
     }
+  },
+
+  "table-column-header-cell": {
+    height: "100%",
+    verticalAlign: "bottom"
   }
 })


### PR DESCRIPTION
## Before

Column headings change colour when clicked.

Headings are centre justified. When headings are wrapped, single line headings stop being aligned.

Reason column heading slightly lower than other headings

Order icons do not line up when headings wrap.

![Screenshot 2023-09-04 at 13 43 51](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/ff60d741-f295-4398-8dca-0fd406289475)
![Screenshot 2023-09-04 at 13 44 22](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/59e04a8f-b865-441c-a1d7-98eee9e317b3)


## After

Clicked links in the table header no longer change colour. All headings are sentence cased and bottom justified. 

When headings are wrapped, order arrows align to the bottom row of text. 

The reason heading is now in line with the other headings.

![Screenshot 2023-09-04 at 13 36 16](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/6be324cf-23a1-473d-a91f-b7b967a2d1bd)
![Screenshot 2023-09-04 at 13 36 41](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/fdcbec27-a471-4318-925f-d8f576d3b55a)
