### PR TITLE
Only select required fields when querying court cases

### DIFF
--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -50,7 +50,27 @@ const listCourtCases = async (
     .createQueryBuilder("notes")
     .select("COUNT(note_id)")
     .where("error_id = courtCase.errorId")
-  let query = repository.createQueryBuilder("courtCase")
+  let query = repository
+    .createQueryBuilder("courtCase")
+    .select([
+      "courtCase.errorId",
+      "courtCase.triggerCount",
+      "courtCase.isUrgent",
+      "courtCase.asn",
+      "courtCase.errorReport",
+      "courtCase.errorReason",
+      "courtCase.triggerReason",
+      "courtCase.errorCount",
+      "courtCase.courtDate",
+      "courtCase.ptiurn",
+      "courtCase.courtName",
+      "courtCase.resolutionTimestamp",
+      "courtCase.errorResolvedBy",
+      "courtCase.triggerResolvedBy",
+      "courtCase.defendantName",
+      "courtCase.errorLockedByUsername",
+      "courtCase.triggerLockedByUsername"
+    ])
   query = courtCasesByOrganisationUnitQuery(query, user) as SelectQueryBuilder<CourtCase>
   leftJoinAndSelectTriggersQuery(query, user.excludedTriggers, caseState ?? "Unresolved")
     .leftJoinAndSelect("courtCase.notes", "note")


### PR DESCRIPTION
### Context
We are facing significant performance issues when listing a large number of cases. 

### Change
This query reduces the columns we request in the list cases query(one of the main cause for poor query performance is the size AHO XML message, which is not required on the case list page)