### PR TITLE
Fix typing into next hearing date field

### DIFF
--- a/src/features/CourtCaseDetails/Tabs/Panels/Offences/Offence/HearingResult.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/Offences/Offence/HearingResult.tsx
@@ -43,14 +43,19 @@ const getNextHearingDateValue = (
   amendmentRecords: AmendmentRecords,
   offenceIndex: number,
   resultIndex: number
-): string => {
+): string | undefined => {
+  const validDateFormat = /^20\d{2}-\d{2}-\d{2}$/
   const nextHearingDateAmendment =
     amendmentRecords?.nextHearingDate &&
     (amendmentRecords.nextHearingDate as UpdatedNextHearingDate[]).find(
       (record) => record.offenceIndex === offenceIndex && record.resultIndex === resultIndex
     )?.updatedValue
 
-  return nextHearingDateAmendment ? formatFormInputDateString(new Date(nextHearingDateAmendment)) : ""
+  if (!nextHearingDateAmendment) {
+    return ""
+  }
+
+  return validDateFormat.test(nextHearingDateAmendment) ? nextHearingDateAmendment : undefined
 }
 
 const getNextHearingLocationValue = (

--- a/src/services/amendCourtCase/applyAmendmentsToAho.test.ts
+++ b/src/services/amendCourtCase/applyAmendmentsToAho.test.ts
@@ -226,7 +226,7 @@ describe("applyAmendmentsToAho", () => {
       nextHearingDate: [
         {
           offenceIndex,
-          updatedValue: new Date(2022, 8, 24),
+          updatedValue: "2022-08-24",
           resultIndex: 0
         }
       ]

--- a/src/types/Amendments.ts
+++ b/src/types/Amendments.ts
@@ -61,7 +61,7 @@ export type UpdatedOffenceResult = UpdatedOffenceValue & {
 export type UpdatedNextHearingDate = {
   offenceIndex: number
   resultIndex: number
-  updatedValue: Date
+  updatedValue: string
 }
 
 export type UpdatedOffence = {

--- a/src/utils/amendments/amendNextHearingDate/amendNextHearingDate.test.ts
+++ b/src/utils/amendments/amendNextHearingDate/amendNextHearingDate.test.ts
@@ -18,7 +18,7 @@ describe("amend fresult variable text", () => {
 
   it("amend valid next hearing date to defendant result", () => {
     const offenceIndex = -1
-    const updatedValue = new Date(2022, 8, 24)
+    const updatedValue = "2022-08-24"
     const resultIndex = 0
 
     expect(aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant?.Result?.NextHearingDate).toBe(undefined)
@@ -33,7 +33,7 @@ describe("amend fresult variable text", () => {
 
   it("amend valid next hearing date to offender result", () => {
     const offenceIndex = 0
-    const updatedValue = new Date(2022, 8, 24)
+    const updatedValue = "2022-08-24"
     const resultIndex = 0
 
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Offence = [
@@ -59,7 +59,7 @@ describe("amend fresult variable text", () => {
 
   it("throws an error as defendant Result is undefined", () => {
     const offenceIndex = -1
-    const updatedValue = new Date(2022, 8, 24)
+    const updatedValue = "2022-08-24"
     const resultIndex = 0
 
     aho.AnnotatedHearingOutcome.HearingOutcome.Case.HearingDefendant.Result = undefined
@@ -80,7 +80,7 @@ describe("amend fresult variable text", () => {
 
   it("throws an error if result is out of range", () => {
     const offenceIndex = 0
-    const updatedValue = new Date(2022, 8, 24)
+    const updatedValue = "2022-08-24"
     const resultIndex = 2
 
     expect(() =>
@@ -99,7 +99,7 @@ describe("amend fresult variable text", () => {
 
   it("throws an error if offence is out of range", () => {
     const offenceIndex = 1
-    const updatedValue = new Date(2022, 8, 24)
+    const updatedValue = "2022-08-24"
     const resultIndex = 0
 
     expect(() =>
@@ -120,12 +120,12 @@ describe("amend fresult variable text", () => {
     const amendments = [
       {
         offenceIndex: 0,
-        updatedValue: new Date(2022, 8, 24),
+        updatedValue: "2022-08-24",
         resultIndex: 0
       },
       {
         offenceIndex: 3,
-        updatedValue: new Date(2022, 7, 24),
+        updatedValue: "2022-07-24",
         resultIndex: 0
       }
     ]
@@ -159,12 +159,12 @@ describe("amend fresult variable text", () => {
     const amendments = [
       {
         offenceIndex: 0,
-        updatedValue: new Date(2022, 8, 24),
+        updatedValue: "2022-08-24",
         resultIndex: 0
       },
       {
         offenceIndex: 3,
-        updatedValue: new Date(2022, 7, 24),
+        updatedValue: "2022-07-24",
         resultIndex: 1
       }
     ]

--- a/src/utils/amendments/getSystemNotes.test.ts
+++ b/src/utils/amendments/getSystemNotes.test.ts
@@ -78,7 +78,7 @@ describe("getSystemNotes", () => {
   })
 
   it("can generate system notes when the amendment value is UpdatedNextHearingDate type", () => {
-    const updatedDate = new Date("2023-01-16")
+    const updatedDate = "2023-01-16"
     expect(
       getSystemNotes(
         {
@@ -96,7 +96,7 @@ describe("getSystemNotes", () => {
     ).toStrictEqual([
       {
         errorId: dummyErrorId,
-        noteText: `${user.username}: Portal Action: Update Applied. Element: nextHearingDate. New Value: 16/01/2023`,
+        noteText: `${user.username}: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2023-01-16`,
         userId: "System"
       }
     ])

--- a/src/utils/amendments/setAmendedField.test.ts
+++ b/src/utils/amendments/setAmendedField.test.ts
@@ -4,7 +4,7 @@ describe("setAmendedField", () => {
   describe("nextHearingDate", () => {
     it("can set the amended value when there are no other amendments", () => {
       const existingAmendments = {}
-      const updatedValue = new Date("2024-01-01")
+      const updatedValue = "2024-01-01"
 
       const result = setAmendedField(
         "nextHearingDate",
@@ -18,12 +18,12 @@ describe("setAmendedField", () => {
     })
 
     it("can update the an existing amendment value", () => {
-      const oldValue = new Date("2001-05-05")
+      const oldValue = "2001-05-05"
       const existingAmendments = {
         nextHearingDate: [{ resultIndex: 0, offenceIndex: 0, updatedValue: oldValue }]
       }
 
-      const updatedValue = new Date("2024-01-02")
+      const updatedValue = "2024-01-02"
 
       const result = setAmendedField(
         "nextHearingDate",
@@ -37,8 +37,8 @@ describe("setAmendedField", () => {
     })
 
     it("can set multiple amended value for the same key", () => {
-      const firstResultOfFirstOffenceNextHearingDate = new Date("2024-01-01")
-      const secondResultOfFirstOffenceNextHearingDate = new Date("2024-01-02")
+      const firstResultOfFirstOffenceNextHearingDate = "2024-01-01"
+      const secondResultOfFirstOffenceNextHearingDate = "2024-01-02"
 
       const existingAmendments = {
         nextHearingDate: [{ offenceIndex: 0, resultIndex: 0, updatedValue: firstResultOfFirstOffenceNextHearingDate }]
@@ -59,8 +59,8 @@ describe("setAmendedField", () => {
     })
 
     it("can add amendments when there are other amendments", () => {
-      const firstResultOfFirstOffenceNextHearingDate = new Date("2024-01-01")
-      const secondResultOfFirstOffenceNextHearingDate = new Date("2024-01-02")
+      const firstResultOfFirstOffenceNextHearingDate = "2024-01-01"
+      const secondResultOfFirstOffenceNextHearingDate = "2024-01-02"
 
       const existingAmendments = {
         forceOwner: "03",


### PR DESCRIPTION
### Context
Next hearing date field value is populated from the amendments, however, as a user is typing in the field, the amended value is updated with an incomplete date until the user finishes entering the date, making the field unusable by the keyboard.

### Changes
- Check if the amended date is a valid date
- Update nextHearingDate amendment type(input date field returns a string)