### PR TITLE
Disable reallocation for cases in phase 2

### DIFF
--- a/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
@@ -228,7 +228,7 @@ describe("Case details", () => {
 
     cy.contains(
       "This case can not be reallocated within new bichard; Switch to the old bichard to reallocate this case."
-    ).should("not.exist")
+    ).should("not.be.visible")
 
     cy.visit("/bichard/court-cases/1")
 

--- a/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
@@ -208,7 +208,7 @@ describe("Case details", () => {
     }
   )
 
-  it("Should not allow reallocating phase 2 cases", () => {
+  it.only("Should not allow reallocating phase 2 cases", () => {
     cy.task("insertCourtCasesWithFields", [
       { orgForPoliceFilter: "01", phase: 1 },
       { orgForPoliceFilter: "01", phase: 2 }
@@ -235,6 +235,9 @@ describe("Case details", () => {
     cy.contains(
       "This case can not be reallocated within new bichard; Switch to the old bichard to reallocate this case."
     ).should("exist")
+
+    cy.visit("/bichard/court-cases/1/reallocate")
+    cy.url().should("match", /\/court-cases\/\d+/)
   })
 })
 

--- a/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
@@ -1,7 +1,7 @@
 import User from "services/entities/User"
 import { TestTrigger } from "../../../../test/utils/manageTriggers"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import canReallocateTestData from "../../../fixtures/canReallocateTestData.json"
+import hashedPassword from "../../../fixtures/hashedPassword"
 
 describe("Case details", () => {
   const defaultUsers: Partial<User>[] = Array.from(Array(4)).map((_value, idx) => {
@@ -207,6 +207,35 @@ describe("Case details", () => {
       })
     }
   )
+
+  it("Should not allow reallocating phase 2 cases", () => {
+    cy.task("insertCourtCasesWithFields", [
+      { orgForPoliceFilter: "01", phase: 1 },
+      { orgForPoliceFilter: "01", phase: 2 }
+    ])
+    const triggers: TestTrigger[] = [
+      {
+        triggerId: 0,
+        triggerCode: "TRPR0001",
+        status: "Unresolved",
+        createdAt: new Date("2022-07-09T10:22:34.000Z")
+      }
+    ]
+    cy.task("insertTriggers", { caseId: 0, triggers })
+    cy.login("bichard01@example.com", "password")
+
+    cy.visit("/bichard/court-cases/0")
+
+    cy.contains(
+      "This case can not be reallocated within new bichard; Switch to the old bichard to reallocate this case."
+    ).should("not.exist")
+
+    cy.visit("/bichard/court-cases/1")
+
+    cy.contains(
+      "This case can not be reallocated within new bichard; Switch to the old bichard to reallocate this case."
+    ).should("exist")
+  })
 })
 
 export {}

--- a/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
+++ b/cypress/e2e/court-cases/court-case-details/reallocate.cy.ts
@@ -208,7 +208,7 @@ describe("Case details", () => {
     }
   )
 
-  it.only("Should not allow reallocating phase 2 cases", () => {
+  it("Should not allow reallocating phase 2 cases", () => {
     cy.task("insertCourtCasesWithFields", [
       { orgForPoliceFilter: "01", phase: 1 },
       { orgForPoliceFilter: "01", phase: 2 }

--- a/src/features/CourtCaseDetails/Header.tsx
+++ b/src/features/CourtCaseDetails/Header.tsx
@@ -139,7 +139,7 @@ const Header: React.FC<Props> = ({ courtCase, user, canReallocate }: Props) => {
         />
       </HeaderRow>
       <ButtonContainer>
-        <ConditionalRender isRendered={canReallocate}>
+        <ConditionalRender isRendered={canReallocate && courtCase.phase === 1}>
           <LinkButton
             href={reallocatePath}
             className="b7-reallocate-button"

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-throw-literal */
 import { AnnotatedHearingOutcome } from "@moj-bichard7-developers/bichard7-next-core/dist/types/AnnotatedHearingOutcome"
+import ConditionalDisplay from "components/ConditionalDisplay"
 import Layout from "components/Layout"
 import CourtCaseDetails from "features/CourtCaseDetails/CourtCaseDetails"
 import { withAuthentication, withMultipleServerSideProps } from "middleware"
 import type { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from "next"
 import Head from "next/head"
 import { ParsedUrlQuery } from "querystring"
+import { createUseStyles } from "react-jss"
 import addNote from "services/addNote"
 import { courtCaseToDisplayFullCourtCaseDto } from "services/dto/courtCaseDto"
 import { userToDisplayFullUserDto } from "services/dto/userDto"
@@ -154,6 +156,18 @@ interface Props {
   canReallocate: boolean
 }
 
+const useStyles = createUseStyles({
+  attentionContainer: {
+    marginTop: "0.3rem",
+    marginRight: "100rem",
+    width: "100%"
+  },
+  attentionBanner: {
+    textTransform: "none",
+    fontWeight: 300
+  }
+})
+
 const CourtCaseDetailsPage: NextPage<Props> = ({
   courtCase,
   aho,
@@ -161,6 +175,7 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
   errorLockedByAnotherUser,
   canReallocate
 }: Props) => {
+  const classes = useStyles()
   return (
     <>
       <Head>
@@ -171,6 +186,16 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
         user={user}
         bichardSwitch={{ display: true, href: `/bichard-ui/SelectRecord?unstick=true&error_id=${courtCase.errorId}` }}
       >
+        <ConditionalDisplay isDisplayed={courtCase.phase != 1}>
+          <div className={`${classes.attentionContainer} govuk-tag govuk-!-width-full`}>
+            <div className="govuk-tag">{"Attention:"}</div>
+            <div className={`${classes.attentionBanner} govuk-tag`}>
+              {
+                "This case can not be reallocated within new bichard; Switch to the old bichard to reallocate this case."
+              }
+            </div>
+          </div>
+        </ConditionalDisplay>
         <CourtCaseDetails
           courtCase={courtCase}
           aho={aho}

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -185,7 +185,7 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
         user={user}
         bichardSwitch={{ display: true, href: `/bichard-ui/SelectRecord?unstick=true&error_id=${courtCase.errorId}` }}
       >
-        <ConditionalDisplay isDisplayed={courtCase.phase != 1}>
+        <ConditionalDisplay isDisplayed={courtCase.phase !== 1}>
           <div className={`${classes.attentionContainer} govuk-tag govuk-!-width-full`}>
             <div className="govuk-tag">{"Attention:"}</div>
             <div className={`${classes.attentionBanner} govuk-tag`}>

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -159,7 +159,6 @@ interface Props {
 const useStyles = createUseStyles({
   attentionContainer: {
     marginTop: "0.3rem",
-    marginRight: "100rem",
     width: "100%"
   },
   attentionBanner: {

--- a/src/pages/court-cases/[courtCaseId]/reallocate.tsx
+++ b/src/pages/court-cases/[courtCaseId]/reallocate.tsx
@@ -49,6 +49,10 @@ export const getServerSideProps = withMultipleServerSideProps(
       return forbidden(res)
     }
 
+    if (courtCase.phase !== 1) {
+      return redirectTo(`/court-cases/${courtCase.errorId}`)
+    }
+
     const props = {
       user: userToDisplayFullUserDto(currentUser),
       courtCase: courtCaseToDisplayFullCourtCaseDto(courtCase),

--- a/src/services/dto/courtCaseDto.ts
+++ b/src/services/dto/courtCaseDto.ts
@@ -37,7 +37,8 @@ export const courtCaseToDisplayFullCourtCaseDto = (courtCase: CourtCase): Displa
     ...courtCaseToDisplayPartialCourtCaseDto(courtCase),
     orgForPoliceFilter: courtCase.orgForPoliceFilter,
     courtCode: courtCase.courtCode,
-    courtReference: courtCase.courtReference
+    courtReference: courtCase.courtReference,
+    phase: courtCase.phase
   }
 
   return courtCaseInfo

--- a/src/types/display/CourtCases.ts
+++ b/src/types/display/CourtCases.ts
@@ -36,4 +36,5 @@ export type DisplayFullCourtCase = Pick<CourtCase, FieldsForDisplayFullCourtCase
   notes: DisplayNote[]
   triggers: DisplayTrigger[]
   resolutionTimestamp: string | null
+  phase?: number | null
 }


### PR DESCRIPTION
We want to temporary disable reallocation for cases that are in phase 2. This PR includes:

- New attention banner that shows when a case is in phase 2 and prompts user to use old bichard
- conditionally displaying the reallocate button 
- Redirect a user that tries to access the reallocate page via the url `bichard/court-cases/0/reallocate`