### PR TITLE
Fix bug: Add note when user has a locked trigger or exception

### DIFF
--- a/src/features/CourtCaseDetails/CourtCaseDetails.tsx
+++ b/src/features/CourtCaseDetails/CourtCaseDetails.tsx
@@ -20,7 +20,7 @@ import { Offences } from "./Tabs/Panels/Offences/Offences"
 interface Props {
   courtCase: DisplayFullCourtCase
   aho: AnnotatedHearingOutcome
-  errorLockedByAnotherUser: boolean
+  isLockedByCurrentUser: boolean
   user: DisplayFullUser
   canReallocate: boolean
   canResolveAndSubmit: boolean
@@ -53,7 +53,7 @@ const CourtCaseDetails: React.FC<Props> = ({
   courtCase,
   aho,
   user,
-  errorLockedByAnotherUser,
+  isLockedByCurrentUser,
   canReallocate,
   canResolveAndSubmit,
   csrfToken,
@@ -143,7 +143,7 @@ const CourtCaseDetails: React.FC<Props> = ({
           <Notes
             className={activeTab === "Notes" ? classes.visible : classes.notVisible}
             notes={courtCase.notes}
-            lockedByAnotherUser={errorLockedByAnotherUser}
+            isLockedByCurrentUser={isLockedByCurrentUser}
             csrfToken={csrfToken}
           />
         </GridCol>

--- a/src/features/CourtCaseDetails/Tabs/Panels/Notes/AddNoteForm.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/Notes/AddNoteForm.tsx
@@ -6,11 +6,11 @@ import { useBeforeunload } from "react-beforeunload"
 import Form from "../../../../../components/Form"
 
 interface Props {
-  lockedByAnotherUser: boolean
+  isLockedByCurrentUser: boolean
   csrfToken: string
 }
 
-const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser, csrfToken }: Props) => {
+const AddNoteForm: React.FC<Props> = ({ isLockedByCurrentUser, csrfToken }: Props) => {
   const [noteRemainingLength, setNoteRemainingLength] = useState(MAX_NOTE_LENGTH)
   const [submitted, setSubmitted] = useState(false)
   const [isFormValid, setIsFormValid] = useState(true)
@@ -43,7 +43,7 @@ const AddNoteForm: React.FC<Props> = ({ lockedByAnotherUser, csrfToken }: Props)
   }
 
   return (
-    <ConditionalRender isRendered={!lockedByAnotherUser}>
+    <ConditionalRender isRendered={isLockedByCurrentUser}>
       <Form method="POST" action="" onSubmit={handleSubmit} csrfToken={csrfToken}>
         <FormGroup>
           <Label className="govuk-heading-m b7-form-label-lg" htmlFor="note-text">

--- a/src/features/CourtCaseDetails/Tabs/Panels/Notes/Notes.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/Notes/Notes.tsx
@@ -11,7 +11,7 @@ import AddNoteForm from "./AddNoteForm"
 interface NotesProps {
   className: string
   notes: DisplayNote[]
-  lockedByAnotherUser: boolean
+  isLockedByCurrentUser: boolean
   csrfToken: string
 }
 
@@ -35,7 +35,7 @@ const filterNotes = (notes: DisplayNote[], viewOption?: NotesViewOption) => {
   return [filteredNotes, noNoteText] as const
 }
 
-export const Notes = ({ className, notes, lockedByAnotherUser, csrfToken }: NotesProps) => {
+export const Notes = ({ className, notes, isLockedByCurrentUser, csrfToken }: NotesProps) => {
   const [viewOption, setViewOption] = useState<NotesViewOption | undefined>()
   const [filteredNotes, noNoteText] = filterNotes(notes, viewOption)
   const hasNotes = notes.length > 0
@@ -68,7 +68,7 @@ export const Notes = ({ className, notes, lockedByAnotherUser, csrfToken }: Note
       <ConditionalRender isRendered={!hasFilteredNotes}>
         <Paragraph>{`Case has no ${noNoteText}.`}</Paragraph>
       </ConditionalRender>
-      <AddNoteForm lockedByAnotherUser={lockedByAnotherUser} csrfToken={csrfToken} />
+      <AddNoteForm isLockedByCurrentUser={isLockedByCurrentUser} csrfToken={csrfToken} />
     </CourtCaseDetailsPanel>
   )
 }

--- a/src/pages/court-cases/[courtCaseId]/index.tsx
+++ b/src/pages/court-cases/[courtCaseId]/index.tsx
@@ -171,7 +171,7 @@ export const getServerSideProps = withMultipleServerSideProps(
         user: userToDisplayFullUserDto(currentUser),
         courtCase: courtCaseToDisplayFullCourtCaseDto(courtCase),
         aho: JSON.parse(JSON.stringify(annotatedHearingOutcome)),
-        errorLockedByAnotherUser: courtCase.exceptionsAreLockedByAnotherUser(currentUser.username),
+        isLockedByCurrentUser: courtCase.isLockedByCurrentUser(currentUser.username),
         canReallocate: courtCase.canReallocate(currentUser.username),
         canResolveAndSubmit: courtCase.canResolveOrSubmit(currentUser),
         displaySwitchingSurveyFeedback: shouldShowSwitchingFeedbackForm(lastSwitchingFormSubmission ?? new Date(0))
@@ -184,7 +184,7 @@ interface Props {
   user: DisplayFullUser
   courtCase: DisplayFullCourtCase
   aho: AnnotatedHearingOutcome
-  errorLockedByAnotherUser: boolean
+  isLockedByCurrentUser: boolean
   canReallocate: boolean
   canResolveAndSubmit: boolean
   csrfToken: string
@@ -207,7 +207,7 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
   courtCase,
   aho,
   user,
-  errorLockedByAnotherUser,
+  isLockedByCurrentUser,
   canReallocate,
   canResolveAndSubmit,
   displaySwitchingSurveyFeedback,
@@ -244,7 +244,7 @@ const CourtCaseDetailsPage: NextPage<Props> = ({
           courtCase={courtCase}
           aho={aho}
           user={user}
-          errorLockedByAnotherUser={errorLockedByAnotherUser}
+          isLockedByCurrentUser={isLockedByCurrentUser}
           canReallocate={canReallocate}
           canResolveAndSubmit={canResolveAndSubmit}
           previousPath={previousPath}

--- a/src/services/addNote.ts
+++ b/src/services/addNote.ts
@@ -26,10 +26,10 @@ const addNote = async (
     }
   }
 
-  if (courtCase.isLockedByAnotherUser(username)) {
+  if (!courtCase.isLockedByCurrentUser(username)) {
     return {
       isSuccessful: false,
-      ValidationException: "Case is locked by another user"
+      ValidationException: "Case is not locked by the user"
     }
   }
 

--- a/test/services/addNote.integration.test.ts
+++ b/test/services/addNote.integration.test.ts
@@ -11,22 +11,12 @@ import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
 jest.mock("services/insertNotes")
 
 const note = "Dummy note"
-
-const insertRecords = async (
-  errorLockedByUsername: string | null = null,
-  triggerLockedByUsername: string | null = null
-) => {
-  const existingCourtCasesDbObject = {
-    courtDate: new Date("2008-09-25"),
-    orgForPoliceFilter: "36FPA1".padEnd(6, " "),
-    errorId: 0,
-    messageId: uuid(),
-    errorLockedByUsername: errorLockedByUsername,
-    triggerLockedByUsername: triggerLockedByUsername
-  }
-
-  await insertCourtCasesWithFields([existingCourtCasesDbObject])
+const existingCourtCasesDbObject = {
+  courtDate: new Date("2008-09-25"),
+  orgForPoliceFilter: "36FPA1".padEnd(6, " "),
+  errorId: 0
 }
+const currentUsername = "username"
 
 describe("addNote", () => {
   let dataSource: DataSource
@@ -49,47 +39,72 @@ describe("addNote", () => {
     await dataSource.destroy()
   })
 
-  it("Should add note when record is not locked by other user", async () => {
-    await insertRecords()
+  it("Should add note when record is fully locked by the user", async () => {
+    await insertCourtCasesWithFields([
+      {
+        messageId: uuid(),
+        errorLockedByUsername: currentUsername,
+        triggerLockedByUsername: currentUsername,
+        ...existingCourtCasesDbObject
+      }
+    ])
     const date = new Date()
     MockDate.set(date)
-    const result = await addNote(dataSource, 0, "username", note)
+    const result = await addNote(dataSource, 0, currentUsername, note)
 
     expect(insertNotes).toHaveBeenCalledTimes(1)
-    expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [{ errorId: 0, noteText: note, userId: "username" }])
+    expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
+      { errorId: 0, noteText: note, userId: currentUsername }
+    ])
 
     expect(result).toStrictEqual({ isSuccessful: true })
   })
 
-  it("Should not add note when error is locked by other user", async () => {
-    await insertRecords("DisplayPartialUser")
+  it("Should add note when record is partially locked by the user", async () => {
+    await insertCourtCasesWithFields([
+      {
+        messageId: uuid(),
+        errorLockedByUsername: "DisplayPartialUser",
+        triggerLockedByUsername: currentUsername,
+        ...existingCourtCasesDbObject
+      }
+    ])
     const date = new Date()
     MockDate.set(date)
-    const result = await addNote(dataSource, 0, "username", note)
+    const result = await addNote(dataSource, 0, currentUsername, note)
 
-    expect(result).toStrictEqual({
-      isSuccessful: false,
-      ValidationException: "Case is locked by another user"
-    })
+    expect(insertNotes).toHaveBeenCalledTimes(1)
+    expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
+      { errorId: 0, noteText: note, userId: currentUsername }
+    ])
 
-    expect(insertNotes).toHaveBeenCalledTimes(0)
+    expect(result).toStrictEqual({ isSuccessful: true })
   })
 
-  it("Should not add note when trigger is locked by other user", async () => {
-    await insertRecords(null, "DisplayPartialUser")
+  it("Should not add note when error is not locked by the user", async () => {
+    await insertCourtCasesWithFields([
+      {
+        ...existingCourtCasesDbObject,
+        messageId: uuid(),
+        errorLockedByUsername: "DisplayPartialUser",
+        triggerLockedByUsername: "another user"
+      }
+    ])
+
     const date = new Date()
     MockDate.set(date)
-    const result = await addNote(dataSource, 0, "username", note)
+    const result = await addNote(dataSource, 0, currentUsername, note)
 
     expect(result).toStrictEqual({
       isSuccessful: false,
-      ValidationException: "Case is locked by another user"
+      ValidationException: "Case is not locked by the user"
     })
+
     expect(insertNotes).toHaveBeenCalledTimes(0)
   })
 
   it("Should not add note when case does not exist", async () => {
-    const result = await addNote(dataSource, 0, "username", note)
+    const result = await addNote(dataSource, 0, currentUsername, note)
 
     expect(result).toStrictEqual({
       isSuccessful: false,
@@ -100,16 +115,18 @@ describe("addNote", () => {
   })
 
   it("Should add multiple notes when note text length is more than the 1000 characters", async () => {
-    await insertRecords()
+    await insertCourtCasesWithFields([
+      { messageId: uuid(), ...existingCourtCasesDbObject, errorLockedByUsername: currentUsername }
+    ])
 
-    const result = await addNote(dataSource, 0, "username", "A".repeat(2503))
+    const result = await addNote(dataSource, 0, currentUsername, "A".repeat(2503))
     expect(result).toStrictEqual({ isSuccessful: true })
 
     expect(insertNotes).toHaveBeenCalledTimes(1)
     expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
-      { errorId: 0, noteText: "A".repeat(1000), userId: "username" },
-      { errorId: 0, noteText: "A".repeat(1000), userId: "username" },
-      { errorId: 0, noteText: "A".repeat(503), userId: "username" }
+      { errorId: 0, noteText: "A".repeat(1000), userId: currentUsername },
+      { errorId: 0, noteText: "A".repeat(1000), userId: currentUsername },
+      { errorId: 0, noteText: "A".repeat(503), userId: currentUsername }
     ])
   })
 })


### PR DESCRIPTION
### Context
Currently, when an error is locked by someone else, but the trigger is locked by the user, the notes form is disabled, and the user cannot add a note.

### Changes
- Allow users to add note when they partially locking a case