### PR TITLE
Remove tests directory before cloning it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - run: ./.circleci/scripts/build-ui.sh
       - run:
           name: Clone bichard7-next-tests
-          command: git clone --depth 1 https://github.com/ministryofjustice/bichard7-next-tests.git ~/bichard7-next-tests
+          command: rm -rf ~/bichard7-next-tests && git clone --depth 1 https://github.com/ministryofjustice/bichard7-next-tests.git ~/bichard7-next-tests
       - node/install-packages:
           app-dir: ~/bichard7-next-tests
           cache-path: ~/bichard7-next-tests/node_modules


### PR DESCRIPTION
CircleCI runner seems to already have the tests directory sometimes - remove it and then clone it. Might be something to do with how the node orb is caching dependencies.

https://app.circleci.com/pipelines/github/ministryofjustice/bichard7-next-ui/3425/workflows/5fa3c89e-e8cf-4ce5-a46f-42359e27fdb0/jobs/22377