### PR TITLE
Display court house code as LJA in summary box

### DIFF
--- a/cypress/component/CourtCaseDetailsSummary.cy.tsx
+++ b/cypress/component/CourtCaseDetailsSummary.cy.tsx
@@ -5,7 +5,7 @@ describe("Court Case Details Summary Box", () => {
     cy.mount(
       <CourtCaseDetailsSummaryBox
         asn="asn-value"
-        courtCode="courtCode-value"
+        courtHouseCode="courtHouseCodeLJA-value"
         courtName="courtName-value"
         courtReference={"courtReference-value"}
         pnci="pnci-value"
@@ -19,7 +19,7 @@ describe("Court Case Details Summary Box", () => {
     cy.contains("asn-value")
 
     cy.contains("Court code (LJA)")
-    cy.contains("ourtCode-value")
+    cy.contains("courtHouseCodeLJA-value")
 
     cy.contains("Court name")
     cy.contains("courtName-value")

--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -88,7 +88,7 @@ const CourtCaseDetails: React.FC<Props> = ({
       />
       <CourtCaseDetailsSummaryBox
         asn={courtCase.asn}
-        courtCode={courtCase.courtCode}
+        courtHouseCode={aho.AnnotatedHearingOutcome.HearingOutcome.Hearing.CourtHouseCode.toString()}
         courtName={courtCase.courtName}
         courtReference={courtCase.courtReference}
         pnci={aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.PNCIdentifier}

--- a/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetailsSummaryBox.tsx
@@ -32,7 +32,7 @@ const useStyles = createUseStyles({
 
 interface CourtCaseDetailsSummaryBoxProps {
   asn: string | null
-  courtCode: string | null
+  courtHouseCode: string | null
   courtName: string
   courtReference: string
   pnci: string | undefined
@@ -43,7 +43,7 @@ interface CourtCaseDetailsSummaryBoxProps {
 
 const CourtCaseDetailsSummaryBox = ({
   asn,
-  courtCode,
+  courtHouseCode,
   courtName,
   courtReference,
   pnci,
@@ -60,7 +60,7 @@ const CourtCaseDetailsSummaryBox = ({
       <CourtCaseDetailsSummaryBoxField label="PNCID" value={pnci} />
       <CourtCaseDetailsSummaryBoxField label="DOB" value={formatDisplayedDate(dob || "")} />
       <CourtCaseDetailsSummaryBoxField label="Hearing date" value={formatDisplayedDate(hearingDate || "")} />
-      <CourtCaseDetailsSummaryBoxField label="Court code (LJA)" value={courtCode} />
+      <CourtCaseDetailsSummaryBoxField label="Court code (LJA)" value={courtHouseCode} />
       <CourtCaseDetailsSummaryBoxField label="Court case reference" value={courtReference} />
       <CourtCaseDetailsSummaryBoxField label="Court name" value={courtName} />
     </div>


### PR DESCRIPTION
### Context
Previously the summary box displayed the `courtCode` in the LJA section, but a user pointed out that this should be the court location(court house code).
I confirmed that the legacy application also displays the court house code as LJA code.

### Changes
- Update LJA code in summary box to display the correct data