### PR TITLE
Update the filter behaviour when combining reason and caseState filters

### DIFF
--- a/cypress/e2e/filter/filterCases.cy.ts
+++ b/cypress/e2e/filter/filterCases.cy.ts
@@ -364,7 +364,7 @@ describe("Filtering cases", () => {
     cy.get('label[for="case-age-today"]').should("have.text", "Today (1)")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     cy.get("tr")
       .not(":first")
       .each((row) => {
@@ -372,7 +372,7 @@ describe("Filtering cases", () => {
       })
 
     removeFilterTag("Today")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Tests for "yesterday"
     cy.get("button#filter-button").click()
@@ -380,12 +380,12 @@ describe("Filtering cases", () => {
     cy.get('label[for="case-age-yesterday"]').should("have.text", "Yesterday (2)")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 2)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 2)
     confirmMultipleFieldsDisplayed(["Case00001", "Case00002"])
     confirmMultipleFieldsNotDisplayed(["Case00000", "Case00003", "Case00004", "Case00005", "Case00006", "Case00007"])
 
     removeFilterTag("Yesterday")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Tests for "Day 2"
     cy.get("button#filter-button").click()
@@ -393,7 +393,7 @@ describe("Filtering cases", () => {
     filterByCaseAge("#case-age-day-2")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     cy.get("tr")
       .not(":first")
       .each((row) => {
@@ -401,7 +401,7 @@ describe("Filtering cases", () => {
       })
 
     removeFilterTag("Day 2")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Tests for "Day 3"
     cy.get("button#filter-button").click()
@@ -409,12 +409,12 @@ describe("Filtering cases", () => {
     filterByCaseAge("#case-age-day-3")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 3)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 3)
     confirmMultipleFieldsDisplayed(["Case00004", "Case00005", "Case00006"])
     confirmMultipleFieldsNotDisplayed(["Case00000", "Case00001", "Case00002", "Case00003", "Case00007"])
 
     removeFilterTag("Day 3")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Tests for "Day 15 and older"
     cy.get("button#filter-button").click()
@@ -425,7 +425,7 @@ describe("Filtering cases", () => {
     filterByCaseAge("#case-age-day-15-and-older")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     confirmMultipleFieldsDisplayed(["Case00007"])
     confirmMultipleFieldsNotDisplayed([
       "Case00000",
@@ -438,7 +438,7 @@ describe("Filtering cases", () => {
     ])
 
     removeFilterTag("Day 15 and older")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Test for multiple SLA
     cy.get("button#filter-button").click()
@@ -446,14 +446,14 @@ describe("Filtering cases", () => {
     filterByCaseAge("#case-age-day-3")
     cy.get("button#search").click()
 
-    cy.get("tr").not(":first").should("have.length", 4)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 4)
     confirmMultipleFieldsDisplayed(["Case00000", "Case00004", "Case00005", "Case00006"])
     confirmMultipleFieldsNotDisplayed(["Case00001", "Case00002", "Case00003", "Case00007"])
 
     removeFilterTag("Day 3")
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     removeFilterTag("Today")
-    cy.get("tr").not(":first").should("have.length", 8)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
   })
 
   it("Should display cases filtered for a date range", () => {
@@ -491,13 +491,13 @@ describe("Filtering cases", () => {
     cy.get("#date-from").should("have.value", "2022-01-01")
     cy.get("#date-to").should("have.value", "2022-12-31")
 
-    cy.get("tr").not(":first").should("have.length", 7)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 7)
 
     cy.contains("Hide filter").click()
 
     confirmFiltersAppliedContains("01/01/2022 - 31/12/2022")
     removeFilterTag("01/01/2022 - 31/12/2022")
-    cy.get("tr").not(":first").should("have.length", 13)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 13)
   })
 
   it("Should update 'selected filter' chip when changing date range filter", () => {
@@ -524,7 +524,7 @@ describe("Filtering cases", () => {
     ])
 
     cy.visit("/bichard?caseAge=invalid")
-    cy.get("tr").not(":first").should("have.length", 3)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 3)
   })
 
   it("Should filter cases by whether they have triggers and exceptions", () => {
@@ -642,7 +642,7 @@ describe("Filtering cases", () => {
     cy.get("#urgent").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 3)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 3)
     cy.get("tr")
       .not(":first")
       .each((row) => {
@@ -651,19 +651,19 @@ describe("Filtering cases", () => {
 
     // Removing urgent filter tag all case should be shown with the filter disabled
     removeFilterTag("Urgent")
-    cy.get("tr").not(":first").should("have.length", 4)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 4)
 
     // Filter for non-urgent cases
     cy.get("button[id=filter-button]").click()
     cy.get("#non-urgent").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     cy.contains("Case00001")
 
     // Removing non-urgent filter tag all case should be shown with the filter disabled
     removeFilterTag("Non-urgent")
-    cy.get("tr").not(":first").should("have.length", 4)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 4)
   })
 
   it("Should filter cases by case state", () => {
@@ -682,24 +682,24 @@ describe("Filtering cases", () => {
     cy.get("#unresolved-and-resolved").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 4)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 4)
     cy.contains("Case00000")
 
     // Removing case state filter tag unresolved cases should be shown with the filter disabled
     removeFilterTag("Unresolved & resolved cases")
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
 
     // Filter for resolved cases
     cy.get("button[id=filter-button]").click()
     cy.get("#resolved").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 3)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 3)
     cy.contains("Case00001")
 
     // Removing case state filter tag unresolved cases should be shown with the filter disabled
     removeFilterTag("Resolved cases")
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
   })
 
   it("Should filter cases by locked state", () => {
@@ -713,24 +713,24 @@ describe("Filtering cases", () => {
     cy.get("#locked").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     cy.contains("Case00000")
 
     // Removing locked filter tag all case should be shown with the filter disabled
     removeFilterTag("Locked")
-    cy.get("tr").not(":first").should("have.length", 2)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 2)
 
     // Filter for unlocked cases
     cy.get("button[id=filter-button]").click()
     cy.get("#unlocked").click()
     cy.get("button[id=search]").click()
 
-    cy.get("tr").not(":first").should("have.length", 1)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     cy.contains("Case00001")
 
     // Removing unlocked filter tag all case should be shown with the filter disabled
     removeFilterTag("Unlocked")
-    cy.get("tr").not(":first").should("have.length", 2)
+    cy.get(".moj-scrollable-pane tbody tr").should("have.length", 2)
   })
 
   it("Should clear filters when clicked on the link outside of the filter panel", () => {

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -198,7 +198,7 @@ const listCourtCases = async (
             ? { triggerResolvedTimestamp: IsNull() }
             : {}),
           ...(reasons?.includes(Reason.Exceptions) ? { errorResolvedTimestamp: IsNull() } : {}),
-          ...(!reasons ? { resolutionTimestamp: IsNull() } : {})
+          ...(!reasons || reasons.length === 0 ? { resolutionTimestamp: IsNull() } : {})
         })
       })
     )
@@ -208,7 +208,7 @@ const listCourtCases = async (
         ? { triggerResolvedTimestamp: Not(IsNull()) }
         : {}),
       ...(reasons?.includes(Reason.Exceptions) ? { errorResolvedTimestamp: Not(IsNull()) } : {}),
-      ...(!reasons ? { resolutionTimestamp: Not(IsNull()) } : {})
+      ...(!reasons || reasons.length === 0 ? { resolutionTimestamp: Not(IsNull()) } : {})
     })
 
     if (resolvedByUsername !== undefined) {

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -194,13 +194,21 @@ const listCourtCases = async (
     query.andWhere(
       new Brackets((qb) => {
         qb.where({
-          resolutionTimestamp: IsNull()
-        }).orWhere("trigger.status = 1")
+          ...(reasons?.includes(Reason.Triggers) || reasons?.includes(Reason.Bails)
+            ? { triggerResolvedTimestamp: IsNull() }
+            : {}),
+          ...(reasons?.includes(Reason.Exceptions) ? { errorResolvedTimestamp: IsNull() } : {}),
+          ...(!reasons ? { resolutionTimestamp: IsNull() } : {})
+        })
       })
     )
   } else if (caseState === "Resolved") {
     query.andWhere({
-      resolutionTimestamp: Not(IsNull())
+      ...(reasons?.includes(Reason.Triggers) || reasons?.includes(Reason.Bails)
+        ? { triggerResolvedTimestamp: Not(IsNull()) }
+        : {}),
+      ...(reasons?.includes(Reason.Exceptions) ? { errorResolvedTimestamp: Not(IsNull()) } : {}),
+      ...(!reasons ? { resolutionTimestamp: Not(IsNull()) } : {})
     })
 
     if (resolvedByUsername !== undefined) {

--- a/test/services/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases.integration.test.ts
@@ -39,7 +39,7 @@ jest.mock("services/queries/leftJoinAndSelectTriggersQuery")
 jest.setTimeout(100000)
 describe("listCourtCases", () => {
   let dataSource: DataSource
-  const orgCode = "36FPA1"
+  const orgCode = "01"
   const testUser = {
     visibleForces: [orgCode],
     visibleCourts: [],
@@ -1051,6 +1051,87 @@ describe("listCourtCases", () => {
       expect(cases[1].errorId).toBe(1)
       expect(cases[2].errorId).toBe(2)
     })
+  })
+
+  describe("Filter cases having a combination of reason and resolved status filter", () => {
+    const unresolvedTrigger: Partial<TestTrigger> = {
+      triggerCode: "TRPR0001",
+      status: "Unresolved",
+      createdAt: new Date("2022-07-09T10:22:34.000Z")
+    }
+    const resolvedTrigger: Partial<TestTrigger> = {
+      triggerCode: "TRPR0001",
+      status: "Resolved",
+      createdAt: new Date("2022-07-09T10:22:34.000Z")
+    }
+
+    it.only("Filter for Triggers and Unresolved cases", async () => {
+      // Triggers and Unresolved cases
+      // Seed a cases wth Triggers resolved, Exceptions Resolved, Everything resolved, Everything Unresolved
+      await insertCourtCasesWithFields([
+        {
+          defendantName: "Trigger Resolved",
+          orgForPoliceFilter: orgCode,
+          triggerResolvedBy: "Dummy user",
+          triggerResolvedTimestamp: new Date(),
+          triggerStatus: "Resolved"
+        },
+        {
+          defendantName: "Exceptions Resolved",
+          orgForPoliceFilter: orgCode,
+          errorResolvedBy: "Dummy user",
+          errorResolvedTimestamp: new Date(),
+          errorStatus: "Resolved"
+        },
+        {
+          defendantName: "Everything Resolved",
+          orgForPoliceFilter: orgCode,
+          triggerResolvedBy: "Dummy user",
+          triggerResolvedTimestamp: new Date(),
+          triggerStatus: "Resolved",
+          errorResolvedBy: "Dummy user",
+          errorResolvedTimestamp: new Date(),
+          errorStatus: "Resolved",
+          resolutionTimestamp: new Date()
+        },
+        { defendantName: "Everything Unresolved", orgForPoliceFilter: orgCode }
+      ])
+      await insertTriggers(0, [resolvedTrigger as TestTrigger])
+      await insertException(0, "HO100300", undefined, "Unresolved")
+
+      await insertTriggers(1, [unresolvedTrigger as TestTrigger])
+      await insertException(1, "HO100300", undefined, "Resolved")
+
+      await insertTriggers(2, [resolvedTrigger as TestTrigger])
+      await insertException(2, "HO100300", undefined, "Resolved")
+
+      await insertTriggers(3, [unresolvedTrigger as TestTrigger])
+      await insertException(3, "HO100300", undefined, "Unresolved")
+
+      // await insertException(0, "HO100300")
+      // await insertTriggers(1, [testTrigger])
+      // await insertTriggers(2, [conditionalBailTrigger])
+
+      // const result = await listCourtCases(
+      //   dataSource,
+      //   {
+      //     maxPageItems: "100",
+      //     reasons: [Reason.Bails, Reason.Exceptions, Reason.Triggers]
+      //   },
+      //   testUser
+      // )
+
+      // expect(isError(result)).toBeFalsy()
+      // const { result: cases } = result as ListCourtCaseResult
+
+      // expect(cases).toHaveLength(3)
+      // expect(cases[0].errorId).toBe(0)
+      // expect(cases[1].errorId).toBe(1)
+      // expect(cases[2].errorId).toBe(2)
+    })
+    // Exceptions and unresolved cases
+    // Triggers and Resolved cases
+    // Exceptions and Resolved cases
   })
 
   describe("Filter cases by urgency", () => {

--- a/test/utils/manageExceptions.ts
+++ b/test/utils/manageExceptions.ts
@@ -1,7 +1,13 @@
+import { ResolutionStatus } from "types/ResolutionStatus"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 
-export default async (caseId: number, exceptionCode: string, errorReport?: string): Promise<boolean> => {
+export default async (
+  caseId: number,
+  exceptionCode: string,
+  errorReport?: string,
+  exceptionResolved?: ResolutionStatus
+): Promise<boolean> => {
   const dataSource = await getDataSource()
 
   await dataSource
@@ -13,7 +19,10 @@ export default async (caseId: number, exceptionCode: string, errorReport?: strin
       ...(errorReport && {
         errorReport: () =>
           `(CASE WHEN (error_report = '') THEN '${errorReport}' ELSE error_report || ', ' || '${errorReport}' END)`
-      })
+      }),
+      errorResolvedBy: exceptionResolved === "Resolved" ? "Dummy UserName" : null,
+      errorResolvedTimestamp: exceptionResolved === "Resolved" ? new Date() : null,
+      errorStatus: exceptionResolved ?? "Unresolved"
     })
     .where("errorId = :id", { id: caseId })
     .execute()

--- a/test/utils/manageTriggers.ts
+++ b/test/utils/manageTriggers.ts
@@ -23,7 +23,12 @@ const insertTriggers = async (caseId: number, triggers: TestTrigger[]): Promise<
     .into(Trigger)
     .values(
       triggers.map((t) => {
-        return { ...t, errorId: caseId }
+        return {
+          resolvedAt: t.status === "Resolved" ? new Date() : null,
+          resolvedBy: t.status === "Resolved" ? "Dummy User" : null,
+          errorId: caseId,
+          ...t
+        }
       })
     )
     .execute()


### PR DESCRIPTION
Previously, having different combinations of reason and caseState filters returned incorrect results. We have written tests and implemented the fix.