### PR TITLE
Replace KeyValuePair with Record

### DIFF
--- a/cypress/e2e/court-cases-index/orgsAndForces.cy.ts
+++ b/cypress/e2e/court-cases-index/orgsAndForces.cy.ts
@@ -74,11 +74,11 @@ describe("How orgs and forces are presented", () => {
 
     loginAndGoToUrl()
 
-    cy.get("tr")
-      .not(":first")
-      .each((row, index) => {
-        cy.wrap(row).get("td:nth-child(5)").contains(`Case0000${index}`)
-      })
+    cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00000")
+    cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00001")
+    cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00002")
+    cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00003")
+    cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00004")
   })
 
   it("Should display cases for parent forces up to the second-level force", () => {

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -1,14 +1,12 @@
 import { subDays } from "date-fns"
 import CourtCase from "../src/services/entities/CourtCase"
-import Trigger from "../src/services/entities/Trigger"
-import Note from "../src/services/entities/Trigger"
+import { default as Note, default as Trigger } from "../src/services/entities/Trigger"
 import getDataSource from "../src/services/getDataSource"
+import createAuditLogRecord from "../test/helpers/createAuditLogRecord"
 import createDummyCase from "../test/helpers/createDummyCase"
 import deleteFromEntity from "../test/utils/deleteFromEntity"
-import createAuditLogRecord from "../test/helpers/createAuditLogRecord"
-import insertManyIntoDynamoTable from "../test/utils/insertManyIntoDynamoTable"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import { insertLockUsers } from "../test/utils/insertLockUsers"
+import insertManyIntoDynamoTable from "../test/utils/insertManyIntoDynamoTable"
 import { insertNoteUser } from "../test/utils/insertNoteUser"
 
 if (process.env.DEPLOY_NAME !== "e2e-test") {
@@ -28,7 +26,7 @@ console.log(`Seeding ${numCases} cases for force ID ${forceId}`)
 
 getDataSource().then(async (dataSource) => {
   const entitiesToClear = [CourtCase, Trigger, Note]
-  const auditLogs: KeyValuePair<string, unknown>[] = []
+  const auditLogs: Record<string, unknown>[] = []
   await Promise.all(entitiesToClear.map((entity) => deleteFromEntity(entity)))
 
   const courtCases = await Promise.all(

--- a/scripts/utility/resolve-triggers/generateAuditLogEvents.ts
+++ b/scripts/utility/resolve-triggers/generateAuditLogEvents.ts
@@ -2,11 +2,10 @@ import Trigger from "../../../src/services/entities/Trigger"
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { v4 as uuid } from "uuid"
 import AuditLogEvent from "../../../../bichard7-next-audit-logging/src/shared-types/src/AuditLogEvent"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 
 type GeneratedEvents = {
   events: AuditLogEvent[]
-  valueLookup: KeyValuePair<string, unknown>[]
+  valueLookup: Record<string, unknown>[]
 }
 
 export default function generateAuditLogEvents(
@@ -20,7 +19,7 @@ export default function generateAuditLogEvents(
   const triggerCodesResolved = triggerCodes.filter((triggerCode) =>
     resolvedTriggers.some((r) => r.triggerCode === triggerCode)
   )
-  const triggerDetailsObj = triggerCodesResolved.reduce((acc: KeyValuePair<string, string>, triggerCode, index) => {
+  const triggerDetailsObj = triggerCodesResolved.reduce((acc: Record<string, string>, triggerCode, index) => {
     acc[`Trigger ${index} Details`] = triggerCode
     return acc
   }, {})
@@ -50,7 +49,7 @@ export default function generateAuditLogEvents(
       "Original Hearing Outcome / PNC Update Dataset": {
         valueLookup: ahoValueLookup.id
       },
-      ...triggerCodesResolved.reduce((acc: KeyValuePair<string, string>, triggerCode, index) => {
+      ...triggerCodesResolved.reduce((acc: Record<string, string>, triggerCode, index) => {
         acc[`Trigger Code ${index.toString().padStart(2, "0")}`] = triggerCode
         return acc
       }, {})

--- a/scripts/utility/resolve-triggers/updateAuditLogRecord.ts
+++ b/scripts/utility/resolve-triggers/updateAuditLogRecord.ts
@@ -1,13 +1,12 @@
-import { isError } from "../../../src/types/Result"
 import AuditLog from "../../../../bichard7-next-audit-logging/src/shared-types/src/AuditLog"
 import AuditLogEvent from "../../../../bichard7-next-audit-logging/src/shared-types/src/AuditLogEvent"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
+import { isError } from "../../../src/types/Result"
 
 export default async function updateAuditLogRecord(
   dynamoDbClient: AWS.DynamoDB.DocumentClient,
   auditLog: AuditLog,
   events: AuditLogEvent[],
-  valueLookups: KeyValuePair<string, unknown>[]
+  valueLookups: Record<string, unknown>[]
 ) {
   // Store lookup values
   for (const valueLookup of valueLookups) {

--- a/src/components/FeatureFlag/FeatureFlag.tsx
+++ b/src/components/FeatureFlag/FeatureFlag.tsx
@@ -1,9 +1,8 @@
 import ConditionalRender from "components/ConditionalRender"
 import { ReactNode } from "react"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 
 interface Props {
-  featureFlags: KeyValuePair<string, boolean> | undefined
+  featureFlags: Record<string, boolean> | undefined
   featureName: string
   children: ReactNode
 }

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -1,17 +1,16 @@
-import { CaseAgeOptions } from "utils/caseAgeOptions"
-import { mapCaseAges } from "utils/validators/validateCaseAges"
-import RadioButton from "components/RadioButton/RadioButton"
-import type { FilterAction } from "types/CourtCaseFilter"
-import type { Dispatch } from "react"
 import DateInput from "components/CustomDateInput/DateInput"
-import { SerializedCourtDateRange } from "types/CaseListQueryParams"
-import { formatDisplayedDate } from "utils/formattedDate"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
+import RadioButton from "components/RadioButton/RadioButton"
+import type { Dispatch } from "react"
 import { createUseStyles } from "react-jss"
+import { SerializedCourtDateRange } from "types/CaseListQueryParams"
+import type { FilterAction } from "types/CourtCaseFilter"
+import { CaseAgeOptions } from "utils/caseAgeOptions"
+import { formatDisplayedDate } from "utils/formattedDate"
+import { mapCaseAges } from "utils/validators/validateCaseAges"
 
 interface Props {
   caseAges?: string[]
-  caseAgeCounts: KeyValuePair<string, number>
+  caseAgeCounts: Record<string, number>
   dispatch: Dispatch<FilterAction>
   dateRange: SerializedCourtDateRange | undefined
 }
@@ -39,7 +38,7 @@ const getCaseAgeWithFormattedDate = (namedCaseAge: string): string => {
     : `${namedCaseAge} (${formatDisplayedDate(dateRange.from)})`
 }
 
-const labelForCaseAge = (namedCaseAge: string, caseAgeCounts: KeyValuePair<string, number>): string => {
+const labelForCaseAge = (namedCaseAge: string, caseAgeCounts: Record<string, number>): string => {
   const caseCount = `(${caseAgeCounts[namedCaseAge as string]})`
 
   return ["Today", "Yesterday"].includes(namedCaseAge)

--- a/src/components/FilterOptions/LockedFilterOptions.tsx
+++ b/src/components/FilterOptions/LockedFilterOptions.tsx
@@ -1,7 +1,6 @@
 import RadioButton from "components/RadioButton/RadioButton"
 import type { ChangeEvent, Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import lockedFilters from "utils/lockedFilters"
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
   dispatch: Dispatch<FilterAction>
 }
 
-const LockedOptions: KeyValuePair<string, boolean> = {
+const LockedOptions: Record<string, boolean> = {
   Locked: true,
   Unlocked: false
 }

--- a/src/components/FilterOptions/UrgencyFilterOptions.tsx
+++ b/src/components/FilterOptions/UrgencyFilterOptions.tsx
@@ -1,14 +1,13 @@
 import RadioButton from "components/RadioButton/RadioButton"
 import type { Dispatch } from "react"
 import type { FilterAction } from "types/CourtCaseFilter"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 
 interface Props {
   urgency?: boolean
   dispatch: Dispatch<FilterAction>
 }
 
-const UrgencyOptions: KeyValuePair<string, boolean> = {
+const UrgencyOptions: Record<string, boolean> = {
   Urgent: true,
   "Non-urgent": false
 }

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -1,21 +1,20 @@
+import ConditionalRender from "components/ConditionalRender"
 import CaseStateFilterOptions from "components/FilterOptions/CaseStateFilterOptions"
+import LockedFilterOptions from "components/FilterOptions/LockedFilterOptions"
 import ReasonFilterOptions from "components/FilterOptions/ReasonFilterOptions/ReasonFilterOptions"
 import UrgencyFilterOptions from "components/FilterOptions/UrgencyFilterOptions"
-import LockedFilterOptions from "components/FilterOptions/LockedFilterOptions"
 import { LabelText } from "govuk-react"
 import { ChangeEvent, useReducer } from "react"
 import { createUseStyles } from "react-jss"
+import User from "services/entities/User"
 import { CaseState, Reason, SerializedCourtDateRange } from "types/CaseListQueryParams"
 import type { Filter, FilterAction } from "types/CourtCaseFilter"
+import Feature from "types/Feature"
 import { caseStateLabels } from "utils/caseStateFilters"
 import { anyFilterChips } from "utils/filterChips"
 import CourtDateFilterOptions from "../../components/FilterOptions/CourtDateFilterOptions"
 import ExpandingFilters from "./ExpandingFilters"
 import FilterChipSection from "./FilterChipSection"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-import ConditionalRender from "components/ConditionalRender"
-import User from "services/entities/User"
-import Feature from "types/Feature"
 
 interface Props {
   defendantName: string | null
@@ -24,7 +23,7 @@ interface Props {
   ptiurn: string | null
   reasons: Reason[]
   caseAge: string[]
-  caseAgeCounts: KeyValuePair<string, number>
+  caseAgeCounts: Record<string, number>
   dateRange: SerializedCourtDateRange | null
   urgency: string | null
   locked: string | null

--- a/src/features/CourtCaseList/CourtCaseListEntry/ExceptionsColumns.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/ExceptionsColumns.tsx
@@ -1,9 +1,8 @@
-import KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-import { SingleException } from "./CaseDetailsRow/SingleException"
-import LockedByTag from "../tags/LockedByTag/LockedByTag"
 import CaseUnlockedTag from "../tags/CaseUnlockedTag"
+import LockedByTag from "../tags/LockedByTag/LockedByTag"
+import { SingleException } from "./CaseDetailsRow/SingleException"
 
-export const ExceptionsReasonCell = ({ exceptionCounts }: { exceptionCounts: KeyValuePair<string, number> }) => {
+export const ExceptionsReasonCell = ({ exceptionCounts }: { exceptionCounts: Record<string, number> }) => {
   return (
     <>
       {Object.keys(exceptionCounts).map((exception, exceptionId) => {

--- a/src/pages/feedback.tsx
+++ b/src/pages/feedback.tsx
@@ -1,4 +1,3 @@
-import KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import Layout from "components/Layout"
 import RadioButton from "components/RadioButton/RadioButton"
 import { MAX_FEEDBACK_LENGTH } from "config"
@@ -26,7 +25,7 @@ enum FeedbackExperienceKey {
   veryDissatisfied
 }
 
-const FeedbackExperienceOptions: KeyValuePair<FeedbackExperienceKey, string> = {
+const FeedbackExperienceOptions: Record<FeedbackExperienceKey, string> = {
   0: "Very satisfied",
   1: "Satisfied",
   2: "Neither satisfied nor dissatisfied",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import ConditionalDisplay from "components/ConditionalDisplay"
 import Layout from "components/Layout"
 import Pagination from "components/Pagination"
@@ -49,7 +48,7 @@ interface Props {
   reasonCode: string | null
   urgent: string | null
   caseAge: string[]
-  caseAgeCounts: KeyValuePair<string, number>
+  caseAgeCounts: Record<string, number>
   dateRange: SerializedCourtDateRange | null
   page: number
   casesPerPage: number

--- a/src/services/entities/User.ts
+++ b/src/services/entities/User.ts
@@ -1,11 +1,10 @@
-import type { default as KeyValuePair } from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import { Column, Entity, JoinColumn, OneToMany, PrimaryColumn, Relation } from "typeorm"
-import BaseEntity from "./BaseEntity"
-import jsonTransformer from "./transformers/jsonTransformer"
-import delimitedString from "./transformers/delimitedString"
+import Feature from "types/Feature"
 import { UserGroup } from "../../types/UserGroup"
 import { userAccess } from "../../utils/userPermissions"
-import Feature from "types/Feature"
+import BaseEntity from "./BaseEntity"
+import delimitedString from "./transformers/delimitedString"
+import jsonTransformer from "./transformers/jsonTransformer"
 // eslint-disable-next-line import/no-cycle
 import Note from "./Note"
 
@@ -39,7 +38,7 @@ export default class User extends BaseEntity {
   excludedTriggers!: string[]
 
   @Column({ name: "feature_flags", transformer: jsonTransformer, type: "jsonb" })
-  featureFlags!: KeyValuePair<string, boolean>
+  featureFlags!: Record<string, boolean>
 
   @OneToMany(() => Note, (note) => note.user)
   @JoinColumn({ name: "user_id" })

--- a/src/services/entities/transformers/resolutionStatusTransformer.ts
+++ b/src/services/entities/transformers/resolutionStatusTransformer.ts
@@ -1,9 +1,8 @@
 import { FindOperator, ValueTransformer } from "typeorm"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import { ResolutionStatus } from "types/ResolutionStatus"
 import resolveFindOperator from "./resolveFindOperator"
 
-const resolutionStatusByCode: KeyValuePair<number, ResolutionStatus> = {
+const resolutionStatusByCode: Record<number, ResolutionStatus> = {
   1: "Unresolved",
   2: "Resolved",
   3: "Submitted"

--- a/src/services/getCountOfCasesByCaseAge.ts
+++ b/src/services/getCountOfCasesByCaseAge.ts
@@ -1,5 +1,4 @@
 import { DataSource, IsNull, SelectQueryBuilder } from "typeorm"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import PromiseResult from "types/PromiseResult"
 import { isError } from "types/Result"
 import { CaseAgeOptions } from "utils/caseAgeOptions"
@@ -10,10 +9,7 @@ import courtCasesByOrganisationUnitQuery from "./queries/courtCasesByOrganisatio
 
 const asKey = (caseAgeOption: string) => caseAgeOption.toLowerCase().replace(/ /g, "")
 
-const getCountOfCasesByCaseAge = async (
-  connection: DataSource,
-  user: User
-): PromiseResult<KeyValuePair<string, number>> => {
+const getCountOfCasesByCaseAge = async (connection: DataSource, user: User): PromiseResult<Record<string, number>> => {
   const repository = connection.getRepository(CourtCase)
   let query = repository.createQueryBuilder()
   query = courtCasesByOrganisationUnitQuery(query, user) as SelectQueryBuilder<CourtCase>
@@ -45,11 +41,11 @@ const getCountOfCasesByCaseAge = async (
   return isError(response)
     ? response
     : (Object.keys(CaseAgeOptions).reduce(
-        (result: KeyValuePair<string, number>, caseAge: string) => (
+        (result: Record<string, number>, caseAge: string) => (
           (result[caseAge] = response ? response[asKey(caseAge)] : "0"), result
         ),
         {}
-      ) as KeyValuePair<string, number>)
+      ) as Record<string, number>)
 }
 
 export default getCountOfCasesByCaseAge

--- a/src/services/reallocateCourtCase/updateTriggers.ts
+++ b/src/services/reallocateCourtCase/updateTriggers.ts
@@ -1,21 +1,20 @@
-import { EntityManager, IsNull } from "typeorm"
-import CourtCase from "../entities/CourtCase"
-import { isError } from "../../types/Result"
-import { Trigger } from "@moj-bichard7-developers/bichard7-next-core/dist/types/Trigger"
-import { default as TriggerEntity } from "../entities/Trigger"
+import getAuditLogEvent from "@moj-bichard7-developers/bichard7-next-core/dist/lib/auditLog/getAuditLogEvent"
 import {
   AuditLogEvent,
   AuditLogEventOption,
   AuditLogEventOptions
 } from "@moj-bichard7-developers/bichard7-next-core/dist/types/AuditLogEvent"
-import getAuditLogEvent from "@moj-bichard7-developers/bichard7-next-core/dist/lib/auditLog/getAuditLogEvent"
 import EventCategory from "@moj-bichard7-developers/bichard7-next-core/dist/types/EventCategory"
+import { Trigger } from "@moj-bichard7-developers/bichard7-next-core/dist/types/Trigger"
+import { EntityManager, IsNull } from "typeorm"
 import { AUDIT_LOG_EVENT_SOURCE } from "../../config"
+import { isError } from "../../types/Result"
+import CourtCase from "../entities/CourtCase"
+import { default as TriggerEntity } from "../entities/Trigger"
 import User from "../entities/User"
-import KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 
 const getTriggersDetails = (triggers: Trigger[]) =>
-  triggers.reduce((acc: KeyValuePair<string, unknown>, trigger, index) => {
+  triggers.reduce((acc: Record<string, unknown>, trigger, index) => {
     acc[`Trigger ${index + 1} Details`] = trigger.code
     return acc
   }, {})

--- a/src/services/resolveTriggers.ts
+++ b/src/services/resolveTriggers.ts
@@ -1,20 +1,19 @@
-import { DataSource, In, IsNull, UpdateResult } from "typeorm"
-import { isError } from "types/Result"
-import CourtCase from "./entities/CourtCase"
-import Trigger from "./entities/Trigger"
-import User from "./entities/User"
-import getCourtCaseByOrganisationUnit from "./getCourtCaseByOrganisationUnit"
-import storeAuditLogEvents from "./storeAuditLogEvents"
 import getAuditLogEvent from "@moj-bichard7-developers/bichard7-next-core/dist/lib/auditLog/getAuditLogEvent"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import {
   AuditLogEventOptions,
   type AuditLogEvent
 } from "@moj-bichard7-developers/bichard7-next-core/dist/types/AuditLogEvent"
 import EventCategory from "@moj-bichard7-developers/bichard7-next-core/dist/types/EventCategory"
+import { DataSource, In, IsNull, UpdateResult } from "typeorm"
+import { isError } from "types/Result"
 import { AUDIT_LOG_EVENT_SOURCE } from "../config"
-import updateLockStatusToUnlocked from "./updateLockStatusToUnlocked"
 import UnlockReason from "../types/UnlockReason"
+import CourtCase from "./entities/CourtCase"
+import Trigger from "./entities/Trigger"
+import User from "./entities/User"
+import getCourtCaseByOrganisationUnit from "./getCourtCaseByOrganisationUnit"
+import storeAuditLogEvents from "./storeAuditLogEvents"
+import updateLockStatusToUnlocked from "./updateLockStatusToUnlocked"
 
 const generateTriggersAttributes = (triggers: Trigger[]) =>
   triggers.reduce(
@@ -24,7 +23,7 @@ const generateTriggersAttributes = (triggers: Trigger[]) =>
       acc[`Trigger ${index + 1} Details`] = `${trigger.triggerCode}${offenceNumberText}`
       return acc
     },
-    {} as KeyValuePair<string, unknown>
+    {} as Record<string, unknown>
   )
 
 const resolveTriggers = async (

--- a/src/types/NavigationHandler.ts
+++ b/src/types/NavigationHandler.ts
@@ -1,9 +1,8 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import type NavigationLocation from "./NavigationLocation"
 
 type NavigationOptions = {
   location: NavigationLocation
-  args?: KeyValuePair<string, unknown>
+  args?: Record<string, unknown>
 }
 
 type NavigationHandler = (options: NavigationOptions) => void

--- a/src/utils/caseAgeOptions.ts
+++ b/src/utils/caseAgeOptions.ts
@@ -1,8 +1,7 @@
 import { subDays } from "date-fns"
 import { CourtDateRange } from "types/CaseListQueryParams"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 
-export const CaseAgeOptions: KeyValuePair<string, () => CourtDateRange> = {
+export const CaseAgeOptions: Record<string, () => CourtDateRange> = {
   Today: () => {
     const today = new Date()
     return { from: today, to: today }

--- a/src/utils/caseStateFilters.ts
+++ b/src/utils/caseStateFilters.ts
@@ -1,6 +1,4 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-
-export const caseStateLabels: KeyValuePair<string, string> = {
+export const caseStateLabels: Record<string, string> = {
   "Unresolved and resolved": "Unresolved & resolved cases",
   Resolved: "Resolved cases"
 }

--- a/src/utils/formatReasons/groupErrorsFromReport.ts
+++ b/src/utils/formatReasons/groupErrorsFromReport.ts
@@ -1,7 +1,5 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-
-const groupErrorsFromReport = (errorReport: string): KeyValuePair<string, number> => {
-  const errorsCodes: KeyValuePair<string, number> = {}
+const groupErrorsFromReport = (errorReport: string): Record<string, number> => {
+  const errorsCodes: Record<string, number> = {}
   errorReport.match(/(HO)[0-9]{1,9}/g)?.forEach((code) => {
     errorsCodes[code] = errorsCodes[code] ? errorsCodes[code] + 1 : (errorsCodes[code] = 1)
   })

--- a/src/utils/updateQueryString.ts
+++ b/src/utils/updateQueryString.ts
@@ -1,6 +1,4 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-
-const updateQueryString = (params: KeyValuePair<string, unknown>) => {
+const updateQueryString = (params: Record<string, unknown>) => {
   const searchParams = new URLSearchParams(window.location.search)
   Object.entries(params).map(([key, value]) => {
     if (value === null) {

--- a/test/services/getCountOfCasesByCaseAge.integration.test.ts
+++ b/test/services/getCountOfCasesByCaseAge.integration.test.ts
@@ -1,17 +1,16 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import "reflect-metadata"
-import { DataSource, SelectQueryBuilder } from "typeorm"
+import { subDays } from "date-fns"
 import MockDate from "mockdate"
-import deleteFromEntity from "../utils/deleteFromEntity"
-import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
-import { isError } from "../../src/types/Result"
+import "reflect-metadata"
+import User from "services/entities/User"
+import getCountOfCasesByCaseAge from "services/getCountOfCasesByCaseAge"
+import courtCasesByOrganisationUnitQuery from "services/queries/courtCasesByOrganisationUnitQuery"
+import { DataSource, SelectQueryBuilder } from "typeorm"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
-import getCountOfCasesByCaseAge from "services/getCountOfCasesByCaseAge"
-import { subDays } from "date-fns"
-import courtCasesByOrganisationUnitQuery from "services/queries/courtCasesByOrganisationUnitQuery"
-import User from "services/entities/User"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
+import { isError } from "../../src/types/Result"
+import deleteFromEntity from "../utils/deleteFromEntity"
+import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 
 jest.mock(
   "services/queries/courtCasesByOrganisationUnitQuery",
@@ -84,7 +83,7 @@ describe("listCourtCases", () => {
     const result = (await getCountOfCasesByCaseAge(dataSource, {
       visibleCourts: [],
       visibleForces: [orgCode]
-    } as Partial<User> as User)) as KeyValuePair<string, number>
+    } as Partial<User> as User)) as Record<string, number>
 
     expect(isError(result)).toBeFalsy()
 
@@ -109,7 +108,7 @@ describe("listCourtCases", () => {
     const result = (await getCountOfCasesByCaseAge(dataSource, {
       visibleCourts: [],
       visibleForces: [orgCode]
-    } as Partial<User> as User)) as KeyValuePair<string, number>
+    } as Partial<User> as User)) as Record<string, number>
 
     expect(isError(result)).toBeFalsy()
 
@@ -121,7 +120,7 @@ describe("listCourtCases", () => {
       const result = (await getCountOfCasesByCaseAge(dataSource, {
         visibleCourts: [],
         visibleForces: [orgCode]
-      } as Partial<User> as User)) as KeyValuePair<string, number>
+      } as Partial<User> as User)) as Record<string, number>
 
       expect(isError(result)).toBeFalsy()
 

--- a/test/services/reallocateCourtCase/reallocateCourtCaseToForce.integration.test.ts
+++ b/test/services/reallocateCourtCase/reallocateCourtCaseToForce.integration.test.ts
@@ -1,27 +1,26 @@
 import parseAhoXml from "@moj-bichard7-developers/bichard7-next-core/dist/parse/parseAhoXml/parseAhoXml"
+import generateTriggers from "@moj-bichard7-developers/bichard7-next-core/dist/triggers/generate"
 import { AnnotatedHearingOutcome } from "@moj-bichard7-developers/bichard7-next-core/dist/types/AnnotatedHearingOutcome"
+import Phase from "@moj-bichard7-developers/bichard7-next-core/dist/types/Phase"
+import TriggerCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/TriggerCode"
 import Note from "services/entities/Note"
 import User from "services/entities/User"
 import insertNotes from "services/insertNotes"
 import reallocateCourtCaseToForce from "services/reallocateCourtCase/reallocateCourtCaseToForce"
 import { DataSource, UpdateQueryBuilder } from "typeorm"
+import { AUDIT_LOG_EVENT_SOURCE, REALLOCATE_CASE_TRIGGER_CODE } from "../../../src/config"
+import amendCourtCase from "../../../src/services/amendCourtCase"
 import CourtCase from "../../../src/services/entities/CourtCase"
 import getDataSource from "../../../src/services/getDataSource"
+import recalculateTriggers from "../../../src/services/reallocateCourtCase/recalculateTriggers"
+import updateCourtCase from "../../../src/services/reallocateCourtCase/updateCourtCase"
+import updateTriggers from "../../../src/services/reallocateCourtCase/updateTriggers"
 import { isError } from "../../../src/types/Result"
+import fetchAuditLogEvents from "../../helpers/fetchAuditLogEvents"
+import { hasAccessToAll } from "../../helpers/hasAccessTo"
+import deleteFromDynamoTable from "../../utils/deleteFromDynamoTable"
 import deleteFromEntity from "../../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../../utils/insertCourtCases"
-import deleteFromDynamoTable from "../../utils/deleteFromDynamoTable"
-import fetchAuditLogEvents from "../../helpers/fetchAuditLogEvents"
-import { AUDIT_LOG_EVENT_SOURCE, REALLOCATE_CASE_TRIGGER_CODE } from "../../../src/config"
-import KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-import TriggerCode from "@moj-bichard7-developers/bichard7-next-data/dist/types/TriggerCode"
-import { hasAccessToAll } from "../../helpers/hasAccessTo"
-import updateCourtCase from "../../../src/services/reallocateCourtCase/updateCourtCase"
-import amendCourtCase from "../../../src/services/amendCourtCase"
-import updateTriggers from "../../../src/services/reallocateCourtCase/updateTriggers"
-import recalculateTriggers from "../../../src/services/reallocateCourtCase/recalculateTriggers"
-import generateTriggers from "@moj-bichard7-developers/bichard7-next-core/dist/triggers/generate"
-import Phase from "@moj-bichard7-developers/bichard7-next-core/dist/types/Phase"
 
 jest.mock("services/insertNotes")
 jest.mock("services/reallocateCourtCase/recalculateTriggers")
@@ -58,7 +57,7 @@ const createReallocationEvent = (newForceOwner: string, userName: string) => {
 }
 
 const createTriggersGeneratedEvent = (triggers: string[], hasUnresolvedExceptions: boolean, userName: string) => {
-  const triggersDetails = triggers.reduce((acc: KeyValuePair<string, unknown>, triggerCode, index) => {
+  const triggersDetails = triggers.reduce((acc: Record<string, unknown>, triggerCode, index) => {
     acc[`Trigger ${index + 1} Details`] = triggerCode
     return acc
   }, {})

--- a/test/services/resolveTriggers.integration.test.ts
+++ b/test/services/resolveTriggers.integration.test.ts
@@ -2,19 +2,18 @@ import { differenceInMinutes } from "date-fns"
 import User from "services/entities/User"
 import { DataSource } from "typeorm"
 import { isError } from "types/Result"
+import { AUDIT_LOG_EVENT_SOURCE } from "../../src/config"
 import CourtCase from "../../src/services/entities/CourtCase"
 import Trigger from "../../src/services/entities/Trigger"
 import getCourtCaseByOrganisationUnit from "../../src/services/getCourtCaseByOrganisationUnit"
 import getDataSource from "../../src/services/getDataSource"
 import resolveTriggers from "../../src/services/resolveTriggers"
+import fetchAuditLogEvents from "../helpers/fetchAuditLogEvents"
+import { hasAccessToAll } from "../helpers/hasAccessTo"
+import deleteFromDynamoTable from "../utils/deleteFromDynamoTable"
 import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 import { insertTriggers, TestTrigger } from "../utils/manageTriggers"
-import deleteFromDynamoTable from "../utils/deleteFromDynamoTable"
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
-import fetchAuditLogEvents from "../helpers/fetchAuditLogEvents"
-import { AUDIT_LOG_EVENT_SOURCE } from "../../src/config"
-import { hasAccessToAll } from "../helpers/hasAccessTo"
 
 jest.setTimeout(100000)
 
@@ -42,7 +41,7 @@ describe("resolveTriggers", () => {
             acc[`Trigger ${index + 1} Details`] = trigger
             return acc
           },
-          {} as KeyValuePair<string, unknown>
+          {} as Record<string, unknown>
         )
       }
     }

--- a/test/utils/insertManyIntoDynamoTable.ts
+++ b/test/utils/insertManyIntoDynamoTable.ts
@@ -1,8 +1,7 @@
-import type KeyValuePair from "@moj-bichard7-developers/bichard7-next-core/dist/types/KeyValuePair"
 import { isError } from "../../src/types/Result"
 import insertAuditLogIntoDynamoTable from "./insertAuditLogIntoDynamoTable"
 
-const insertManyIntoDynamoTable = async (records: KeyValuePair<string, unknown>[]) => {
+const insertManyIntoDynamoTable = async (records: Record<string, unknown>[]) => {
   while (records.length) {
     const recordsToInsert = records.splice(0, 100)
     const insertAuditLogResult = await insertAuditLogIntoDynamoTable(recordsToInsert)


### PR DESCRIPTION
For some reason we were using this from Core, but Typescript has a built-in `Record` type for this so we should use that instead

Also, fix a flaky test that wasn't actually testing what it was meant to.