### PR TITLE
Allow some wiggle room in size of TLS cert

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -9,7 +9,10 @@ file:
     exists: true
     owner: root
     group: root
-    size: 2394
+    size:
+      and:
+        - gt: 2377
+        - lt: 2395
     filetype: file
     contains: []
   /certs/server.key:


### PR DESCRIPTION
The docker build in AWS is currently failing because the renewed cert file size is 2378