### PR TITLE
Update storeAuditLogEvents to add newUI attribute

### DIFF
--- a/src/services/storeAuditLogEvents.ts
+++ b/src/services/storeAuditLogEvents.ts
@@ -8,6 +8,13 @@ const storeAuditLogEvents = async (messageId: string, events: AuditLogEvent[]) =
     return
   }
 
+  events.forEach((event) => {
+    event.attributes = {
+      ...(event.attributes ?? {}),
+      newUI: true
+    }
+  })
+
   return axios({
     url: `${AUDIT_LOG_API_URL}/messages/${messageId}/events`,
     method: "POST",

--- a/test/services/storeAuditLogEvents.integration.test.ts
+++ b/test/services/storeAuditLogEvents.integration.test.ts
@@ -50,7 +50,7 @@ describe("storeAuditLogEvents", () => {
 
     expect(record.events).toStrictEqual([
       {
-        attributes: { key1: "value1" },
+        attributes: { key1: "value1", newUI: true },
         category: "information",
         eventSource: "dummyEventSource",
         eventCode: "report-run",
@@ -75,7 +75,7 @@ describe("storeAuditLogEvents", () => {
 
     expect(axios).toBeCalledWith({
       url: `${AUDIT_LOG_API_URL}/messages/dummy_key/events`,
-      data: "[{}]",
+      data: '[{"attributes":{"newUI":true}}]',
       headers: { "X-API-Key": AUDIT_LOG_API_KEY },
       method: "POST"
     })


### PR DESCRIPTION
This PR update `storeAuditLogEvents` to ensure that we set `newUI` attribute in all events so we can differentiate between events originating from the old and new UIs.