### PR TITLE
Bicaws7-2482: Expect workspace and build variables to be public

### DIFF
--- a/src/utils/logUiDetails.ts
+++ b/src/utils/logUiDetails.ts
@@ -1,7 +1,7 @@
 export function logUiDetails(): void {
   console.clear()
   console.table({
-    environment: process.env.WORKSPACE || "local",
-    build: process.env.BUILD || "local"
+    environment: process.env.NEXT_PUBLIC_WORKSPACE || "local",
+    build: process.env.NEXT_PUBLIC_BUILD || "local"
   })
 }


### PR DESCRIPTION
Environment variables need to be prefixed with NEXT_PUBLIC_ in order to be accessible in the browser.