### PR TITLE
BICAWS7-2477: Use base Badge component for ResolutionStatusBadge

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -3,7 +3,7 @@ import ConditionalRender from "components/ConditionalRender"
 interface BadgeProps {
   isRendered: boolean
   className?: string
-  colour: "red" | "blue" | "purple"
+  colour: "red" | "blue" | "purple" | "grey"
   label: string
 }
 

--- a/src/features/CourtCaseDetails/Header.tsx
+++ b/src/features/CourtCaseDetails/Header.tsx
@@ -99,13 +99,11 @@ const Header: React.FC<Props> = ({ canReallocate }: Props) => {
       <HeaderRow>
         <Heading as="h2" size="MEDIUM">
           {courtCase.defendantName}
-          <span className={"govuk-!-static-margin-left-5"}>
-            {getResolutionStatus(courtCase) ? (
-              <ResolutionStatusBadge resolutionStatus={getResolutionStatus(courtCase) || "Unresolved"} />
-            ) : (
-              <UrgentTag isUrgent={courtCase.isUrgent} />
-            )}
-          </span>
+          {getResolutionStatus(courtCase) ? (
+            <ResolutionStatusBadge resolutionStatus={getResolutionStatus(courtCase) || "Unresolved"} />
+          ) : (
+            <UrgentTag isUrgent={courtCase.isUrgent} />
+          )}
           <Badge
             isRendered={caseIsViewOnly}
             label="View only"

--- a/src/features/CourtCaseList/tags/ResolutionStatusBadge.tsx
+++ b/src/features/CourtCaseList/tags/ResolutionStatusBadge.tsx
@@ -1,3 +1,4 @@
+import Badge from "components/Badge"
 import { useCustomStyles } from "../../../../styles/customStyles"
 import { ResolutionStatus } from "../../../types/ResolutionStatus"
 
@@ -13,11 +14,12 @@ const ResolutionStatusBadge: React.FC<Props> = ({ resolutionStatus }: Props) => 
   }
 
   return (
-    <span
-      className={`moj-badge moj-badge-${resolutionStatus.toLowerCase()} moj-badge--${
-        resolutionStatus === "Resolved" ? "grey" : "blue"
-      } ${classes["margin-top-bottom"]}`}
-    >{`${resolutionStatus}`}</span>
+    <Badge
+      isRendered={true}
+      label={resolutionStatus}
+      colour={resolutionStatus === "Resolved" ? "grey" : "blue"}
+      className={`govuk-!-static-margin-left-5 moj-badge-${resolutionStatus.toLowerCase()}`}
+    />
   )
 }
 

--- a/src/features/CourtCaseList/tags/ResolutionStatusBadge.tsx
+++ b/src/features/CourtCaseList/tags/ResolutionStatusBadge.tsx
@@ -1,26 +1,21 @@
 import Badge from "components/Badge"
-import { useCustomStyles } from "../../../../styles/customStyles"
 import { ResolutionStatus } from "../../../types/ResolutionStatus"
 
 interface Props {
   resolutionStatus: ResolutionStatus
 }
 
-const ResolutionStatusBadge: React.FC<Props> = ({ resolutionStatus }: Props) => {
-  const classes = useCustomStyles()
-
-  if (resolutionStatus === "Unresolved") {
-    return <></>
-  }
-
-  return (
-    <Badge
-      isRendered={true}
-      label={resolutionStatus}
-      colour={resolutionStatus === "Resolved" ? "grey" : "blue"}
-      className={`govuk-!-static-margin-left-5 moj-badge-${resolutionStatus.toLowerCase()}`}
-    />
-  )
-}
+const ResolutionStatusBadge: React.FC<Props> = ({ resolutionStatus }: Props) => (
+  <>
+    {resolutionStatus !== "Unresolved" && (
+      <Badge
+        isRendered={true}
+        label={resolutionStatus}
+        colour={resolutionStatus === "Resolved" ? "grey" : "blue"}
+        className={`govuk-!-static-margin-left-5 moj-badge-${resolutionStatus.toLowerCase()}`}
+      />
+    )}
+  </>
+)
 
 export default ResolutionStatusBadge


### PR DESCRIPTION
Before:
![Screenshot 2024-01-11 at 15 23 56](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/c437d426-f4b6-48b7-9099-82389943bd0f)

After:
![Screenshot 2024-01-11 at 15 23 11](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/b8903aa8-29be-4b40-be89-45c149c228d7)
