### PR TITLE
Update the ASN Hint Text

### DIFF
--- a/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.tsx
@@ -147,12 +147,13 @@ export const DefendantDetails = ({ amendFn, amendmentRecords, stopLeavingFn }: D
             isEditable={isAsnEditable}
           >
             <Label>{"Enter the ASN"}</Label>
-            <HintText>
+            <HintText>{"Long form ASN"}</HintText>
+            {/* <HintText>
               {
                 "Last 2 digits of year / 4 divisional ID location characters / 2 digits from owning force / 4 digits / 1 check letter "
               }
             </HintText>
-            <HintText>{"Example: 22 49AB 49 1234 C"}</HintText>
+            <HintText>{"Example: 22 49AB 49 1234 C"}</HintText> */}
             <div className={showError() ? `${asnFormGroupError}` : ""}>
               {showError() && (
                 <p id="event-name-error" className="govuk-error-message">


### PR DESCRIPTION
Left the old Hint Text in a comment so when we support it, it's there.

![Screenshot 2024-03-21 at 17 03 30](https://github.com/ministryofjustice/bichard7-next-ui/assets/1273965/cda214bb-7192-4e6d-843b-6ed80cd3ed9a)
