### PR TITLE
Update Cypress; only able to update it to 13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-styled-components": "^2.1.4",
     "concurrently": "^8.2.1",
-    "cypress": "^12.17.4",
+    "cypress": "13.1.0",
     "cypress-axe": "^1.5.0",
     "eslint": "^8.51.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
This is the error I get when I go above 13.2.0, the current version is 13.3.2.

![Screenshot 2023-10-20 at 12 02 44](https://github.com/ministryofjustice/bichard7-next-ui/assets/1273965/086c8a6d-43ea-4a11-866c-898f468a03f0)
