### PR TITLE
Store meaningful values in feedback response

### DIFF
--- a/cypress/e2e/switchingFeedback.cy.ts
+++ b/cypress/e2e/switchingFeedback.cy.ts
@@ -32,8 +32,8 @@ const navigateAndClickSwitchToOldBichard = (url = "/bichard") => {
 }
 
 const expectFeedbackForm = () => {
-  cy.get("#caseListOrDetail").should("not.exist")
-  cy.get("#otherFeedback").should("not.exist")
+  cy.get("#pageWithIssue").should("not.exist")
+  cy.get("#comment").should("not.exist")
   cy.get("button").contains("Send feedback and continue").should("not.exist")
 }
 
@@ -148,9 +148,9 @@ describe("Switching Bichard Version Feedback Form", () => {
     typeFeedback()
     clickSendFeedbackButton()
     verifyFeedback({
-      otherFeedback: "Some feedback",
-      caseListOrDetail: Page.caseList,
-      issueOrPreference: SwitchingReason.issue
+      comment: "Some feedback",
+      pageWithIssue: Page.caseList,
+      switchingReason: SwitchingReason.issue
     })
   })
 
@@ -169,9 +169,9 @@ describe("Switching Bichard Version Feedback Form", () => {
     typeFeedback()
     clickSendFeedbackButton()
     verifyFeedback({
-      otherFeedback: "Some feedback",
-      caseListOrDetail: Page.caseDetails,
-      issueOrPreference: SwitchingReason.issue
+      comment: "Some feedback",
+      pageWithIssue: Page.caseDetails,
+      switchingReason: SwitchingReason.issue
     })
   })
 
