### PR TITLE
Fix goss syntax

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -19,6 +19,7 @@ file:
     filetype: file
     size:
       lt: 3300
+    size:
       gt: 3267
     contains: []
   /etc/nginx/nginx.conf:


### PR DESCRIPTION
The codebuild job is currently failing with

> Invalid matcher configuration. At a given nesting level, only one matcher is allowed

This PR fixes the build by running the file size tests on their own nesting level