### PR TITLE
BICAWS7 2562 change filter option title on case age to case recieved

### DIFF
--- a/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
@@ -369,10 +369,10 @@ describe("Filtering cases", () => {
     removeFilterTag("Yesterday")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
-    // Tests for "Day 2"
+    // Tests for "2 days ago"
     cy.get("button#filter-button").click()
-    cy.get('label[for="case-age-day-2"]').should("have.text", `Day 2 (${day2DateString}) (1)`)
-    filterByCaseAge("#case-age-day-2")
+    cy.get('label[for="case-age-2-days-ago"]').should("have.text", `2 days ago (${day2DateString}) (1)`)
+    filterByCaseAge("#case-age-2-days-ago")
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
@@ -382,29 +382,29 @@ describe("Filtering cases", () => {
         cy.wrap(row).contains("Case00003").should("exist")
       })
 
-    removeFilterTag("Day 2")
+    removeFilterTag("2 days ago")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
-    // Tests for "Day 3"
+    // Tests for "3 days ago"
     cy.get("button#filter-button").click()
-    cy.get('label[for="case-age-day-3"]').should("have.text", `Day 3 (${day3DateString}) (3)`)
-    filterByCaseAge("#case-age-day-3")
+    cy.get('label[for="case-age-3-days-ago"]').should("have.text", `3 days ago (${day3DateString}) (3)`)
+    filterByCaseAge("#case-age-3-days-ago")
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 3)
     confirmMultipleFieldsDisplayed(["Case00004", "Case00005", "Case00006"])
     confirmMultipleFieldsNotDisplayed(["Case00000", "Case00001", "Case00002", "Case00003", "Case00007"])
 
-    removeFilterTag("Day 3")
+    removeFilterTag("3 days ago")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
-    // Tests for "Day 15 and older"
+    // Tests for "15 days ago and older"
     cy.get("button#filter-button").click()
-    cy.get('label[for="case-age-day-15-and-older"]').should(
+    cy.get('label[for="case-age-15-days-ago-and-older"]').should(
       "have.text",
-      `Day 15 and older (up to ${day15DateString}) (1)`
+      `15 days ago and older (up to ${day15DateString}) (1)`
     )
-    filterByCaseAge("#case-age-day-15-and-older")
+    filterByCaseAge("#case-age-15-days-ago-and-older")
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
@@ -419,20 +419,20 @@ describe("Filtering cases", () => {
       "Case00006"
     ])
 
-    removeFilterTag("Day 15 and older")
+    removeFilterTag("15 days ago and older")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)
 
     // Test for multiple SLA
     cy.get("button#filter-button").click()
     filterByCaseAge("#case-age-today")
-    filterByCaseAge("#case-age-day-3")
+    filterByCaseAge("#case-age-3-days-ago")
     cy.get("button#search").click()
 
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 4)
     confirmMultipleFieldsDisplayed(["Case00000", "Case00004", "Case00005", "Case00006"])
     confirmMultipleFieldsNotDisplayed(["Case00001", "Case00002", "Case00003", "Case00007"])
 
-    removeFilterTag("Day 3")
+    removeFilterTag("3 days ago")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 1)
     removeFilterTag("Today")
     cy.get(".moj-scrollable-pane tbody tr").should("have.length", 8)

