### PR TITLE
Bicaws7-2482: Get runtime environment variables as server side props

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -69,6 +69,8 @@ interface Props {
   displaySwitchingSurveyFeedback: boolean
   searchOrder: string | null
   orderBy: string | null
+  environment?: string
+  build?: string
 }
 
 const validateOrder = (param: unknown): param is QueryOrder => param === "asc" || param === "desc"
@@ -217,7 +219,9 @@ export const getServerSideProps = withMultipleServerSideProps(
         locked: validatedLocked ? validatedLocked : null,
         caseState: validatedCaseState ? validatedCaseState : null,
         myCases: !!validatedMyCases,
-        queryStringCookieName
+        queryStringCookieName,
+        environment: process.env.NEXT_PUBLIC_WORKSPACE,
+        build: process.env.NEXT_PUBLIC_BUILD
       }
     }
   }

--- a/src/utils/logUiDetails.ts
+++ b/src/utils/logUiDetails.ts
@@ -1,7 +1,7 @@
-export function logUiDetails(): void {
+export function logUiDetails(environment: string = "local", build: string = "local"): void {
   console.clear()
   console.table({
-    environment: process.env.NEXT_PUBLIC_WORKSPACE || "local",
-    build: process.env.NEXT_PUBLIC_BUILD || "local"
+    environment,
+    build
   })
 }


### PR DESCRIPTION
https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables

> By default, environment variables are only available on the server. To expose an environment variable to the browser, it must be prefixed with NEXT_PUBLIC_. However, these public environment variables will be inlined into the JavaScript bundle during next build.
> 
> To read runtime environment variables, we recommend using getServerSideProps or [incrementally adopting the App Router](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration).