### PR TITLE
Remove trigger filter for trigger handlers

### DIFF
--- a/cypress/e2e/filter/reasons.roles.cy.ts
+++ b/cypress/e2e/filter/reasons.roles.cy.ts
@@ -42,18 +42,12 @@ describe("Reasons filters", () => {
     cy.get("#filter-panel .reasons .exceptions").should("exist")
   })
 
-  it("should display 'Triggers' and 'Bails' for trigger handlers", () => {
+  it("should only display 'Bails' for trigger handlers", () => {
     newUserLogin({ groups: [UserGroup.TriggerHandler] })
     navigateAndShowFilters()
 
     cy.get("#filter-panel .reasons .bails").should("exist")
-    cy.get("#filter-panel .reasons .triggers").should("exist")
-  })
-
-  it("should not display 'Exceptions' for trigger handlers", () => {
-    newUserLogin({ groups: [UserGroup.TriggerHandler] })
-    navigateAndShowFilters()
-
+    cy.get("#filter-panel .reasons .triggers").should("not.exist")
     cy.get("#filter-panel .reasons .exceptions").should("not.exist")
   })
 

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -175,7 +175,7 @@ const CourtCaseFilter: React.FC<Props> = ({
                   reasons={state.reasonFilter.map((reasonFilter) => reasonFilter.value)}
                   reasonOptions={
                     currentUser.hasAccessTo[Permission.Triggers] && !currentUser.hasAccessTo[Permission.Exceptions]
-                      ? [Reason.Bails, Reason.Triggers]
+                      ? [Reason.Bails]
                       : undefined
                   }
                   dispatch={dispatch}


### PR DESCRIPTION
Users in the trigger handler group no longer see the trigger filter, only Bails:
<img width="411" alt="image" src="https://github.com/ministryofjustice/bichard7-next-ui/assets/103956365/37c03943-7e5b-49a0-82cf-3c61679fdb89">