@@ -186,7 +186,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     ).should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: SwitchingReason.preference })
+    verifyFeedback({ comment: "Some feedback", switchingReason: SwitchingReason.preference })
   })
 
   it("Other > Give feedback > Submit", () => {
@@ -196,7 +196,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Is there another reason why you are switching version of Bichard?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: SwitchingReason.other })
+    verifyFeedback({ comment: "Some feedback", switchingReason: SwitchingReason.other })
   })
 
   it("Found an issue > Don't fill anything > Submit", () => {

--- a/cypress/e2e/switchingFeedback.cy.ts
+++ b/cypress/e2e/switchingFeedback.cy.ts
@@ -1,7 +1,7 @@
 import SurveyFeedback from "services/entities/SurveyFeedback"
 import hashedPassword from "../fixtures/hashedPassword"
 import { addHours, addMinutes } from "date-fns"
-import { Page, type SwitchingFeedbackResponse } from "../../src/types/SurveyFeedback"
+import { Page, SwitchingReason, type SwitchingFeedbackResponse } from "../../src/types/SurveyFeedback"
 
 const expectedUserId = 0
 
@@ -147,7 +147,11 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Could you explain in detail what problem you have experienced?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: Page.caseList, issueOrPreference: "issue" })
+    verifyFeedback({
+      otherFeedback: "Some feedback",
+      caseListOrDetail: Page.caseList,
+      issueOrPreference: SwitchingReason.issue
+    })
   })
 
   it("Found an issue > Case details page > Give feedback > Submit", () => {
@@ -164,7 +168,11 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Could you explain in detail what problem you have experienced?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: Page.caseDetails, issueOrPreference: "issue" })
+    verifyFeedback({
+      otherFeedback: "Some feedback",
+      caseListOrDetail: Page.caseDetails,
+      issueOrPreference: SwitchingReason.issue
+    })
   })
 
   it("Prefer old Bichard > Give feedback > Submit", () => {
@@ -178,7 +186,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     ).should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: "preference" })
+    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: SwitchingReason.preference })
   })
 
   it("Other > Give feedback > Submit", () => {
@@ -188,7 +196,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Is there another reason why you are switching version of Bichard?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: "other" })
+    verifyFeedback({ otherFeedback: "Some feedback", issueOrPreference: SwitchingReason.other })
   })
 
   it("Found an issue > Don't fill anything > Submit", () => {

--- a/cypress/e2e/switchingFeedback.cy.ts
+++ b/cypress/e2e/switchingFeedback.cy.ts
@@ -1,7 +1,7 @@
 import SurveyFeedback from "services/entities/SurveyFeedback"
 import hashedPassword from "../fixtures/hashedPassword"
 import { addHours, addMinutes } from "date-fns"
-import type { SwitchingFeedbackResponse } from "../../src/types/SurveyFeedback"
+import { Page, type SwitchingFeedbackResponse } from "../../src/types/SurveyFeedback"
 
 const expectedUserId = 0
 
@@ -147,7 +147,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Could you explain in detail what problem you have experienced?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: "caselist", issueOrPreference: "issue" })
+    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: Page.caseList, issueOrPreference: "issue" })
   })
 
   it("Found an issue > Case details page > Give feedback > Submit", () => {
@@ -164,7 +164,7 @@ describe("Switching Bichard Version Feedback Form", () => {
     cy.contains("Could you explain in detail what problem you have experienced?").should("exist")
     typeFeedback()
     clickSendFeedbackButton()
-    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: "casedetail", issueOrPreference: "issue" })
+    verifyFeedback({ otherFeedback: "Some feedback", caseListOrDetail: Page.caseDetails, issueOrPreference: "issue" })
   })
 
   it("Prefer old Bichard > Give feedback > Submit", () => {

--- a/src/pages/feedback.tsx
+++ b/src/pages/feedback.tsx
@@ -15,7 +15,7 @@ import getDataSource from "services/getDataSource"
 import insertSurveyFeedback from "services/insertSurveyFeedback"
 import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
 import { isError } from "types/Result"
-import { FeedbackExperienceValue, SurveyFeedbackResponse, SurveyFeedbackType } from "types/SurveyFeedback"
+import { SurveyFeedbackResponse, SurveyFeedbackType } from "types/SurveyFeedback"
 import { DisplayFullUser } from "types/display/Users"
 import getQueryStringCookieName from "utils/getQueryStringCookieName"
 import { isPost } from "utils/http"
@@ -32,7 +32,7 @@ enum FeedbackExperienceKey {
   veryDissatisfied
 }
 
-const FeedbackExperienceOptions: Record<FeedbackExperienceKey, FeedbackExperienceValue> = {
+const FeedbackExperienceOptions: Record<FeedbackExperienceKey, string> = {
   0: "Very satisfied",
   1: "Satisfied",
   2: "Neither satisfied nor dissatisfied",
@@ -69,7 +69,7 @@ export const getServerSideProps = withMultipleServerSideProps(
           userId: isAnonymous === "no" ? currentUser.id : null,
           response: {
             isAnonymous,
-            experience: FeedbackExperienceOptions[+experience as FeedbackExperienceKey],
+            experience: +experience,
             comment: feedback
           } as SurveyFeedbackResponse
         } as SurveyFeedback)

--- a/src/pages/feedback.tsx
+++ b/src/pages/feedback.tsx
@@ -15,7 +15,7 @@ import getDataSource from "services/getDataSource"
 import insertSurveyFeedback from "services/insertSurveyFeedback"
 import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
 import { isError } from "types/Result"
-import { SurveyFeedbackResponse, SurveyFeedbackType } from "types/SurveyFeedback"
+import { FeedbackExperienceValue, SurveyFeedbackResponse, SurveyFeedbackType } from "types/SurveyFeedback"
 import { DisplayFullUser } from "types/display/Users"
 import getQueryStringCookieName from "utils/getQueryStringCookieName"
 import { isPost } from "utils/http"
@@ -32,7 +32,7 @@ enum FeedbackExperienceKey {
   veryDissatisfied
 }
 
-const FeedbackExperienceOptions: Record<FeedbackExperienceKey, string> = {
+const FeedbackExperienceOptions: Record<FeedbackExperienceKey, FeedbackExperienceValue> = {
   0: "Very satisfied",
   1: "Satisfied",
   2: "Neither satisfied nor dissatisfied",
@@ -67,7 +67,11 @@ export const getServerSideProps = withMultipleServerSideProps(
         const result = await insertSurveyFeedback(dataSource, {
           feedbackType: SurveyFeedbackType.General,
           userId: isAnonymous === "no" ? currentUser.id : null,
-          response: { isAnonymous, experience, comment: feedback } as SurveyFeedbackResponse
+          response: {
+            isAnonymous,
+            experience: FeedbackExperienceOptions[+experience as FeedbackExperienceKey],
+            comment: feedback
+          } as SurveyFeedbackResponse
         } as SurveyFeedback)
 
         if (!isError(result)) {

--- a/src/pages/switching-feedback.tsx
+++ b/src/pages/switching-feedback.tsx
@@ -14,7 +14,7 @@ import getDataSource from "services/getDataSource"
 import insertSurveyFeedback from "services/insertSurveyFeedback"
 import AuthenticationServerSidePropsContext from "types/AuthenticationServerSidePropsContext"
 import { isError } from "types/Result"
-import { SurveyFeedbackType, SwitchingFeedbackResponse } from "types/SurveyFeedback"
+import { Page, SurveyFeedbackType, SwitchingFeedbackResponse } from "types/SurveyFeedback"
 import { DisplayFullUser } from "types/display/Users"
 import { isPost } from "utils/http"
 import redirectTo from "utils/redirectTo"
@@ -24,7 +24,7 @@ import withCsrf from "../middleware/withCsrf/withCsrf"
 
 interface SwitchingFeedbackFormState {
   issueOrPreference?: string
-  caseListOrDetail?: string
+  caseListOrDetail?: Page
   feedback?: string
 }
 interface Props {
@@ -52,7 +52,7 @@ function validateForm(form: SwitchingFeedbackFormState): boolean {
     !!form.issueOrPreference && ["issue", "preference", "other"].includes(form.issueOrPreference)
   const isCaseListOrDetailValid =
     form.issueOrPreference !== "issue" ||
-    (!!form.caseListOrDetail && ["caselist", "casedetail"].includes(form.caseListOrDetail))
+    (!!form.caseListOrDetail && Object.values(Page).includes(form.caseListOrDetail as Page))
   const isFeedbackValid = !!form.feedback
 
   return isIssueOrPreferenceValid && isCaseListOrDetailValid && isFeedbackValid
@@ -102,7 +102,7 @@ export const getServerSideProps = withMultipleServerSideProps(
       if (validateForm(form)) {
         const response: SwitchingFeedbackResponse = {
           ...(form.issueOrPreference ? { issueOrPreference: form.issueOrPreference } : {}),
-          ...(form.caseListOrDetail ? { caseListOrDetail: form.caseListOrDetail } : {}),
+          ...(form.caseListOrDetail ? { caseListOrDetail: form.caseListOrDetail as Page } : {}),
           ...(form.feedback ? { otherFeedback: form.feedback } : {})
         }
 
@@ -147,7 +147,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
   const [formState, setFormState] = useState<SwitchingFeedbackFormState>({
     feedback: fields?.feedback.value ?? undefined,
     issueOrPreference: fields?.issueOrPreference.value ?? undefined,
-    caseListOrDetail: fields?.caseListOrDetail.value ?? undefined
+    caseListOrDetail: fields?.caseListOrDetail.value as Page
   })
   const handleFormChange = useCallback(
     <T extends keyof SwitchingFeedbackFormState>(field: T, value: SwitchingFeedbackFormState[T]) => {
@@ -249,18 +249,18 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
               >
                 <RadioButton
                   name={"caseListOrDetail"}
-                  id={"caseListOrDetail-caselist"}
-                  defaultChecked={fields?.caseListOrDetail.value === "caselist"}
-                  value={"caselist"}
+                  id={"caseListOrDetail-case-list"}
+                  defaultChecked={fields?.caseListOrDetail.value === Page.caseList}
+                  value={Page.caseList}
                   label={"Case list page"}
-                  onChange={() => handleFormChange("caseListOrDetail", "caselist")}
+                  onChange={() => handleFormChange("caseListOrDetail", Page.caseList)}
                 />
                 <RadioButton
                   name={"caseListOrDetail"}
-                  id={"caseListOrDetail-casedetail"}
-                  defaultChecked={fields?.caseListOrDetail.value === "casedetail"}
-                  value={"casedetail"}
-                  onChange={() => handleFormChange("caseListOrDetail", "casedetail")}
+                  id={"caseListOrDetail-case-detail"}
+                  defaultChecked={fields?.caseListOrDetail.value === Page.caseDetails}
+                  value={Page.caseDetails}
+                  onChange={() => handleFormChange("caseListOrDetail", Page.caseDetails)}
                   label={"Case details page"}
                 />
               </MultiChoice>

--- a/src/pages/switching-feedback.tsx
+++ b/src/pages/switching-feedback.tsx
@@ -29,8 +29,8 @@ const SwitchingReasonLabel: Record<SwitchingReason, string> = {
 }
 
 interface SwitchingFeedbackFormState {
-  issueOrPreference?: SwitchingReason
-  caseListOrDetail?: Page
+  switchingReason?: SwitchingReason
+  pageWithIssue?: Page
   feedback?: string
 }
 
@@ -39,13 +39,13 @@ interface Props {
   csrfToken: string
   previousPath: string
   fields?: {
-    issueOrPreference: {
+    switchingReason: {
       hasError: boolean
-      value?: string | null
+      value?: SwitchingReason | null
     }
-    caseListOrDetail: {
+    pageWithIssue: {
       hasError: boolean
-      value?: string | null
+      value?: Page | null
     }
     feedback: {
       hasError: boolean
@@ -56,10 +56,10 @@ interface Props {
 
 function validateForm(form: SwitchingFeedbackFormState): boolean {
   const isIssueOrPreferenceValid =
-    !!form.issueOrPreference && Object.values(SwitchingReason).includes(form.issueOrPreference as SwitchingReason)
+    !!form.switchingReason && Object.values(SwitchingReason).includes(form.switchingReason as SwitchingReason)
   const isCaseListOrDetailValid =
-    form.issueOrPreference !== SwitchingReason.issue ||
-    (!!form.caseListOrDetail && Object.values(Page).includes(form.caseListOrDetail as Page))
+    form.switchingReason !== SwitchingReason.issue ||
+    (!!form.pageWithIssue && Object.values(Page).includes(form.pageWithIssue as Page))
   const isFeedbackValid = !!form.feedback
 
   return isIssueOrPreferenceValid && isCaseListOrDetailValid && isFeedbackValid
@@ -108,9 +108,9 @@ export const getServerSideProps = withMultipleServerSideProps(
 
       if (validateForm(form)) {
         const response: SwitchingFeedbackResponse = {
-          ...(form.issueOrPreference ? { issueOrPreference: form.issueOrPreference as SwitchingReason } : {}),
-          ...(form.caseListOrDetail ? { caseListOrDetail: form.caseListOrDetail as Page } : {}),
-          ...(form.feedback ? { otherFeedback: form.feedback } : {})
+          ...(form.switchingReason ? { switchingReason: form.switchingReason as SwitchingReason } : {}),
+          ...(form.pageWithIssue ? { pageWithIssue: form.pageWithIssue as Page } : {}),
+          ...(form.feedback ? { comment: form.feedback } : {})
         }
 
         const result = await insertSurveyFeedback(dataSource, {
@@ -129,13 +129,13 @@ export const getServerSideProps = withMultipleServerSideProps(
           props: {
             ...props,
             fields: {
-              issueOrPreference: {
-                hasError: !form.issueOrPreference ? true : false,
-                value: form.issueOrPreference ?? null
+              switchingReason: {
+                hasError: !form.switchingReason ? true : false,
+                value: form.switchingReason ?? null
               },
-              caseListOrDetail: {
-                hasError: !form.caseListOrDetail ? true : false,
-                value: form.caseListOrDetail ?? null
+              pageWithIssue: {
+                hasError: !form.pageWithIssue ? true : false,
+                value: form.pageWithIssue ?? null
               },
               feedback: { hasError: !form.feedback ? true : false, value: form.feedback ?? null }
             }
@@ -153,8 +153,8 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
 
   const [formState, setFormState] = useState<SwitchingFeedbackFormState>({
     feedback: fields?.feedback.value ?? undefined,
-    issueOrPreference: fields?.issueOrPreference.value as SwitchingReason,
-    caseListOrDetail: fields?.caseListOrDetail.value as Page
+    switchingReason: fields?.switchingReason.value as SwitchingReason,
+    pageWithIssue: fields?.pageWithIssue.value as Page
   })
   const handleFormChange = useCallback(
     <T extends keyof SwitchingFeedbackFormState>(field: T, value: SwitchingFeedbackFormState[T]) => {
@@ -197,7 +197,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
           </p>
         </Fieldset>
         <Fieldset>
-          <FormGroup id="issueOrPreference">
+          <FormGroup id="switchingReason">
             <Heading as="h3" size="SMALL">
               {"Why have you decided to switch version of Bichard?"}
             </Heading>
@@ -208,37 +208,37 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
               label={""}
               meta={{
                 error: "Select one of the below options",
-                touched: fields?.issueOrPreference.hasError
+                touched: fields?.switchingReason.hasError
               }}
             >
               <RadioButton
-                name={"issueOrPreference"}
-                id={`issueOrPreference-${SwitchingReason.issue}`}
-                defaultChecked={fields?.issueOrPreference.value === SwitchingReason.issue}
+                name={"switchingReason"}
+                id={`switchingReason-${SwitchingReason.issue}`}
+                defaultChecked={fields?.switchingReason.value === SwitchingReason.issue}
                 value={SwitchingReason.issue}
-                onChange={() => handleFormChange("issueOrPreference", SwitchingReason.issue)}
+                onChange={() => handleFormChange("switchingReason", SwitchingReason.issue)}
                 label={SwitchingReasonLabel[SwitchingReason.issue]}
               />
               <RadioButton
-                name={"issueOrPreference"}
-                id={`issueOrPreference-${SwitchingReason.preference}`}
-                defaultChecked={fields?.issueOrPreference.value === SwitchingReason.preference}
+                name={"switchingReason"}
+                id={`switchingReason-${SwitchingReason.preference}`}
+                defaultChecked={fields?.switchingReason.value === SwitchingReason.preference}
                 value={SwitchingReason.preference}
-                onChange={() => handleFormChange("issueOrPreference", SwitchingReason.preference)}
+                onChange={() => handleFormChange("switchingReason", SwitchingReason.preference)}
                 label={SwitchingReasonLabel[SwitchingReason.preference]}
               />
               <RadioButton
-                name={"issueOrPreference"}
-                id={`issueOrPreference-${SwitchingReason.other}`}
-                defaultChecked={fields?.issueOrPreference.value === SwitchingReason.other}
+                name={"switchingReason"}
+                id={`switchingReason-${SwitchingReason.other}`}
+                defaultChecked={fields?.switchingReason.value === SwitchingReason.other}
                 value={SwitchingReason.other}
-                onChange={() => handleFormChange("issueOrPreference", SwitchingReason.other)}
+                onChange={() => handleFormChange("switchingReason", SwitchingReason.other)}
                 label={SwitchingReasonLabel[SwitchingReason.other]}
               />
             </MultiChoice>
           </FormGroup>
-          <ConditionalRender isRendered={formState.issueOrPreference === SwitchingReason.issue}>
-            <FormGroup id="caseListOrDetail">
+          <ConditionalRender isRendered={formState.switchingReason === SwitchingReason.issue}>
+            <FormGroup id="pageWithIssue">
               <Heading as="h3" size="SMALL">
                 {"Which page were you finding an issue with?"}
               </Heading>
@@ -249,28 +249,28 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
                 label={""}
                 meta={{
                   error: "Select one of the below options",
-                  touched: fields?.caseListOrDetail.hasError
+                  touched: fields?.pageWithIssue.hasError
                 }}
               >
                 <RadioButton
-                  name={"caseListOrDetail"}
-                  id={"caseListOrDetail-case-list"}
-                  defaultChecked={fields?.caseListOrDetail.value === Page.caseList}
+                  name={"pageWithIssue"}
+                  id={"pageWithIssue-case-list"}
+                  defaultChecked={fields?.pageWithIssue.value === Page.caseList}
                   value={Page.caseList}
                   label={"Case list page"}
-                  onChange={() => handleFormChange("caseListOrDetail", Page.caseList)}
+                  onChange={() => handleFormChange("pageWithIssue", Page.caseList)}
                 />
                 <RadioButton
-                  name={"caseListOrDetail"}
-                  id={"caseListOrDetail-case-detail"}
-                  defaultChecked={fields?.caseListOrDetail.value === Page.caseDetails}
+                  name={"pageWithIssue"}
+                  id={"pageWithIssue-case-detail"}
+                  defaultChecked={fields?.pageWithIssue.value === Page.caseDetails}
                   value={Page.caseDetails}
-                  onChange={() => handleFormChange("caseListOrDetail", Page.caseDetails)}
+                  onChange={() => handleFormChange("pageWithIssue", Page.caseDetails)}
                   label={"Case details page"}
                 />
               </MultiChoice>
             </FormGroup>
-            <FormGroup id="otherFeedback">
+            <FormGroup id="comment">
               <Heading as="h3" size="SMALL">
                 {"Could you explain in detail what problem you have experienced?"}
               </Heading>
@@ -294,7 +294,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
               <HintText>{`You have ${getRemainingLength()} characters remaining`}</HintText>
             </FormGroup>
           </ConditionalRender>
-          <ConditionalRender isRendered={formState.issueOrPreference === SwitchingReason.preference}>
+          <ConditionalRender isRendered={formState.switchingReason === SwitchingReason.preference}>
             <FormGroup id="versionPreferenceFeedback">
               <Heading as="h3" size="SMALL">
                 {
@@ -321,7 +321,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
               <HintText>{`You have ${getRemainingLength()} characters remaining`}</HintText>
             </FormGroup>
           </ConditionalRender>
-          <ConditionalRender isRendered={formState.issueOrPreference === SwitchingReason.other}>
+          <ConditionalRender isRendered={formState.switchingReason === SwitchingReason.other}>
             <FormGroup id="otherReasonFeedback">
               <Heading as="h3" size="SMALL">
                 {"Is there another reason why you are switching version of Bichard?"}
@@ -347,7 +347,7 @@ const SwitchingFeedbackPage: NextPage<Props> = ({ user, previousPath, fields, cs
             </FormGroup>
           </ConditionalRender>
 
-          <ConditionalRender isRendered={Boolean(formState.issueOrPreference)}>
+          <ConditionalRender isRendered={Boolean(formState.switchingReason)}>
             <FormGroup>
               <Button type="submit">{"Send feedback and continue"}</Button>
             </FormGroup>

--- a/src/types/SurveyFeedback.ts
+++ b/src/types/SurveyFeedback.ts
@@ -5,12 +5,17 @@ export type FeedbackExperienceValue =
   | "Dissatisfied"
   | "Very dissatisfied"
 
+export enum Page {
+    caseList = "Case list",
+    caseDetails = "Case details",
+  }
+
 export type SurveyFeedbackResponse = { experience: FeedbackExperienceValue; comment: string }
 
 export type SwitchingFeedbackResponse =
   | {
       issueOrPreference?: string
-      caseListOrDetail?: string
+      caseListOrDetail?: Page
       otherFeedback?: string
     }
   | {

--- a/src/types/SurveyFeedback.ts
+++ b/src/types/SurveyFeedback.ts
@@ -20,9 +20,9 @@ export type SurveyFeedbackResponse = { experience: FeedbackExperienceValue; comm
 
 export type SwitchingFeedbackResponse =
   | {
-      issueOrPreference?: SwitchingReason
-      caseListOrDetail?: Page
-      otherFeedback?: string
+      switchingReason?: SwitchingReason
+      pageWithIssue?: Page
+      comment?: string
     }
   | {
       skipped: boolean

--- a/src/types/SurveyFeedback.ts
+++ b/src/types/SurveyFeedback.ts
@@ -5,16 +5,22 @@ export type FeedbackExperienceValue =
   | "Dissatisfied"
   | "Very dissatisfied"
 
+export enum SwitchingReason {
+  issue = "issue",
+  preference = "preference",
+  other = "other"
+}
+
 export enum Page {
-    caseList = "Case list",
-    caseDetails = "Case details",
-  }
+  caseList = "Case list",
+  caseDetails = "Case details"
+}
 
 export type SurveyFeedbackResponse = { experience: FeedbackExperienceValue; comment: string }
 
 export type SwitchingFeedbackResponse =
   | {
-      issueOrPreference?: string
+      issueOrPreference?: SwitchingReason
       caseListOrDetail?: Page
       otherFeedback?: string
     }

--- a/src/types/SurveyFeedback.ts
+++ b/src/types/SurveyFeedback.ts
@@ -1,10 +1,3 @@
-export type FeedbackExperienceValue =
-  | "Very satisfied"
-  | "Satisfied"
-  | "Neither satisfied nor dissatisfied"
-  | "Dissatisfied"
-  | "Very dissatisfied"
-
 export enum SwitchingReason {
   issue = "issue",
   preference = "preference",
@@ -16,7 +9,7 @@ export enum Page {
   caseDetails = "Case details"
 }
 
-export type SurveyFeedbackResponse = { experience: FeedbackExperienceValue; comment: string }
+export type SurveyFeedbackResponse = { experience: number; comment: string }
 
 export type SwitchingFeedbackResponse =
   | {

--- a/src/types/SurveyFeedback.ts
+++ b/src/types/SurveyFeedback.ts
@@ -1,4 +1,11 @@
-export type SurveyFeedbackResponse = { experience: string; comment: string }
+export type FeedbackExperienceValue =
+  | "Very satisfied"
+  | "Satisfied"
+  | "Neither satisfied nor dissatisfied"
+  | "Dissatisfied"
+  | "Very dissatisfied"
+
+export type SurveyFeedbackResponse = { experience: FeedbackExperienceValue; comment: string }
 
 export type SwitchingFeedbackResponse =
   | {

--- a/test/services/insertSurveyFeedback.integration.test.ts
+++ b/test/services/insertSurveyFeedback.integration.test.ts
@@ -8,7 +8,7 @@ import deleteFromEntity from "../utils/deleteFromEntity"
 
 describe("insertSurveyFeedback", () => {
   let dataSource: DataSource
-  const dummyResponse = { experience: "very satisfied", comment: "some comment" }
+  const dummyResponse = { experience: 0, comment: "some comment" }
   const feedbackId = 0
 
   beforeAll(async () => {


### PR DESCRIPTION
### Context
We store user feedbacks in JSON format. This PR is to update the keys and values stored for general and switching feedback so its easy to process and more meaningful for user research.

### Before
```
// General feedback:
{"comment": "This is the user's comment", "experience": "1", "isAnonymous": "no"}

// Switching feedback:
{"feedback": "This is the user's comment ", "issueOrPreference": "issue", caseListOrDetail: "casedetail"}
```

### After
```
// General feedback:
{"comment": "This is the user's comment", "experience": 1, "isAnonymous": "no"}

// Switching feedback:
{"comment": "This is the user's comment about the issue",  "switchingReason": "issue",  "pageWithIssue": "Case details"}
```