--- a/cypress/e2e/case-list/filter-cases/filterChips.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/filterChips.cy.ts
@@ -103,8 +103,8 @@ describe("Case list", () => {
         cy.get(".govuk-heading-s").contains("Case age (SLA)").should("exist")
         cy.get(".moj-filter__tag").contains("Today").should("exist")
         cy.get(".moj-filter__tag").contains("Yesterday").should("not.exist")
-        cy.get(".moj-filter__tag").contains("Day 2").should("not.exist")
-        cy.get(".moj-filter__tag").contains("Day 3").should("not.exist")
+        cy.get(".moj-filter__tag").contains("2 days ago").should("not.exist")
+        cy.get(".moj-filter__tag").contains("3 days ago").should("not.exist")
       })
 
       it("Should remove the case age filter chip when date range is selected", () => {
@@ -270,7 +270,7 @@ describe("Case list", () => {
         cy.get("#filter-button").click()
         cy.get(".govuk-checkboxes__item").contains("Triggers").click()
 
-        filterByCaseAge("#case-age-day-2")
+        filterByCaseAge("#case-age-2-days-ago")
         cy.get("#my-cases-filter").click()
 
         // Check that relevant chips and headers are present on screen
@@ -283,16 +283,16 @@ describe("Case list", () => {
         cy.get(".moj-filter__tag").contains("Cases locked to me").should("exist")
         // Case Age (SLA)
         cy.get(".govuk-heading-s").contains("Case age (SLA)").should("exist")
-        cy.get(".moj-filter__tag").contains("Day 2").should("exist")
+        cy.get(".moj-filter__tag").contains("2 days ago").should("exist")
         cy.get(".moj-filter__tag").contains("Today").should("not.exist")
         cy.get(".moj-filter__tag").contains("Yesterday").should("not.exist")
-        cy.get(".moj-filter__tag").contains("Day 3").should("not.exist")
+        cy.get(".moj-filter__tag").contains("3 days ago").should("not.exist")
 
         // submit query and display filter chips in filters applied section
         cy.get("#search").contains("Apply filters").click()
         cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Triggers").should("exist")
         cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Cases locked to me").should("exist")
-        cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("Day 2").should("exist")
+        cy.get(".moj-button-menu__wrapper .moj-filter__tag").contains("2 days ago").should("exist")
       })
     })
 

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -1,6 +1,5 @@
 import DateInput from "components/CustomDateInput/DateInput"
 import RadioButton from "components/RadioButton/RadioButton"
-import { formatDistance } from "date-fns"
 import type { Dispatch } from "react"
 import { createUseStyles } from "react-jss"
 import { SerializedCourtDateRange } from "types/CaseListQueryParams"
@@ -33,10 +32,10 @@ const getCaseAgeWithFormattedDate = (namedCaseAge: string): string => {
   }
 
   const dateRange = [caseAge].flat()[0]
-
-  return namedCaseAge === "Day 15 and older"
+  console.log("Named Case Age: ", namedCaseAge)
+  return namedCaseAge === "15 days ago and older"
     ? `15 days ago and older (up to ${formatDisplayedDate(dateRange.to)})`
-    : `${formatDistance(dateRange.from, new Date())} ago (${formatDisplayedDate(dateRange.from)})`
+    : `${namedCaseAge} (${formatDisplayedDate(dateRange.from)})`
 }
 
 const labelForCaseAge = (namedCaseAge: string, caseAgeCounts: Record<string, number>): string => {

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -32,7 +32,7 @@ const getCaseAgeWithFormattedDate = (namedCaseAge: string): string => {
   }
 
   const dateRange = [caseAge].flat()[0]
-  console.log("Named Case Age: ", namedCaseAge)
+
   return namedCaseAge === "15 days ago and older"
     ? `15 days ago and older (up to ${formatDisplayedDate(dateRange.to)})`
     : `${namedCaseAge} (${formatDisplayedDate(dateRange.from)})`

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -33,7 +33,7 @@ const getCaseAgeWithFormattedDate = (namedCaseAge: string): string => {
 
   const dateRange = [caseAge].flat()[0]
 
-  return namedCaseAge === "Day 15 and older"
+  return namedCaseAge === "15 days ago and older"
     ? `${namedCaseAge} (up to ${formatDisplayedDate(dateRange.to)})`
     : `${namedCaseAge} (${formatDisplayedDate(dateRange.from)})`
 }
@@ -73,7 +73,7 @@ const CourtDateFilterOptions: React.FC<Props> = ({ caseAges, caseAgeCounts, disp
           id={"case-age"}
           dataAriaControls={"conditional-case-age"}
           defaultChecked={caseAges && caseAges.length > 0 ? true : false}
-          label={"Case age (SLA)"}
+          label={"Case Recieved"}
         />
         <div className="govuk-radios__conditional" id="conditional-case-age">
           <div className={classes["scrollable-case-ages"]}>

--- a/src/components/FilterOptions/CourtDateFilterOptions.tsx
+++ b/src/components/FilterOptions/CourtDateFilterOptions.tsx
@@ -1,5 +1,6 @@
 import DateInput from "components/CustomDateInput/DateInput"
 import RadioButton from "components/RadioButton/RadioButton"
+import { formatDistance } from "date-fns"
 import type { Dispatch } from "react"
 import { createUseStyles } from "react-jss"
 import { SerializedCourtDateRange } from "types/CaseListQueryParams"
@@ -33,9 +34,9 @@ const getCaseAgeWithFormattedDate = (namedCaseAge: string): string => {
 
   const dateRange = [caseAge].flat()[0]
 
-  return namedCaseAge === "15 days ago and older"
-    ? `${namedCaseAge} (up to ${formatDisplayedDate(dateRange.to)})`
-    : `${namedCaseAge} (${formatDisplayedDate(dateRange.from)})`
+  return namedCaseAge === "Day 15 and older"
+    ? `15 days ago and older (up to ${formatDisplayedDate(dateRange.to)})`
+    : `${formatDistance(dateRange.from, new Date())} ago (${formatDisplayedDate(dateRange.from)})`
 }
 
 const labelForCaseAge = (namedCaseAge: string, caseAgeCounts: Record<string, number>): string => {

--- a/src/services/getCountOfCasesByCaseAge.ts
+++ b/src/services/getCountOfCasesByCaseAge.ts
@@ -7,7 +7,7 @@ import CourtCase from "./entities/CourtCase"
 import User from "./entities/User"
 import courtCasesByOrganisationUnitQuery from "./queries/courtCasesByOrganisationUnitQuery"
 
-const asKey = (caseAgeOption: string) => caseAgeOption.toLowerCase().replace(/ /g, "")
+const asKey = (caseAgeOption: string) => "_" + caseAgeOption.toLowerCase().replace(/ /g, "")
 
 const getCountOfCasesByCaseAge = async (connection: DataSource, user: User): PromiseResult<Record<string, number>> => {
   const repository = connection.getRepository(CourtCase)

--- a/src/utils/caseAgeOptions.ts
+++ b/src/utils/caseAgeOptions.ts
@@ -10,59 +10,59 @@ export const CaseAgeOptions: Record<string, () => CourtDateRange> = {
     const yesterday = subDays(new Date(), 1)
     return { from: yesterday, to: yesterday }
   },
-  "2 days ago": () => {
+  "Day 2": () => {
     const day2 = subDays(new Date(), 2)
     return { from: day2, to: day2 }
   },
-  "3 days ago": () => {
+  "Day 3": () => {
     const day3 = subDays(new Date(), 3)
     return { from: day3, to: day3 }
   },
-  "4 days ago": () => {
+  "Day 4": () => {
     const day4 = subDays(new Date(), 4)
     return { from: day4, to: day4 }
   },
-  "5 days ago": () => {
+  "Day 5": () => {
     const day5 = subDays(new Date(), 5)
     return { from: day5, to: day5 }
   },
-  "6 days ago": () => {
+  "Day 6": () => {
     const day6 = subDays(new Date(), 6)
     return { from: day6, to: day6 }
   },
-  "7 days ago": () => {
+  "Day 7": () => {
     const day7 = subDays(new Date(), 7)
     return { from: day7, to: day7 }
   },
-  "8 days ago": () => {
+  "Day 8": () => {
     const day8 = subDays(new Date(), 8)
     return { from: day8, to: day8 }
   },
-  "9 days ago": () => {
+  "Day 9": () => {
     const day9 = subDays(new Date(), 9)
     return { from: day9, to: day9 }
   },
-  "10 days ago": () => {
+  "Day 10": () => {
     const day10 = subDays(new Date(), 10)
     return { from: day10, to: day10 }
   },
-  "11 days ago": () => {
+  "Day 11": () => {
     const day11 = subDays(new Date(), 11)
     return { from: day11, to: day11 }
   },
-  "12 days ago": () => {
+  "Day 12": () => {
     const day12 = subDays(new Date(), 12)
     return { from: day12, to: day12 }
   },
-  "13 days ago": () => {
+  "Day 13": () => {
     const day13 = subDays(new Date(), 13)
     return { from: day13, to: day13 }
   },
-  "14 days ago": () => {
+  "Day 14": () => {
     const day14 = subDays(new Date(), 14)
     return { from: day14, to: day14 }
   },
-  "15 days ago and older": () => {
+  "Day 15 and older": () => {
     const unixEpoch = new Date(0)
     const day15 = subDays(new Date(), 15)
     return { from: unixEpoch, to: day15 }

--- a/src/utils/caseAgeOptions.ts
+++ b/src/utils/caseAgeOptions.ts
@@ -10,59 +10,59 @@ export const CaseAgeOptions: Record<string, () => CourtDateRange> = {
     const yesterday = subDays(new Date(), 1)
     return { from: yesterday, to: yesterday }
   },
-  "Day 2": () => {
+  "2 days ago": () => {
     const day2 = subDays(new Date(), 2)
     return { from: day2, to: day2 }
   },
-  "Day 3": () => {
+  "3 days ago": () => {
     const day3 = subDays(new Date(), 3)
     return { from: day3, to: day3 }
   },
-  "Day 4": () => {
+  "4 days ago": () => {
     const day4 = subDays(new Date(), 4)
     return { from: day4, to: day4 }
   },
-  "Day 5": () => {
+  "5 days ago": () => {
     const day5 = subDays(new Date(), 5)
     return { from: day5, to: day5 }
   },
-  "Day 6": () => {
+  "6 days ago": () => {
     const day6 = subDays(new Date(), 6)
     return { from: day6, to: day6 }
   },
-  "Day 7": () => {
+  "7 days ago": () => {
     const day7 = subDays(new Date(), 7)
     return { from: day7, to: day7 }
   },
-  "Day 8": () => {
+  "8 days ago": () => {
     const day8 = subDays(new Date(), 8)
     return { from: day8, to: day8 }
   },
-  "Day 9": () => {
+  "9 days ago": () => {
     const day9 = subDays(new Date(), 9)
     return { from: day9, to: day9 }
   },
-  "Day 10": () => {
+  "10 days ago": () => {
     const day10 = subDays(new Date(), 10)
     return { from: day10, to: day10 }
   },
-  "Day 11": () => {
+  "11 days ago": () => {
     const day11 = subDays(new Date(), 11)
     return { from: day11, to: day11 }
   },
-  "Day 12": () => {
+  "12 days ago": () => {
     const day12 = subDays(new Date(), 12)
     return { from: day12, to: day12 }
   },
-  "Day 13": () => {
+  "13 days ago": () => {
     const day13 = subDays(new Date(), 13)
     return { from: day13, to: day13 }
   },
-  "Day 14": () => {
+  "14 days ago": () => {
     const day14 = subDays(new Date(), 14)
     return { from: day14, to: day14 }
   },
-  "Day 15 and older": () => {
+  "15 days ago and older": () => {
     const unixEpoch = new Date(0)
     const day15 = subDays(new Date(), 15)
     return { from: unixEpoch, to: day15 }

--- a/src/utils/validators/validateCaseAges.test.ts
+++ b/src/utils/validators/validateCaseAges.test.ts
@@ -24,23 +24,23 @@ describe("mapCaseAges", () => {
     expect(result).toEqual({ from: dateYesterday, to: dateYesterday })
   })
 
-  it("Should return a date range for 'Day 2'", () => {
+  it("Should return a date range for '2 days ago'", () => {
     const dateToday = new Date("2022-11-15T12:30")
     const dateDay2 = subDays(dateToday, 2)
 
     MockDate.set(dateToday)
 
-    const result = mapCaseAges("Day 2")
+    const result = mapCaseAges("2 days ago")
     expect(result).toEqual({ from: dateDay2, to: dateDay2 })
   })
 
-  it("Should return a date range for 'Day 3'", () => {
+  it("Should return a date range for '3 days ago'", () => {
     const dateToday = new Date("2022-11-15T12:30")
     const dateDay3 = subDays(dateToday, 3)
 
     MockDate.set(dateToday)
 
-    const result = mapCaseAges("Day 3")
+    const result = mapCaseAges("3 days ago")
     expect(result).toEqual({ from: dateDay3, to: dateDay3 })
   })
 
@@ -54,7 +54,7 @@ describe("mapCaseAges", () => {
 
     MockDate.set(dateToday)
 
-    const result = mapCaseAges(["Today", "Day 2", "Should ignore invalid key"])
+    const result = mapCaseAges(["Today", "2 days ago", "Should ignore invalid key"])
     expect(result).toEqual([
       { from: dateToday, to: dateToday },
       { from: dateDay2, to: dateDay2 }
@@ -71,8 +71,8 @@ describe("validateCaseAgeKeys", () => {
   it.each([
     { input: "Today", expected: true },
     { input: "Yesterday", expected: true },
-    { input: "Day 2", expected: true },
-    { input: "Day 3", expected: true },
+    { input: "2 days ago", expected: true },
+    { input: "3 days ago", expected: true },
     { input: "Invalid Date Range", expected: false }
   ])("check whether '$input' is a valid date range", ({ input, expected }) => {
     expect(validateCaseAgeKeys(input)).toBe(expected)

--- a/test/services/getCountOfCasesByCaseAge.integration.test.ts
+++ b/test/services/getCountOfCasesByCaseAge.integration.test.ts
@@ -71,10 +71,10 @@ describe("listCourtCases", () => {
 
     expect(result.Today).toEqual("4")
     expect(result.Yesterday).toEqual("3")
-    expect(result["Day 2"]).toEqual("2")
-    expect(result["Day 3"]).toEqual("1")
-    expect(result["Day 14"]).toEqual("1")
-    expect(result["Day 15 and older"]).toEqual("3")
+    expect(result["2 days ago"]).toEqual("2")
+    expect(result["3 days ago"]).toEqual("1")
+    expect(result["14 days ago"]).toEqual("1")
+    expect(result["15 days ago and older"]).toEqual("3")
   })
 
   it("Should ignore resolved cases", async () => {
@@ -128,10 +128,10 @@ describe("listCourtCases", () => {
 
       expect(result.Today).toEqual("0")
       expect(result.Yesterday).toEqual("0")
-      expect(result["Day 2"]).toEqual("0")
-      expect(result["Day 3"]).toEqual("0")
-      expect(result["Day 14"]).toEqual("0")
-      expect(result["Day 15 and older"]).toEqual("0")
+      expect(result["2 days ago"]).toEqual("0")
+      expect(result["3 days ago"]).toEqual("0")
+      expect(result["14 days ago"]).toEqual("0")
+      expect(result["15 days ago and older"]).toEqual("0")
     })
   })
 


### PR DESCRIPTION
The filter option title changes:

- Change title of Filter Option “Case Age” To “Case Received” 
- Change filter Option titles. e.g. from “Day 2 (00/00/00)” “Day 3(00/00/00)” etc to “2 days ago (00/00/00)” etc to “15+ days ago”. 
Before:
![image](https://github.com/ministryofjustice/bichard7-next-ui/assets/65850511/a21b3b8e-e961-406e-85d4-2d2c1044c57c)
After:
![Screenshot 2024-02-20 at 10 13 19](https://github.com/ministryofjustice/bichard7-next-ui/assets/65850511/e53b1c5b-78d3-46d6-b711-2b2228f0b82c)
![Screenshot 2024-02-20 at 10 13 51](https://github.com/ministryofjustice/bichard7-next-ui/assets/65850511/858c05c8-54b1-49ee-a197-677b9e5339fb)
![Screenshot 2024-02-20 at 10 14 29](https://github.com/ministryofjustice/bichard7-next-ui/assets/65850511/7b05850e-81d2-491a-a2b6-2730c820c6cc)
