### PR TITLE
Bicaws7-2482: Log UI details when page loads

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,6 +43,7 @@ import { validateQueryParams } from "utils/validators/validateQueryParams"
 import withCsrf from "../middleware/withCsrf/withCsrf"
 import CsrfServerSidePropsContext from "../types/CsrfServerSidePropsContext"
 import shouldShowSwitchingFeedbackForm from "../utils/shouldShowSwitchingFeedbackForm"
+import { logUiDetails } from "utils/logUiDetails"
 
 interface Props {
   csrfToken: string
@@ -251,6 +252,7 @@ const Home: NextPage<Props> = (props) => {
   } = props
 
   useEffect(() => {
+    logUiDetails()
     const nonSavedParams = ["unlockTrigger", "unlockException"]
     const [, queryString] = router.asPath.split("?")
 

--- a/src/utils/logUiDetails.ts
+++ b/src/utils/logUiDetails.ts
@@ -1,0 +1,7 @@
+export function logUiDetails(): void {
+  console.clear()
+  console.table({
+    environment: process.env.NODE_ENV,
+    version: process.env.UI_HASH ? process.env.UI_HASH.slice(0, 7) : "local"
+  })
+}


### PR DESCRIPTION
Adds a function which prints a table in the console when the case list page loads:
![Screenshot 2024-01-26 at 15 27 06](https://github.com/ministryofjustice/bichard7-next-ui/assets/36984875/f2dc4a87-9ebb-424c-95cf-d58c85b5c3e1)
