### PR TITLE
Set up and use users more sensibly and don't wipe the database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       image: ubuntu-2204:current
       docker_layer_caching: true
     resource_class: xlarge
-    parallelism: 5
+    parallelism: 10
     steps:
       - attach_workspace:
           at: .

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,9 +5,9 @@ import User from "./src/services/entities/User"
 import deleteFromEntity from "./test/utils/deleteFromEntity"
 import { getCourtCaseById } from "./test/utils/getCourtCaseById"
 import {
+  getAhoWithCustomExceptions,
   getAhoWithMultipleOffences,
   insertCourtCasesWithFields,
-  getAhoWithCustomExceptions,
   insertDummyCourtCasesWithNotes,
   insertDummyCourtCasesWithNotesAndLock,
   insertDummyCourtCasesWithTriggers,
@@ -15,15 +15,15 @@ import {
 } from "./test/utils/insertCourtCases"
 import { deleteFeedback, getAllFeedbacksFromDatabase, insertFeedback } from "./test/utils/manageFeedbackSurveys"
 
+import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
 import SurveyFeedback from "services/entities/SurveyFeedback"
 import { ResolutionStatus } from "types/ResolutionStatus"
-import insertException from "./test/utils/manageExceptions"
-import { deleteTriggers, insertTriggers } from "./test/utils/manageTriggers"
-import { deleteUsers, insertUsersWithOverrides } from "./test/utils/manageUsers"
 import generateAhoWithPncException, {
   GenerateAhoWithPncExceptionParams
 } from "./test/helpers/generateAhoWithPncException"
-import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
+import insertException from "./test/utils/manageExceptions"
+import { deleteTriggers, insertTriggers } from "./test/utils/manageTriggers"
+import { insertUsersWithOverrides } from "./test/utils/manageUsers"
 
 export default defineConfig({
   e2e: {
@@ -131,11 +131,6 @@ export default defineConfig({
 
         insertUsers(params: { users: Partial<User>[]; userGroups?: string[] }) {
           return insertUsersWithOverrides(params.users, params.userGroups)
-        },
-
-        async clearUsers() {
-          await deleteUsers()
-          return true
         },
 
         insertTriggers(args) {

--- a/cypress/e2e/api/organisation-units/searchOrganisationUnits.cy.ts
+++ b/cypress/e2e/api/organisation-units/searchOrganisationUnits.cy.ts
@@ -1,29 +1,11 @@
-import hashedPassword from "../../../fixtures/hashedPassword"
-import User from "../../../../src/services/entities/User"
 import OrganisationUnitApiResponse from "../../../../src/types/OrganisationUnitApiResponse"
 
-describe("Organiation Units API endpoint", () => {
-  before(() => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "Bichard user",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        } as Partial<User>
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-    cy.clearCookies()
+describe("Organisation Units API endpoint", () => {
+  beforeEach(() => {
+    cy.loginAs("GeneralHandler")
   })
 
   it("returns a list of organisations that matches the search keyword", () => {
-    cy.login("bichard01@example.com", "password")
-
     const searchKeyword = "croydon"
     cy.request({
       method: "GET",
@@ -40,8 +22,6 @@ describe("Organiation Units API endpoint", () => {
   })
 
   it("returns one item in a list for when search keyword is an exact match", () => {
-    cy.login("bichard01@example.com", "password")
-
     const searchKeyword = "B01EF00"
     cy.request({
       method: "GET",

--- a/cypress/e2e/assets.cy.ts
+++ b/cypress/e2e/assets.cy.ts
@@ -1,29 +1,14 @@
-import hashedPassword from "../fixtures/hashedPassword"
+import { loginAndVisit } from "../support/helpers"
 
 describe("GOV.UK Assets", () => {
   beforeEach(() => {
     cy.viewport(1280, 720)
     cy.task("clearCourtCases")
-    cy.task("clearUsers")
 
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp"]
-    })
-    cy.login("bichard01@example.com", "password")
+    loginAndVisit()
   })
 
   it("Should provide copyright logo", () => {
-    cy.visit("/bichard")
     cy.get(
       "a[href='https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/']"
     )
@@ -32,7 +17,6 @@ describe("GOV.UK Assets", () => {
   })
 
   it("Should provide favicon icon that loads correctly", () => {
-    cy.visit("/bichard")
     cy.get("link[rel='shortcut icon']")
       .should("have.attr", "href")
       .then((iconHref) => {

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/arrestSummonsNumber.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/arrestSummonsNumber.cy.ts
@@ -2,28 +2,9 @@ import AnnotatedHO from "../../../../../test/test-data/AnnotatedHO1.json"
 import AsnExceptionHO100206 from "../../../../../test/test-data/AsnExceptionHo100206.json"
 import AsnExceptionHO100321 from "../../../../../test/test-data/AsnExceptionHo100321.json"
 import ExceptionHO100239 from "../../../../../test/test-data/HO100239_1.json"
-import hashedPassword from "../../../../fixtures/hashedPassword"
-import { verifyUpdatedMessage } from "../../../../support/helpers"
+import { loginAndVisit, verifyUpdatedMessage } from "../../../../support/helpers"
 
 describe("ASN", () => {
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
@@ -32,7 +13,7 @@ describe("ASN", () => {
         hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
   })
@@ -48,15 +29,14 @@ describe("ASN", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("not.exist")
   })
 
   it("Should not be able to edit ASN field when the case isn't in 'unresolved' state", () => {
-    const submittedCaseId = 0
-    const resolvedCaseId = 1
+    const submittedCaseId = 1
+    const resolvedCaseId = 2
     cy.task("insertCourtCasesWithFields", [
       {
         errorStatus: "Submitted",
@@ -76,8 +56,7 @@ describe("ASN", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit(`/bichard/court-cases/${submittedCaseId}`)
+    loginAndVisit(`/bichard/court-cases/${submittedCaseId}`)
 
     cy.get(".moj-badge").contains("Editable Field").should("not.exist")
     cy.get("#asn").should("not.exist")
@@ -96,12 +75,11 @@ describe("ASN", () => {
         hearingOutcome: ExceptionHO100239.hearingOutcomeXml,
         updatedHearingOutcome: ExceptionHO100239.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("exist")
     cy.get("#asn").clear()
@@ -114,8 +92,8 @@ describe("ASN", () => {
     ).should("exist")
     cy.get("button").contains("Submit exception(s)").click()
 
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -132,12 +110,11 @@ describe("ASN", () => {
         hearingOutcome: ExceptionHO100239.hearingOutcomeXml,
         updatedHearingOutcome: ExceptionHO100239.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("exist")
     // error message should be displayed when ASN is not entered
@@ -171,12 +148,11 @@ describe("ASN", () => {
         hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("exist")
     cy.get("#asn").clear()
@@ -189,8 +165,8 @@ describe("ASN", () => {
     ).should("exist")
     cy.get("button").contains("Submit exception(s)").click()
 
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -207,12 +183,11 @@ describe("ASN", () => {
         hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
         updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("exist")
     cy.get("#asn").clear()
@@ -225,8 +200,8 @@ describe("ASN", () => {
     ).should("exist")
     cy.get("button").contains("Submit exception(s)").click()
 
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -236,8 +211,7 @@ describe("ASN", () => {
   })
 
   it("should display the updated ASN after submission along with CORRECTION badge", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Correction").should("not.exist")
     cy.get(".Defendant-details-table").contains("AAAAAAAAAAAAAAAAAAA")
@@ -252,8 +226,7 @@ describe("ASN", () => {
   })
 
   it("should display error when invalid ASN is entered", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("#asn").type("asdf")
 
@@ -268,32 +241,26 @@ describe("ASN", () => {
         hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard02"
+        errorLockedByUsername: "BichardForce02"
       }
     ])
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-badge").contains("Editable Field").should("not.exist")
   })
 
-  it("Should not be able to edit ASN field if user is not exception-handler", () => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "triggerHandler Test User",
-          surname: "01",
-          email: "triggerhandler@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7TriggerHandler_grp"]
-    })
-    cy.login("triggerhandler@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+  it("Should not be able to edit ASN field if user is not an exception handler", () => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
+        updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
+        errorCount: 1,
+        errorLockedByUsername: "TriggerHandler"
+      }
+    ])
+    loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
     cy.get(".moj-badge").should("not.exist")
   })

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-next-hearing-date.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-next-hearing-date.cy.ts
@@ -1,27 +1,8 @@
 import nextHearingDateExceptions from "../../../../../test/test-data/NextHearingDateExceptions.json"
 import dummyAho from "../../../../../test/test-data/error_list_aho.json"
-import hashedPassword from "../../../../fixtures/hashedPassword"
-import { submitAndConfirmExceptions, verifyUpdatedMessage } from "../../../../support/helpers"
+import { loginAndVisit, submitAndConfirmExceptions, verifyUpdatedMessage } from "../../../../support/helpers"
 
 describe("NextHearingDate", () => {
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
@@ -43,8 +24,7 @@ describe("NextHearingDate", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Burglary other than dwelling with intent to steal").click()
@@ -75,8 +55,7 @@ describe("NextHearingDate", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit(`/bichard/court-cases/${submittedCaseId}`)
+    loginAndVisit(`/bichard/court-cases/${submittedCaseId}`)
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()
@@ -94,8 +73,7 @@ describe("NextHearingDate", () => {
   })
 
   it("Shouldn't see editable next hearing date when it has no value", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with no exceptions").click()
@@ -114,8 +92,7 @@ describe("NextHearingDate", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()
@@ -132,8 +109,8 @@ describe("NextHearingDate", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-01-01")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-01-01")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -159,8 +136,7 @@ describe("NextHearingDate", () => {
         errorCount: 1
       }
     ])
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link")
@@ -177,8 +153,8 @@ describe("NextHearingDate", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2023-12-24")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2023-12-24")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -198,8 +174,7 @@ describe("NextHearingDate", () => {
   })
 
   it("Should be able to edit and submit multiple next hearing dates", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()
@@ -222,9 +197,9 @@ describe("NextHearingDate", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-01-01")
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2023-12-24")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-01-01")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2023-12-24")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -261,12 +236,11 @@ describe("NextHearingDate", () => {
         hearingOutcome: nextHearingDateExceptions.hearingOutcomeXml,
         updatedHearingOutcome: nextHearingDateExceptions.updatedHearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "bichard02"
+        errorLockedByUsername: "BichardForce02"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()
@@ -285,8 +259,7 @@ describe("NextHearingDate", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()
@@ -294,23 +267,7 @@ describe("NextHearingDate", () => {
   })
 
   it("Should not be able to edit next hearing date field when user is not exception-handler", () => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "triggerHandler",
-          visibleForces: ["001"],
-          forenames: "triggerHandler Test User",
-          surname: "01",
-          email: "triggerhandler@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7TriggerHandler_grp"]
-    })
-
-    cy.login("triggerhandler@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION").click()

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-next-hearing-location.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-next-hearing-location.cy.ts
@@ -1,27 +1,8 @@
 import dummyAho from "../../../../../test/test-data/HO100102_1.json"
 import nextHearingLocationExceptions from "../../../../../test/test-data/NextHearingLocationExceptions.json"
-import hashedPassword from "../../../../fixtures/hashedPassword"
-import { submitAndConfirmExceptions, verifyUpdatedMessage } from "../../../../support/helpers"
+import { loginAndVisit, submitAndConfirmExceptions, verifyUpdatedMessage } from "../../../../support/helpers"
 
 describe("NextHearingLocation", () => {
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
@@ -30,14 +11,13 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
         updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
   })
 
   it("Should not be able to edit next hearing location field if there is no exception", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with no exception").click()
@@ -54,8 +34,7 @@ describe("NextHearingLocation", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Use a motor vehicle on a road / public place without third party insurance").click()
@@ -71,12 +50,11 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100200,
         updatedHearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100200,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100200 - Unrecognised Force or Station Code").click()
@@ -96,8 +74,8 @@ describe("NextHearingLocation", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF01")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF01")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -121,12 +99,11 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100300,
         updatedHearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100300,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100300 - Organisation not recognised").click()
@@ -144,8 +121,8 @@ describe("NextHearingLocation", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B46DB00")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B46DB00")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -169,12 +146,11 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100322,
         updatedHearingOutcome: nextHearingLocationExceptions.hearingOutcomeXmlHO100322,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link")
@@ -194,8 +170,8 @@ describe("NextHearingLocation", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF00")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF00")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -214,8 +190,7 @@ describe("NextHearingLocation", () => {
   })
 
   it("Should be able to edit multiple next hearing locations", () => {
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100300 - Organisation not recognised").click()
@@ -241,9 +216,9 @@ describe("NextHearingLocation", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF00")
-    cy.contains("Bichard01: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B46DB00")
-    cy.contains("Bichard01: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B01EF00")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextSourceOrganisation. New Value: B46DB00")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
 
     verifyUpdatedMessage({
       expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
@@ -294,7 +269,7 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
         updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       },
       {
         errorStatus: "Resolved",
@@ -303,12 +278,11 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
         updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit(`/bichard/court-cases/${submittedCaseId}`)
+    loginAndVisit(`/bichard/court-cases/${submittedCaseId}`)
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100200 - Unrecognised Force or Station Code").click()
@@ -329,12 +303,11 @@ describe("NextHearingLocation", () => {
         hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
         updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "bichard02"
+        errorLockedByUsername: "BichardForce02"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100200 - Unrecognised Force or Station Code").click()
@@ -354,8 +327,7 @@ describe("NextHearingLocation", () => {
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100200 - Unrecognised Force or Station Code").click()
@@ -364,23 +336,7 @@ describe("NextHearingLocation", () => {
   })
 
   it("Should not be able to edit next hearing location field when user is not exception-handler", () => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "triggerHandler",
-          visibleForces: ["001"],
-          forenames: "triggerHandler Test User",
-          surname: "01",
-          email: "triggerhandler@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7TriggerHandler_grp"]
-    })
-
-    cy.login("triggerhandler@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
     cy.get(".govuk-link").contains("Offence with HO100200 - Unrecognised Force or Station Code").click()

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/exceptions-icons.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/exceptions-icons.cy.ts
@@ -1,44 +1,28 @@
-import hashedPassword from "../../../../fixtures/hashedPassword"
 import AsnExceptionHO100206 from "../../../../../test/test-data/AsnExceptionHo100206.json"
 import AsnExceptionHO100321 from "../../../../../test/test-data/AsnExceptionHo100321.json"
+import nextHearingDateAndLocationExceptions from "../../../../../test/test-data/NextHearingDateAndLocationExceptions.json"
 import nextHearingDateExceptions from "../../../../../test/test-data/NextHearingDateExceptions.json"
 import nextHearingLocationExceptions from "../../../../../test/test-data/NextHearingLocationExceptions.json"
-import nextHearingDateAndLocationExceptions from "../../../../../test/test-data/NextHearingDateAndLocationExceptions.json"
-import { submitAndConfirmExceptions, loginAndGoToUrl, clickTab } from "../../../../support/helpers"
+import { clickTab, loginAndVisit, submitAndConfirmExceptions } from "../../../../support/helpers"
 
 describe("Tabs exceptions icons", () => {
-  before(() => {
+  beforeEach(() => {
     cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
   })
 
   describe("ASN exception", () => {
     it("Should display 1 next to Defendant tab text when HO100206 is raised", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
           hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
           updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
           errorCount: 1,
-          errorLockedByUsername: "Bichard01"
+          errorLockedByUsername: "GeneralHandler"
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("1")
       cy.get("ul.moj-sub-navigation__list>li").eq(1).contains("Hearing").contains("1").should("not.exist")
@@ -48,18 +32,17 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display 1 next to Defendant tab text when HO100321 is raised", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
           hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
           updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
           errorCount: 1,
-          errorLockedByUsername: "Bichard01"
+          errorLockedByUsername: "GeneralHandler"
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("1")
       cy.get("ul.moj-sub-navigation__list>li").eq(1).contains("Hearing").contains("1").should("not.exist")
@@ -69,18 +52,17 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display checkmark icon next to Defendant tab text when asn exception is resolved", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
           hearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
           updatedHearingOutcome: AsnExceptionHO100206.hearingOutcomeXml,
           errorCount: 1,
-          errorLockedByUsername: "Bichard01"
+          errorLockedByUsername: "GeneralHandler"
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("#asn").clear()
       cy.get("#asn").type("1101ZD0100000448754K")
@@ -100,7 +82,6 @@ describe("Tabs exceptions icons", () => {
         nextHearingDateExceptions.hearingOutcomeXmlHO100323
       ].forEach((exception) => {
         it("Should display 1 next to the Offences tab text when either of the next-hearing-date exceptions is raised", () => {
-          cy.task("clearCourtCases")
           cy.task("insertCourtCasesWithFields", [
             {
               orgForPoliceFilter: "01",
@@ -110,7 +91,7 @@ describe("Tabs exceptions icons", () => {
             }
           ])
 
-          loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+          loginAndVisit("/bichard/court-cases/0")
 
           cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("1")
           cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("1").should("not.exist")
@@ -122,7 +103,6 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display 2 next to the Offences tab text when HO100102 and HO100323 are raised", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
@@ -132,7 +112,7 @@ describe("Tabs exceptions icons", () => {
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("2")
       cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("2").should("not.exist")
@@ -142,7 +122,6 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display checkmark icon next to Offences tab text when next-hearing-date exception is resolved", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
@@ -152,7 +131,7 @@ describe("Tabs exceptions icons", () => {
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("1").should("exist")
       clickTab("Offences")
@@ -166,7 +145,6 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display checkmark icon next to Offences tab text when multiple next-hearing-date exceptions are resolved", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
@@ -176,7 +154,7 @@ describe("Tabs exceptions icons", () => {
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("2").should("exist")
       clickTab("Offences")
@@ -202,7 +180,6 @@ describe("Tabs exceptions icons", () => {
         nextHearingLocationExceptions.hearingOutcomeXmlHO100322
       ].forEach((exception) => {
         it("Should display 1 next to the Offences tab text when either of the next-hearing-location exceptions is raised", () => {
-          cy.task("clearCourtCases")
           cy.task("insertCourtCasesWithFields", [
             {
               orgForPoliceFilter: "01",
@@ -212,7 +189,7 @@ describe("Tabs exceptions icons", () => {
             }
           ])
 
-          loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+          loginAndVisit("/bichard/court-cases/0")
 
           cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("1")
           cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("1").should("not.exist")
@@ -224,18 +201,17 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display 3 next to the Offences tab text when HO100200, HO100300, or HO100322 are raised", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
           hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
           updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
           errorCount: 1,
-          errorLockedByUsername: "Bichard01"
+          errorLockedByUsername: "GeneralHandler"
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("3")
       cy.get("ul.moj-sub-navigation__list>li").eq(0).contains("Defendant").contains("3").should("not.exist")
@@ -245,7 +221,6 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display checkmark icon next to Offences tab text when next-hearing-location exception is resolved", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
@@ -255,7 +230,7 @@ describe("Tabs exceptions icons", () => {
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("1").should("exist")
       clickTab("Offences")
@@ -271,18 +246,17 @@ describe("Tabs exceptions icons", () => {
     })
 
     it("Should display checkmark icon next to Offences tab text when multiple next-hearing-location exceptions are resolved", () => {
-      cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "01",
           hearingOutcome: nextHearingLocationExceptions.hearingOutcomeXml,
           updatedHearingOutcome: nextHearingLocationExceptions.updatedHearingOutcomeXml,
           errorCount: 1,
-          errorLockedByUsername: "Bichard01"
+          errorLockedByUsername: "GeneralHandler"
         }
       ])
 
-      loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get("ul.moj-sub-navigation__list>li").eq(3).contains("Offences").contains("3").should("exist")
       clickTab("Offences")
@@ -309,18 +283,17 @@ describe("Tabs exceptions icons", () => {
 
 describe("Offences exceptions icons", () => {
   it("Should display a warning icon in front of the first offence when exception is raised and checkmark icon when exception is resolved", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
         hearingOutcome: nextHearingDateExceptions.hearingOutcomeXmlHO100102,
         updatedHearingOutcome: nextHearingDateExceptions.hearingOutcomeXmlHO100102,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Offences")
     cy.get("#offences tbody tr:nth-child(1)").find(".warning-icon").should("exist")
@@ -336,7 +309,6 @@ describe("Offences exceptions icons", () => {
   })
 
   it("Should display warning icons for the first and second offences when exceptions are raised. Once the exceptions for these offences are resolved, replace the warning icons with checkmark icons", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
@@ -346,7 +318,7 @@ describe("Offences exceptions icons", () => {
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Offences")
     cy.get("#offences tbody tr:nth-child(1)").find(".warning-icon").should("exist")
@@ -382,7 +354,6 @@ describe("Offences exceptions icons", () => {
   })
 
   it("Should display only one warning icon per offence", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
@@ -392,7 +363,7 @@ describe("Offences exceptions icons", () => {
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Offences")
     cy.get("#offences tbody tr:nth-child(1)").find(".warning-icon").should("not.exist")
@@ -402,7 +373,6 @@ describe("Offences exceptions icons", () => {
   })
 
   it("Should display warning icon when only one of the exceptions is resolved for that particular offence", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
@@ -412,7 +382,7 @@ describe("Offences exceptions icons", () => {
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Offences")
     cy.get("#offences tbody tr:nth-child(1)").find(".warning-icon").should("not.exist")

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/exception-permissions.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/exception-permissions.cy.ts
@@ -1,30 +1,7 @@
-import hashedPassword from "../../../fixtures/hashedPassword"
 import canManuallyResolveAndSubmitTestData from "../../../fixtures/canManuallyResolveAndSubmitTestData.json"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Exception permissions", () => {
-  const insertUsers = (userRoles: string[]) => {
-    userRoles.forEach((userRole: string) => {
-      cy.task("insertUsers", {
-        users: [
-          {
-            username: `${userRole} username`,
-            visibleForces: ["01"],
-            forenames: `${userRole}'s forename`,
-            surname: `${userRole}surname`,
-            email: `${userRole}@example.com`,
-            password: hashedPassword
-          }
-        ],
-        userGroups: ["B7NewUI_grp", `B7${userRole}_grp`]
-      })
-    })
-  }
-
-  before(() => {
-    cy.task("clearUsers")
-    insertUsers(["GeneralHandler", "ExceptionHandler", "TriggerHandler", "Supervisor"])
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -44,32 +21,14 @@ describe("Exception permissions", () => {
       } and user is a ${loggedInAs} ${
         !exceptionsFeatureFlagEnabled ? "and exceptions feature flag is disabled" : ""
       }`, () => {
-        if (!exceptionsFeatureFlagEnabled) {
-          cy.task("clearUsers")
-          cy.task("insertUsers", {
-            users: [
-              {
-                username: `${loggedInAs} username`,
-                visibleForces: ["01"],
-                forenames: `${loggedInAs}'s forename`,
-                surname: `${loggedInAs}surname`,
-                email: `${loggedInAs}@example.com`,
-                password: hashedPassword,
-                featureFlags: { exceptionsEnabled: false }
-              }
-            ],
-            userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-          })
-        }
         cy.task("insertCourtCasesWithFields", [
           {
             orgForPoliceFilter: "01",
             errorStatus: exceptionStatus,
-            errorLockedByUsername: exceptionLockedByAnotherUser ? "Bichard03" : `${loggedInAs} username`
+            errorLockedByUsername: exceptionLockedByAnotherUser ? "BichardForce03" : loggedInAs
           }
         ])
-        cy.login(`${loggedInAs}@example.com`, "password")
-        cy.visit("/bichard/court-cases/0")
+        loginAndVisit(loggedInAs, "/bichard/court-cases/0")
 
         if (loggedInAs === "GeneralHandler") {
           cy.get(".triggers-and-exceptions-sidebar #exceptions-tab").click()

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/manually-resolve-exceptions.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/manually-resolve-exceptions.cy.ts
@@ -1,29 +1,6 @@
-import hashedPassword from "../../../fixtures/hashedPassword"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Manually resolve exceptions", () => {
-  const insertUsers = (userRoles: string[]) => {
-    userRoles.forEach((userRole: string) => {
-      cy.task("insertUsers", {
-        users: [
-          {
-            username: `${userRole} username`,
-            visibleForces: ["01"],
-            forenames: `${userRole}'s forename`,
-            surname: `${userRole}surname`,
-            email: `${userRole}@example.com`,
-            password: hashedPassword
-          }
-        ],
-        userGroups: ["B7NewUI_grp", `B7${userRole}_grp`]
-      })
-    })
-  }
-
-  before(() => {
-    cy.task("clearUsers")
-    insertUsers(["GeneralHandler", "ExceptionHandler", "TriggerHandler", "Supervisor"])
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -34,14 +11,12 @@ describe("Manually resolve exceptions", () => {
         orgForPoliceFilter: "01",
         errorCount: 1,
         triggerCount: 0,
-        errorLockedByUsername: "GeneralHandler username",
-        triggerLockedByUsername: "GeneralHandler username"
+        errorLockedByUsername: "GeneralHandler",
+        triggerLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("GeneralHandler@example.com", "password")
-
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.findByText("NAME Defendant").click()
 
@@ -56,9 +31,7 @@ describe("Manually resolve exceptions", () => {
     cy.contains("Notes").click()
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
-    cy.contains(
-      "GeneralHandler username: Portal Action: Record Manually Resolved. Reason: PNCRecordIsAccurate. Reason Text:"
-    )
+    cy.contains("GeneralHandler: Portal Action: Record Manually Resolved. Reason: PNCRecordIsAccurate. Reason Text:")
   })
 
   it("Should prompt the user to enter resolution details if the reason is Reallocated", () => {
@@ -67,13 +40,12 @@ describe("Manually resolve exceptions", () => {
         orgForPoliceFilter: "01",
         errorCount: 1,
         triggerCount: 0,
-        errorLockedByUsername: "GeneralHandler username",
-        triggerLockedByUsername: "GeneralHandler username"
+        errorLockedByUsername: "GeneralHandler",
+        triggerLockedByUsername: "GeneralHandler"
       }
     ])
-    cy.login("GeneralHandler@example.com", "password")
 
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.findByText("NAME Defendant").click()
 
@@ -94,13 +66,13 @@ describe("Manually resolve exceptions", () => {
     const dateTimeRegex = /\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/
     cy.contains(dateTimeRegex)
     cy.contains(
-      "GeneralHandler username: Portal Action: Record Manually Resolved. Reason: Reallocated. Reason Text: Some reason text"
+      "GeneralHandler: Portal Action: Record Manually Resolved. Reason: Reallocated. Reason Text: Some reason text"
     )
   })
 
   it("Should return 404 for a case that this user can not see", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "02" }])
-    cy.login("GeneralHandler@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,
@@ -111,7 +83,7 @@ describe("Manually resolve exceptions", () => {
   })
 
   it("Should return 404 for a case that does not exist", () => {
-    cy.login("GeneralHandler@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/redirect-when-resolve-triggers-and-exceptions.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/redirect-when-resolve-triggers-and-exceptions.cy.ts
@@ -1,6 +1,6 @@
 import { TestTrigger } from "../../../../test/utils/manageTriggers"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import redirectWhenResolveTriggersAndExceptions from "../../../fixtures/redirectWhenResolveTriggersAndExceptions.json"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Redirect when resolve triggers and exceptions", () => {
   beforeEach(() => {
@@ -14,22 +14,6 @@ describe("Redirect when resolve triggers and exceptions", () => {
       } ${hasExceptions && hasTriggers ? "and" : ""} ${hasTriggers ? "unresolved triggers" : ""} and ${loggedInAs} ${
         resolveExceptions ? "resolves exceptions" : ""
       } ${resolveExceptions && resolveTriggers ? "and" : ""} ${resolveTriggers ? "resolves triggers" : ""}`, () => {
-        cy.task("clearUsers")
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `${loggedInAs} username`,
-              visibleForces: ["01"],
-              forenames: `${loggedInAs}'s forename`,
-              surname: `${loggedInAs}surname`,
-              email: `${loggedInAs}@example.com`,
-              password: hashedPassword,
-              featureFlags: { exceptionsEnabled: true }
-            }
-          ],
-          userGroups: ["B7NewUI_grp", `B7${loggedInAs}_grp`]
-        })
-
         cy.task("clearCourtCases")
         cy.task("insertCourtCasesWithFields", [
           {
@@ -51,8 +35,7 @@ describe("Redirect when resolve triggers and exceptions", () => {
           cy.task("insertTriggers", { caseId: 0, triggers: caseTriggers })
         }
 
-        cy.login(`${loggedInAs}@example.com`, "password")
-        cy.visit("/bichard/court-cases/0")
+        loginAndVisit(loggedInAs, "/bichard/court-cases/0")
 
         if (resolveExceptions) {
           if (loggedInAs === "GeneralHandler") {

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/resolve-triggers.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/resolve-triggers.cy.ts
@@ -1,9 +1,7 @@
-import { ResolutionStatus } from "types/ResolutionStatus"
-import { UserGroup } from "types/UserGroup"
-import type { TestTrigger } from "../../../../test/utils/manageTriggers"
-import hashedPassword from "../../../fixtures/hashedPassword"
-import { newUserLogin } from "../../../support/helpers"
 import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
+import { ResolutionStatus } from "types/ResolutionStatus"
+import type { TestTrigger } from "../../../../test/utils/manageTriggers"
+import { loginAndVisit } from "../../../support/helpers"
 
 const caseURL = "/bichard/court-cases/0"
 
@@ -31,24 +29,10 @@ const mixedTriggers = [...resolvedTriggers, ...unresolvedTriggers]
 describe("Triggers and exceptions", () => {
   before(() => {
     cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
   })
 
   beforeEach(() => {
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
     cy.task("clearTriggers")
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
@@ -84,7 +68,7 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -104,7 +88,7 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -167,7 +151,7 @@ describe("Triggers and exceptions", () => {
       cy.task("insertCourtCasesWithFields", [
         {
           errorLockedByUsername: null,
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -182,8 +166,8 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "some.user",
-          errorLockedByUsername: "some.user",
+          triggerLockedByUsername: "BichardForce04",
+          errorLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -224,7 +208,7 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -237,16 +221,16 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
       cy.task("insertTriggers", { caseId: 0, triggers: unresolvedTriggers })
       cy.visit(caseURL)
-      cy.get("#header-container").should("contain.text", "Another User")
-      cy.get("#header-container").should("not.contain.text", "Bichard01")
-      cy.get("#triggers").should("contain.text", "Another User")
-      cy.get("#triggers").should("not.contain.text", "Bichard01")
+      cy.get("#header-container").should("contain.text", "Bichard Test User Force 04")
+      cy.get("#header-container").should("not.contain.text", "GeneralHandler")
+      cy.get("#triggers").should("contain.text", "Bichard Test User Force 04")
+      cy.get("#triggers").should("not.contain.text", "GeneralHandler")
     })
   })
 
@@ -300,7 +284,7 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "another.user",
+          triggerLockedByUsername: "BichardForce04",
           orgForPoliceFilter: "01"
         }
       ])
@@ -328,14 +312,13 @@ describe("Triggers and exceptions", () => {
       cy.task("clearCourtCases")
       cy.task("insertCourtCasesWithFields", [
         {
-          triggerLockedByUsername: "Bichard01",
+          triggerLockedByUsername: "GeneralHandler",
           orgForPoliceFilter: "01",
           errorStatus: "Resolved"
         }
       ])
       cy.task("insertTriggers", { caseId: 0, triggers: caseTriggers })
-      cy.login("bichard01@example.com", "password")
-      cy.visit(caseURL)
+      loginAndVisit(caseURL)
 
       cy.get(".trigger-header input[type='checkbox']").first().check()
       cy.get("#mark-triggers-complete-button").click()
@@ -378,10 +361,9 @@ describe("Triggers and exceptions", () => {
       cy.task("insertDummyCourtCasesWithTriggers", {
         caseTriggers,
         orgCode: "01",
-        triggersLockedByUsername: "Bichard01"
+        triggersLockedByUsername: "GeneralHandler"
       })
-      cy.login("bichard01@example.com", "password")
-      cy.visit(caseURL)
+      loginAndVisit(caseURL)
 
       cy.get("#select-all-triggers button").click()
       cy.get("#mark-triggers-complete-button").click()
@@ -406,13 +388,8 @@ describe("Triggers and exceptions tabs", () => {
     ])
   })
 
-  beforeEach(() => {
-    cy.task("clearUsers")
-  })
-
   it("should show neither triggers nor exceptions to a user with no groups", () => {
-    newUserLogin({})
-    cy.visit(caseURL)
+    loginAndVisit("NoGroups", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #triggers-tab").should("not.exist")
     cy.get(".triggers-and-exceptions-sidebar #triggers").should("not.exist")
@@ -422,8 +399,7 @@ describe("Triggers and exceptions tabs", () => {
   })
 
   it("should only show triggers to Trigger Handlers", () => {
-    newUserLogin({ groups: [UserGroup.TriggerHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("TriggerHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #triggers-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #triggers").should("exist")
@@ -434,8 +410,7 @@ describe("Triggers and exceptions tabs", () => {
   })
 
   it("should only show exceptions to Exception Handlers", () => {
-    newUserLogin({ groups: [UserGroup.ExceptionHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("ExceptionHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #triggers-tab").should("not.exist")
     cy.get(".triggers-and-exceptions-sidebar #triggers").should("not.exist")
@@ -447,8 +422,7 @@ describe("Triggers and exceptions tabs", () => {
 
   it("should show both trigger and exceptions to General Handlers with triggers tab selected", () => {
     cy.task("insertTriggers", { caseId: 0, triggers: mixedTriggers })
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #triggers-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #triggers").should("exist")
@@ -470,8 +444,7 @@ describe("Triggers and exceptions tabs", () => {
       }
     ])
 
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #triggers-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #triggers").should("exist")
@@ -489,10 +462,6 @@ describe("PNC Exceptions", () => {
     cy.task("clearCourtCases")
   })
 
-  beforeEach(() => {
-    cy.task("clearUsers")
-  })
-
   it("should render PNC exception and correctly display the PNC error message", () => {
     cy.task("insertCourtCaseWithPncException", {
       exceptions: {
@@ -506,8 +475,7 @@ describe("PNC Exceptions", () => {
       }
     })
 
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #exceptions-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #exceptions").should("exist")
@@ -532,8 +500,7 @@ describe("PNC Exceptions", () => {
       }
     })
 
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #exceptions-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #exceptions").should("exist")
@@ -556,8 +523,7 @@ describe("PNC Exceptions", () => {
       }
     })
 
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    cy.visit(caseURL)
+    loginAndVisit("GeneralHandler", caseURL)
 
     cy.get(".triggers-and-exceptions-sidebar #exceptions-tab").should("exist")
     cy.get(".triggers-and-exceptions-sidebar #exceptions").should("exist")

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/submit-exceptions.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/submit-exceptions.cy.ts
@@ -1,28 +1,12 @@
-import User from "services/entities/User"
 import AsnExceptionHO100206 from "../../../../test/test-data/AsnExceptionHo100206.json"
 import multipleExceptions from "../../../../test/test-data/MultipleExceptions.json"
 import nextHearingDateExceptions from "../../../../test/test-data/NextHearingDateExceptions.json"
 import nextHearingLocationExceptions from "../../../../test/test-data/NextHearingLocationExceptions.json"
-import hashedPassword from "../../../fixtures/hashedPassword"
 
 describe("Court cases - Submit exceptions", () => {
-  const users: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`00${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
   beforeEach(() => {
-    cy.clearCookies()
     cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7Supervisor_grp" })
+    cy.loginAs("GeneralHandler")
   })
 
   it("Should resubmit a case when edits are made and the submit button is clicked", () => {
@@ -31,11 +15,9 @@ describe("Court cases - Submit exceptions", () => {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
         errorCount: 1,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-
-    cy.login("bichard02@example.com", "password")
 
     cy.visit("/bichard/court-cases/0")
 
@@ -59,8 +41,8 @@ describe("Court cases - Submit exceptions", () => {
     })
 
     cy.contains("Notes").click()
-    cy.contains("Bichard02: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-12-12")
-    cy.contains("Bichard02: Portal Action: Resubmitted Message.")
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: nextHearingDate. New Value: 2024-12-12")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
   })
 
   it("Should not resubmit a case when no updates made on editable field", () => {
@@ -69,11 +51,9 @@ describe("Court cases - Submit exceptions", () => {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
         errorCount: 1,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-
-    cy.login("bichard02@example.com", "password")
 
     cy.visit("/bichard/court-cases/0")
 
@@ -86,11 +66,10 @@ describe("Court cases - Submit exceptions", () => {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
         errorCount: 1,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
 
-    cy.login("bichard02@example.com", "password")
     cy.visit("/bichard/court-cases/0")
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
@@ -133,7 +112,7 @@ describe("Court cases - Submit exceptions", () => {
     const insertCourtCase = (hearingOutcomeXml: string): void => {
       cy.task("insertCourtCasesWithFields", [
         {
-          orgForPoliceFilter: "02",
+          orgForPoliceFilter: "01",
           hearingOutcome: hearingOutcomeXml,
           errorCount: 1,
           errorLockedByUsername: null,
@@ -143,7 +122,7 @@ describe("Court cases - Submit exceptions", () => {
     }
     it("Should be disabled when multiple exceptions are raised and not all the editable fields are updated", () => {
       insertCourtCase(multipleExceptions.hearingOutcomeXml)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       insertNextHearingDate("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION")
@@ -165,7 +144,7 @@ describe("Court cases - Submit exceptions", () => {
 
     it("Should be enabled when multiple exceptions are raised and all the editable fields are updated", () => {
       insertCourtCase(multipleExceptions.hearingOutcomeXml)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       insertNextHearingDate("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION")
@@ -181,7 +160,7 @@ describe("Court cases - Submit exceptions", () => {
 
     it("Should be enabled when only next-hearing-date exception is raised and ASN editable field is not updated", () => {
       insertCourtCase(nextHearingDateExceptions.hearingOutcomeXmlHO100102)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       insertNextHearingDate("Offence with HO100102 - INCORRECTLY FORMATTED DATE EXCEPTION")
@@ -190,7 +169,7 @@ describe("Court cases - Submit exceptions", () => {
 
     it("Should be enabled when only next-hearing-location exception is raised and ASN editable field is not updated", () => {
       insertCourtCase(nextHearingLocationExceptions.hearingOutcomeXmlHO100200)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       insertNextHearingLocation("Offence with HO100200 - Unrecognised Force or Station Code")
@@ -199,7 +178,7 @@ describe("Court cases - Submit exceptions", () => {
 
     it("Should be disabled when ASN exception is raised and ASN editable field is not updated", () => {
       insertCourtCase(AsnExceptionHO100206.hearingOutcomeXml)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       cy.get("button").contains("Submit exception(s)").should("be.disabled")
@@ -207,7 +186,7 @@ describe("Court cases - Submit exceptions", () => {
 
     it("Should be disabled when ASN exception is not raised and ASN editable field is updated with invalid value", () => {
       insertCourtCase(AsnExceptionHO100206.hearingOutcomeXml)
-      cy.login("bichard02@example.com", "password")
+
       cy.visit("/bichard/court-cases/0")
 
       insertAsn("1101ZD010000044875")

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/view-exception-handler-prompt.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/view-exception-handler-prompt.cy.ts
@@ -4,8 +4,7 @@ import HO100307 from "../../../../test/test-data/HO100307.json"
 import HO100309 from "../../../../test/test-data/HO100309.json"
 import HO200113 from "../../../../test/test-data/HO200113.json"
 import HO200114 from "../../../../test/test-data/HO200114.json"
-
-import hashedPassword from "../../../fixtures/hashedPassword"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("View Exception Handler Prompts", () => {
   const caseWithOffenceQualifierError = 0
@@ -14,22 +13,6 @@ describe("View Exception Handler Prompts", () => {
   const caseWithCJSCodeError = 3
 
   before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
@@ -62,8 +45,7 @@ describe("View Exception Handler Prompts", () => {
 
   context("Result Code Qualifier not found - HO100309", () => {
     it("Should display no error prompt if a HO100309 is not raised", () => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithNoError}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithNoError}`)
 
       cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
       cy.get(".govuk-link").contains("Attempt to rape a girl aged 13 / 14 / 15 years of age - SOA 2003").click()
@@ -71,8 +53,7 @@ describe("View Exception Handler Prompts", () => {
     })
 
     it("Should display an error prompt when a HO100309 is raised", () => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithOffenceQualifierError}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithOffenceQualifierError}`)
 
       cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
       cy.get(".govuk-link").contains("Aid and abet theft").click()
@@ -88,8 +69,7 @@ describe("View Exception Handler Prompts", () => {
     })
 
     it("Should not display any error prompts when exceptions are marked as manually resolved", () => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithOffenceQualifierError}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithOffenceQualifierError}`)
 
       cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
       cy.get(".govuk-link").contains("Aid and abet theft").click()
@@ -112,8 +92,7 @@ describe("View Exception Handler Prompts", () => {
 
   context("Offence code error prompts for OffenceCode errors", () => {
     beforeEach(() => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithOffenceCodeErrors}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithOffenceCodeErrors}`)
     })
 
     it("Should display no error prompt if HO100306 or HO100251 are not raised", () => {
@@ -197,8 +176,7 @@ describe("View Exception Handler Prompts", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get(".Defendant-details-table").contains("1101ZD0100000448754K")
       cy.get(".error-prompt-message").should("not.exist")
@@ -214,8 +192,7 @@ describe("View Exception Handler Prompts", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get(".field-value").contains("2300000000000942133G")
       cy.get(".error-prompt").contains(ErrorMessages.HO200113)
@@ -230,8 +207,7 @@ describe("View Exception Handler Prompts", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get(".Defendant-details-table").contains("1101ZD0100000448754K")
       cy.get(".error-prompt-message").should("not.exist")
@@ -247,8 +223,7 @@ describe("View Exception Handler Prompts", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard/court-cases/0")
+      loginAndVisit("/bichard/court-cases/0")
 
       cy.get(".field-value").contains("2300000000000532316D")
       cy.get(".error-prompt").contains(ErrorMessages.HO200114)
@@ -256,8 +231,7 @@ describe("View Exception Handler Prompts", () => {
   })
   context("CJS Code Prompt", () => {
     it("Should display an error prompt when a HO100307 is raised", () => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithCJSCodeError}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithCJSCodeError}`)
       cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
       cy.get(".govuk-link")
         .contains("Use a motor vehicle on a road / public place without third party insurance")
@@ -272,8 +246,7 @@ describe("View Exception Handler Prompts", () => {
     })
 
     it("Should not display an error prompt when a HO100307 is not raised", () => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit(`/bichard/court-cases/${caseWithNoError}`)
+      loginAndVisit(`/bichard/court-cases/${caseWithNoError}`)
       cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
       cy.get(".govuk-link")
         .contains("Use a motor vehicle on a road / public place without third party insurance")

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/view-offence-matching-exception-prompt.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/view-offence-matching-exception-prompt.cy.ts
@@ -1,38 +1,22 @@
 import ExceptionHO100304 from "../../../../test/test-data/HO100304.json"
 import NextHearingDateExceptions from "../../../../test/test-data/NextHearingDateExceptions.json"
-import hashedPassword from "../../../fixtures/hashedPassword"
 
 describe("View offence matching exception prompts", () => {
   before(() => {
     cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["001"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
+    cy.loginAs("GeneralHandler")
   })
 
   it("Should not display an error prompt when HO100304 is not raised", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
         hearingOutcome: NextHearingDateExceptions.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
     cy.visit(`/bichard/court-cases/0`)
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()
@@ -43,17 +27,15 @@ describe("View offence matching exception prompts", () => {
 
   // TODO: re-enable this for offence matching
   it.skip("Should display an error prompt when HO100304 is raised", () => {
-    cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
         orgForPoliceFilter: "01",
         hearingOutcome: ExceptionHO100304.hearingOutcomeXml,
         errorCount: 1,
-        errorLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler"
       }
     ])
 
-    cy.login("bichard01@example.com", "password")
     cy.visit(`/bichard/court-cases/0`)
 
     cy.get("ul.moj-sub-navigation__list").contains("Offences").click()

--- a/cypress/e2e/case-details/lock-cases.cy.ts
+++ b/cypress/e2e/case-details/lock-cases.cy.ts
@@ -1,30 +1,6 @@
-import User from "services/entities/User"
-import hashedPassword from "../../fixtures/hashedPassword"
-import { UserGroup } from "types/UserGroup"
-import { newUserLogin } from "../../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 describe("Lock court cases", () => {
-  const users: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`0${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7TriggerHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7ExceptionHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard03@example.com", groupName: "B7Supervisor_grp" })
-    cy.clearCookies()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -34,14 +10,13 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         triggerCount: 1
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.contains("a", "NAME Defendant").click()
 
@@ -53,26 +28,25 @@ describe("Lock court cases", () => {
   })
 
   it("should not lock a case that is already locked to another user", () => {
-    const existingUserLock = "Another.name"
+    const existingUserLock = "BichardForce04"
     cy.task("insertCourtCasesWithFields", [
       {
         errorLockedByUsername: existingUserLock,
         triggerLockedByUsername: existingUserLock,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         triggerCount: 1
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get(".view-only-badge").should("exist")
     cy.get("#triggers-locked-tag").should("exist")
-    cy.get("#triggers-locked-tag-lockee").should("contain.text", "Another Name")
+    cy.get("#triggers-locked-tag-lockee").should("contain.text", "Bichard Test User Force 04")
     cy.get("#exceptions-locked-tag").should("exist")
-    cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Another Name")
+    cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Bichard Test User Force 04")
   })
 
   it("should not lock exceptions when a trigger handler clicks into a case", () => {
@@ -84,8 +58,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    newUserLogin({ user: "trigger-handler-user", groups: [UserGroup.TriggerHandler] })
-
+    loginAndVisit("TriggerHandler")
     cy.visit("/bichard")
     cy.findByText("NAME Defendant").click()
 
@@ -97,7 +70,7 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         errorStatus: "Unresolved",
         triggerCount: 1,
@@ -105,8 +78,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get("#triggers-resolved-tag").should("exist").should("contain.text", "Resolved")
@@ -120,7 +92,7 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         errorStatus: "Resolved",
         triggerCount: 1,
@@ -128,8 +100,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get("#exceptions-resolved-tag").should("exist").should("contain.text", "Resolved")
@@ -143,7 +114,7 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         errorStatus: "Submitted",
         triggerCount: 1,
@@ -151,8 +122,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get("#exceptions-submitted-tag").should("exist").should("contain.text", "Submitted")
@@ -166,7 +136,7 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         errorStatus: "Submitted",
         triggerCount: 1,
@@ -174,8 +144,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get("#exceptions-submitted-tag").should("exist").should("contain.text", "Submitted")
@@ -189,7 +158,7 @@ describe("Lock court cases", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "03",
+        orgForPoliceFilter: "01",
         errorCount: 1,
         errorStatus: "Resolved",
         triggerCount: 1,
@@ -197,8 +166,7 @@ describe("Lock court cases", () => {
       }
     ])
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit()
     cy.findByText("NAME Defendant").click()
 
     cy.get("#exceptions-resolved-tag").should("exist").should("contain.text", "Resolved")

--- a/cypress/e2e/case-details/reallocate-case.cy.ts
+++ b/cypress/e2e/case-details/reallocate-case.cy.ts
@@ -1,26 +1,8 @@
-import User from "services/entities/User"
 import { TestTrigger } from "../../../test/utils/manageTriggers"
 import canReallocateTestData from "../../fixtures/canReallocateTestData.json"
-import hashedPassword from "../../fixtures/hashedPassword"
-import { clickTab } from "../../support/helpers"
+import { clickTab, loginAndVisit } from "../../support/helpers"
 
 describe("Case details", () => {
-  const defaultUsers: Partial<User>[] = Array.from(Array(4)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`0${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users: defaultUsers, userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"] })
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -37,9 +19,7 @@ describe("Case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.findByText("NAME Defendant").click()
 
@@ -56,8 +36,7 @@ describe("Case details", () => {
     cy.get("H1").should("have.text", "Case list")
     cy.contains("NAME Defendant").should("not.exist")
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit("BichardForce03")
     cy.findByText("NAME Defendant").click()
 
     clickTab("Notes")
@@ -65,9 +44,9 @@ describe("Case details", () => {
     cy.get("table tbody tr:visible").should("have.length", 3)
     cy.get("table tbody tr:visible").should(
       "contain",
-      "Bichard01: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
+      "GeneralHandler: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
     )
-    cy.get("table tbody tr:visible").should("contain", "Bichard01: Case reallocated to new force owner: 03YZ00")
+    cy.get("table tbody tr:visible").should("contain", "GeneralHandler: Case reallocated to new force owner: 03YZ00")
     cy.get("table tbody tr:visible").should("contain", "This is a dummy note")
   })
 
@@ -83,9 +62,7 @@ describe("Case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.findByText("NAME Defendant").click()
 
@@ -100,8 +77,7 @@ describe("Case details", () => {
     cy.get("H1").should("have.text", "Case list")
     cy.contains("NAME Defendant").should("not.exist")
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit("BichardForce03")
     cy.findByText("NAME Defendant").click()
 
     clickTab("Notes")
@@ -109,9 +85,9 @@ describe("Case details", () => {
     cy.get("table tbody tr:visible").should("have.length", 2)
     cy.get("table tbody tr:visible").should(
       "contain",
-      "Bichard01: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
+      "GeneralHandler: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
     )
-    cy.get("table tbody tr:visible").should("contain", "Bichard01: Case reallocated to new force owner: 03YZ00")
+    cy.get("table tbody tr:visible").should("contain", "GeneralHandler: Case reallocated to new force owner: 03YZ00")
   })
 
   it("Should not accept more than 2000 characters in note text field", () => {
@@ -126,9 +102,7 @@ describe("Case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard")
+    loginAndVisit()
 
     cy.findByText("NAME Defendant").click()
 
@@ -148,8 +122,7 @@ describe("Case details", () => {
     cy.get("H1").should("have.text", "Case list")
     cy.contains("NAME Defendant").should("not.exist")
 
-    cy.login("bichard03@example.com", "password")
-    cy.visit("/bichard")
+    loginAndVisit("BichardForce03")
     cy.findByText("NAME Defendant").click()
 
     clickTab("Notes")
@@ -157,16 +130,16 @@ describe("Case details", () => {
     cy.get("table tbody tr:visible").should("have.length", 3)
     cy.get("table tbody tr:visible").should(
       "contain",
-      "Bichard01: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
+      "GeneralHandler: Portal Action: Update Applied. Element: forceOwner. New Value: 03"
     )
-    cy.get("table tbody tr:visible").should("contain", "Bichard01: Case reallocated to new force owner: 03YZ00")
+    cy.get("table tbody tr:visible").should("contain", "GeneralHandler: Case reallocated to new force owner: 03YZ00")
     cy.get("table tbody tr:visible").should("not.contain", "a".repeat(2001))
     cy.get("table tbody tr:visible").should("contain", "a".repeat(1010))
   })
 
   it("Should return 404 for a case that this user can not see", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "02" }])
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,
@@ -177,7 +150,7 @@ describe("Case details", () => {
   })
 
   it("Should return 404 for a case that does not exist", () => {
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,
@@ -199,13 +172,12 @@ describe("Case details", () => {
             orgForPoliceFilter: "01",
             triggerStatus: triggers,
             errorStatus: exceptions,
-            triggersLockedByAnotherUser: triggersLockedByAnotherUser ? "Bichard03" : null,
-            errorLockedByUsername: exceptionLockedByAnotherUser ? "Bichard03" : null
+            triggersLockedByAnotherUser: triggersLockedByAnotherUser ? "BichardForce03" : null,
+            errorLockedByUsername: exceptionLockedByAnotherUser ? "BichardForce03" : null
           }
         ])
 
-        cy.login("bichard01@example.com", "password")
-        cy.visit("/bichard/court-cases/0")
+        loginAndVisit("/bichard/court-cases/0")
 
         cy.get("button.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
 
@@ -233,9 +205,8 @@ describe("Case details", () => {
       }
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
-    cy.login("bichard01@example.com", "password")
 
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".govuk-tag:visible")
       .contains(
@@ -272,8 +243,7 @@ describe("Case details", () => {
       force: "01"
     })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     cy.get("button").contains("Reallocate Case").click()
 
     cy.contains("Another User2")
@@ -296,8 +266,7 @@ describe("Case details", () => {
       force: "01"
     })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     cy.get("button").contains("Reallocate Case").click()
 
     cy.contains("Another User")
@@ -322,8 +291,7 @@ describe("Case details", () => {
       force: "01"
     })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     cy.get("button").contains("Reallocate Case").click()
 
     cy.contains("Another User2")
@@ -350,8 +318,7 @@ describe("Case details", () => {
       force: "01"
     })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     cy.get("button").contains("Reallocate Case").click()
     cy.get("button").contains("show more").click()
 

--- a/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-case-details.cy.ts
@@ -1,36 +1,14 @@
-import User from "services/entities/User"
 import DummyMultipleOffencesNoErrorAho from "../../../../test/test-data/AnnotatedHO1.json"
 import DummyHO100200Aho from "../../../../test/test-data/HO100200_1.json"
 import DummyHO100302Aho from "../../../../test/test-data/HO100302_1.json"
 import dummyMultipleHearingResultsAho from "../../../../test/test-data/multipleHearingResultsOnOffence.json"
 import type { TestTrigger } from "../../../../test/utils/manageTriggers"
 import canReallocateTestData from "../../../fixtures/canReallocateTestData.json"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import a11yConfig from "../../../support/a11yConfig"
-import { clickTab, loginAndGoToUrl } from "../../../support/helpers"
+import { clickTab, loginAndVisit } from "../../../support/helpers"
 import logAccessibilityViolations from "../../../support/logAccessibilityViolations"
 
 describe("View case details", () => {
-  const users: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`00${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7GeneralHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7Supervisor_grp" })
-    cy.clearCookies()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -46,9 +24,8 @@ describe("View case details", () => {
       }
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
-    cy.login("bichard01@example.com", "password")
 
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.injectAxe()
 
@@ -60,7 +37,7 @@ describe("View case details", () => {
 
   it("Should return 404 for a case that this user can not see", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "02" }])
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,
@@ -71,7 +48,7 @@ describe("View case details", () => {
   })
 
   it("Should return 404 for a case that does not exist", () => {
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
 
     cy.request({
       failOnStatusCode: false,
@@ -87,7 +64,7 @@ describe("View case details", () => {
         orgForPoliceFilter: "01"
       }
     ])
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
     cy.request({
       failOnStatusCode: false,
       url: "/bichard/court-cases/0"
@@ -111,9 +88,7 @@ describe("View case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.contains("Case00000")
     cy.contains("Magistrates' Courts Essex Basildon")
@@ -124,11 +99,10 @@ describe("View case details", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Defendant")
     cy.get("H3").contains("Defendant details")
@@ -150,8 +124,7 @@ describe("View case details", () => {
         orgForPoliceFilter: "01"
       }
     ])
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Defendant")
     cy.contains("td", "ASN").siblings().contains("1101ZD0100000448754K")
@@ -189,11 +162,11 @@ describe("View case details", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Case")
     const expectedRows = [
@@ -215,11 +188,11 @@ describe("View case details", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+
+    loginAndVisit("/bichard/court-cases/0")
 
     clickTab("Hearing")
     cy.contains("td", "Court location").siblings().contains("B01EF01")
@@ -241,10 +214,10 @@ describe("View case details", () => {
       {
         errorLockedByUsername: null,
         triggerLockedByUsername: null,
-        orgForPoliceFilter: "02"
+        orgForPoliceFilter: "01"
       }
     ])
-    loginAndGoToUrl("bichard02@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     clickTab("Offences")
 
     cy.contains("tbody tr:nth-child(1) td:nth-child(2)", "1")
@@ -390,7 +363,7 @@ describe("View case details", () => {
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     clickTab("Offences")
     cy.get("tbody tr:nth-child(1) td:nth-child(5) a").click()
 
@@ -406,7 +379,7 @@ describe("View case details", () => {
       }
     ])
 
-    loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
     clickTab("Offences")
     cy.get("tbody tr:nth-child(1) td:nth-child(5) a").click()
 
@@ -433,9 +406,7 @@ describe("View case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-tab-panel-triggers").should("be.visible")
     cy.get(".moj-tab-panel-exceptions").should("not.be.visible")
@@ -454,8 +425,7 @@ describe("View case details", () => {
   it("Should display a message when case has no triggers", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-tab-panel-triggers").should("not.be.visible")
     cy.get(".moj-tab-panel-exceptions").should("be.visible")
@@ -477,9 +447,8 @@ describe("View case details", () => {
       }
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
-    cy.login("bichard01@example.com", "password")
 
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".moj-tab-panel-triggers").should("be.visible")
     cy.get(".moj-tab-panel-exceptions").should("not.be.visible")
@@ -498,9 +467,7 @@ describe("View case details", () => {
       { orgForPoliceFilter: "01", hearingOutcome: DummyMultipleOffencesNoErrorAho.hearingOutcomeXml }
     ])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
 
@@ -531,9 +498,7 @@ describe("View case details", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Offence 1 of 3")
     cy.get(".moj-tab-panel-triggers .trigger-header button").eq(0).contains("Offence 1").click()
@@ -545,9 +510,7 @@ describe("View case details", () => {
   it("Should take the user to offence tab when exception is clicked", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Offence 1 of 3")
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
@@ -559,9 +522,7 @@ describe("View case details", () => {
   it("Should be able to refresh after I click 'Back to all offences'", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Offence 1 of 3")
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
@@ -578,9 +539,7 @@ describe("View case details", () => {
       { orgForPoliceFilter: "01", hearingOutcome: DummyHO100200Aho.hearingOutcomeXml }
     ])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Case")
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
@@ -599,8 +558,7 @@ describe("View case details", () => {
     }
     cy.task("insertTriggers", { caseId: 0, triggers: [trigger] })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get(".triggers-help-preview").should("have.text", "More information")
     cy.get(".triggers-help-preview").click()
@@ -634,9 +592,7 @@ describe("View case details", () => {
       { orgForPoliceFilter: "01", hearingOutcome: DummyHO100200Aho.hearingOutcomeXml }
     ])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Case")
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
@@ -651,9 +607,7 @@ describe("View case details", () => {
       { orgForPoliceFilter: "01", hearingOutcome: DummyHO100302Aho.hearingOutcomeXml }
     ])
 
-    cy.login("bichard01@example.com", "password")
-
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("h3").should("not.have.text", "Case")
     cy.get(".triggers-and-exceptions-sidebar a").contains("Exceptions").click()
@@ -673,12 +627,11 @@ describe("View case details", () => {
       status: "Resolved",
       createdAt: new Date(),
       resolvedAt: new Date(),
-      resolvedBy: "Bichard01"
+      resolvedBy: "BichardForce01"
     }
     cy.task("insertTriggers", { caseId: 0, triggers: [trigger] })
 
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.get("#triggers span").contains("Complete").should("exist")
   })
@@ -695,13 +648,12 @@ describe("View case details", () => {
             orgForPoliceFilter: "01",
             triggerStatus: triggers,
             errorStatus: exceptions,
-            triggersLockedByAnotherUser: triggersLockedByAnotherUser ? "Bichard03" : null,
-            errorLockedByUsername: exceptionLockedByAnotherUser ? "Bichard03" : null
+            triggersLockedByAnotherUser: triggersLockedByAnotherUser ? "BichardForce03" : null,
+            errorLockedByUsername: exceptionLockedByAnotherUser ? "BichardForce03" : null
           }
         ])
 
-        cy.login("bichard01@example.com", "password")
-        cy.visit("/bichard/court-cases/0")
+        loginAndVisit("/bichard/court-cases/0")
 
         cy.get("button.b7-reallocate-button").should(canReallocate ? "exist" : "not.exist")
       })

--- a/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-headers.cy.ts
@@ -1,39 +1,15 @@
-import User from "../../../../src/services/entities/User"
-import hashedPassword from "../../../fixtures/hashedPassword"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("View court case details header", () => {
-  const users: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`0${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7TriggerHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7Supervisor_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard03@example.com", groupName: "B7ExceptionHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard04@example.com", groupName: "B7GeneralHandler_grp" })
-    cy.clearCookies()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
 
   it("should have a leave and lock button that returns to the case list when the case is locked", () => {
-    const user = users[1]
     cy.task("insertCourtCasesWithFields", [
       {
-        triggerLockedByUsername: user.username,
-        orgForPoliceFilter: user.visibleForces![0]
+        triggerLockedByUsername: "TriggerHandler",
+        orgForPoliceFilter: "01"
       }
     ])
     cy.task("insertTriggers", {
@@ -48,9 +24,8 @@ describe("View court case details header", () => {
       ]
     })
 
-    cy.login(user.email!, "password")
-    cy.visit("/bichard")
-    cy.get(".locked-by-tag").should("have.text", "Bichard Test User 01")
+    loginAndVisit("TriggerHandler")
+    cy.get(".locked-by-tag").should("have.text", "Trigger Handler User")
     cy.get("td a").contains("NAME Defendant").click()
     cy.location("pathname").should("equal", "/bichard/court-cases/0")
 
@@ -60,22 +35,18 @@ describe("View court case details header", () => {
       .should("have.attr", "href", "/bichard")
     cy.get("button#leave-and-lock").click()
     cy.location("pathname").should("equal", "/bichard")
-    cy.get(".locked-by-tag").should("have.text", "Bichard Test User 01")
+    cy.get(".locked-by-tag").should("have.text", "Trigger Handler User")
   })
 
   it("should have a return to case list button that returns to the case list when the case isn't locked", () => {
-    const user = users[1]
-    const otherUser = users[2]
-    const caseURL = "/bichard/court-cases/0"
     cy.task("insertCourtCasesWithFields", [
       {
-        triggerLockedByUsername: otherUser.username,
-        orgForPoliceFilter: user.visibleForces![0]
+        triggerLockedByUsername: "Supervisor",
+        orgForPoliceFilter: "01"
       }
     ])
 
-    cy.login(user.email!, "password")
-    cy.visit(caseURL)
+    loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
     cy.get("button#leave-and-lock").should("not.exist")
     cy.get("button#leave-and-unlock").should("not.exist")
@@ -85,11 +56,10 @@ describe("View court case details header", () => {
   })
 
   it("should have a leave and unlock button that unlocks the triggers when you have the triggers locked", () => {
-    const user = users[1]
     cy.task("insertCourtCasesWithFields", [
       {
-        triggerLockedByUsername: user.username,
-        orgForPoliceFilter: user.visibleForces![0]
+        triggerLockedByUsername: "TriggerHandler",
+        orgForPoliceFilter: "01"
       }
     ])
     cy.task("insertTriggers", {
@@ -104,10 +74,8 @@ describe("View court case details header", () => {
       ]
     })
 
-    cy.login(user.email!, "password")
-
-    cy.visit("/bichard")
-    cy.get(".locked-by-tag").should("have.text", "Bichard Test User 01")
+    loginAndVisit("TriggerHandler")
+    cy.get(".locked-by-tag").should("have.text", "Trigger Handler User")
     cy.get("td a").contains("NAME Defendant").click()
     cy.location("pathname").should("equal", "/bichard/court-cases/0")
 
@@ -124,12 +92,11 @@ describe("View court case details header", () => {
   })
 
   it("should have a leave and unlock button that unlocks both triggers and exceptions when both triggers and exceptions are locked", () => {
-    const user = users[4]
     cy.task("insertCourtCasesWithFields", [
       {
-        triggerLockedByUsername: user.username,
-        errorLockedByUsername: user.username,
-        orgForPoliceFilter: user.visibleForces![0]
+        triggerLockedByUsername: "GeneralHandler",
+        errorLockedByUsername: "GeneralHandler",
+        orgForPoliceFilter: "01"
       }
     ])
     cy.task("insertTriggers", {
@@ -144,10 +111,8 @@ describe("View court case details header", () => {
       ]
     })
 
-    cy.login(user.email!, "password")
-
-    cy.visit("/bichard")
-    cy.get(".locked-by-tag").filter(':contains("Bichard Test User 04")').should("have.length", 2)
+    loginAndVisit()
+    cy.get(".locked-by-tag").filter(':contains("General Handler User")').should("have.length", 2)
     cy.get("td a").contains("NAME Defendant").click()
     cy.location("pathname").should("equal", "/bichard/court-cases/0")
 
@@ -165,72 +130,58 @@ describe("View court case details header", () => {
 
   describe("View only badge", () => {
     it("Should show a view only badge on a case that someone else has locked", () => {
-      const caseURL = "/bichard/court-cases/0"
-      const user = users[1]
-      const otherUser = users[2]
       cy.task("insertCourtCasesWithFields", [
         {
-          errorLockedByUsername: otherUser.username,
-          triggerLockedByUsername: otherUser.username,
+          errorLockedByUsername: "Supervisor",
+          triggerLockedByUsername: "Supervisor",
           isUrgent: false,
-          orgForPoliceFilter: user.visibleForces![0]
+          orgForPoliceFilter: "01"
         }
       ])
 
-      cy.login(user.email!, "password")
-      cy.visit(caseURL)
+      loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
       cy.get(".view-only-badge").contains("View only").should("exist").should("be.visible")
     })
 
     it("Should not show a view only badge on a case where we have both locks", () => {
-      const caseURL = "/bichard/court-cases/0"
-      const user = users[1]
       cy.task("insertCourtCasesWithFields", [
         {
-          errorLockedByUsername: user.username,
-          triggerLockedByUsername: user.username,
+          errorLockedByUsername: "TriggerHandler",
+          triggerLockedByUsername: "TriggerHandler",
           isUrgent: false,
-          orgForPoliceFilter: user.visibleForces![0]
+          orgForPoliceFilter: "01"
         }
       ])
 
-      cy.login(user.email!, "password")
-      cy.visit(caseURL)
+      loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
       cy.get(".view-only-badge").should("not.exist")
     })
 
     it("Should not show a view only badge on a case where we have one lock and nobody holds the other lock", () => {
-      const caseURL = "/bichard/court-cases/0"
-      const user = users[1]
       cy.task("insertCourtCasesWithFields", [
         {
           errorLockedByUsername: null,
-          triggerLockedByUsername: user.username,
+          triggerLockedByUsername: "TriggerHandler",
           isUrgent: false,
-          orgForPoliceFilter: user.visibleForces![0]
+          orgForPoliceFilter: "01"
         }
       ])
 
-      cy.login(user.email!, "password")
-      cy.visit(caseURL)
+      loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
       cy.get(".view-only-badge").should("not.exist")
     })
 
     it("Should not show a view only badge on a case where we have one lock and somebody else holds the other lock", () => {
-      const caseURL = "/bichard/court-cases/0"
-      const user = users[1]
-      const otherUser = users[2]
       cy.task("insertCourtCasesWithFields", [
         {
-          errorLockedByUsername: otherUser.username,
-          triggerLockedByUsername: user.username,
+          errorLockedByUsername: "Supervisor",
+          triggerLockedByUsername: "TriggerHandler",
           isUrgent: false,
-          orgForPoliceFilter: user.visibleForces![0]
+          orgForPoliceFilter: "01"
         }
       ])
 
-      cy.login(user.email!, "password")
-      cy.visit(caseURL)
+      loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
       cy.get(".view-only-badge").should("not.exist")
     })
   })
@@ -238,19 +189,15 @@ describe("View court case details header", () => {
   describe("Case locks", () => {
     describe("General handler and supervisor view", () => {
       it("When we have both locks, it shows both lock components as locked to us", () => {
-        const user = users[4]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            errorLockedByUsername: user.username,
-            triggerLockedByUsername: user.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            errorLockedByUsername: "GeneralHandler",
+            triggerLockedByUsername: "GeneralHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
-
+        loginAndVisit("GeneralHandler", "/bichard/court-cases/0")
         cy.get("#exceptions-locked-tag").should("exist")
         cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Locked to you")
         cy.get("#triggers-locked-tag").should("exist")
@@ -258,63 +205,52 @@ describe("View court case details header", () => {
       })
 
       it("When we have one lock and someone else has the other, it shows both lock components correctly", () => {
-        const user = users[4]
-        const otherUser = users[1]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            errorLockedByUsername: user.username,
-            triggerLockedByUsername: otherUser.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            errorLockedByUsername: "GeneralHandler",
+            triggerLockedByUsername: "TriggerHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("GeneralHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("exist")
         cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Locked to you")
 
         cy.get("#triggers-locked-tag").should("exist")
-        cy.get("#triggers-locked-tag-lockee").should("contain.text", "Bichard Test User 01")
+        cy.get("#triggers-locked-tag-lockee").should("contain.text", "Trigger Handler User")
       })
 
       it("When someone else has both locks, it shows both lock components correctly", () => {
-        const user = users[4]
-        const otherUser = users[1]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            errorLockedByUsername: otherUser.username,
-            triggerLockedByUsername: otherUser.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            errorLockedByUsername: "TriggerHandler",
+            triggerLockedByUsername: "TriggerHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("GeneralHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("exist")
-        cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Bichard Test User 01")
+        cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Trigger Handler User")
 
         cy.get("#triggers-locked-tag").should("exist")
-        cy.get("#triggers-locked-tag-lockee").should("contain.text", "Bichard Test User 01")
+        cy.get("#triggers-locked-tag-lockee").should("contain.text", "Trigger Handler User")
       })
     })
 
     describe("Trigger handler view", () => {
       it("When we have the triggers locked, it shows only the trigger lock", () => {
-        const user = users[1]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            triggerLockedByUsername: user.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            triggerLockedByUsername: "TriggerHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("not.exist")
         cy.get("#triggers-locked-tag").should("exist")
@@ -322,38 +258,31 @@ describe("View court case details header", () => {
       })
 
       it("When somebody else has the triggers locked, it shows only the trigger lock", () => {
-        const user = users[1]
-        const otherUser = users[4]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            triggerLockedByUsername: otherUser.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            triggerLockedByUsername: "GeneralHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("TriggerHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("not.exist")
         cy.get("#triggers-locked-tag").should("exist")
-        cy.get("#triggers-locked-tag-lockee").should("contain.text", "Bichard Test User 04")
+        cy.get("#triggers-locked-tag-lockee").should("contain.text", "General Handler User")
       })
     })
 
     describe("Exception handler view", () => {
       it("When we have the exceptions locked, it shows only the exception lock", () => {
-        const user = users[3]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            errorLockedByUsername: user.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            errorLockedByUsername: "ExceptionHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("ExceptionHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("exist")
         cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Locked to you")
@@ -361,21 +290,17 @@ describe("View court case details header", () => {
       })
 
       it("When somebody else has the exceptions locked, it shows only the exception lock", () => {
-        const user = users[3]
-        const otherUser = users[4]
-        const caseURL = "/bichard/court-cases/0"
         cy.task("insertCourtCasesWithFields", [
           {
-            errorLockedByUsername: otherUser.username,
-            orgForPoliceFilter: user.visibleForces![0]
+            errorLockedByUsername: "GeneralHandler",
+            orgForPoliceFilter: "01"
           }
         ])
 
-        cy.login(user.email!, "password")
-        cy.visit(caseURL)
+        loginAndVisit("ExceptionHandler", "/bichard/court-cases/0")
 
         cy.get("#exceptions-locked-tag").should("exist")
-        cy.get("#exceptions-locked-tag-lockee").should("contain.text", "Bichard Test User 04")
+        cy.get("#exceptions-locked-tag-lockee").should("contain.text", "General Handler User")
         cy.get("#triggers-locked-tag").should("not.exist")
       })
     })

--- a/cypress/e2e/case-details/view-case-details/view-notes.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-notes.cy.ts
@@ -1,13 +1,11 @@
-import User from "services/entities/User"
 import CourtCase from "../../../../src/services/entities/CourtCase"
 import type { TestTrigger } from "../../../../test/utils/manageTriggers"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import a11yConfig from "../../../support/a11yConfig"
-import { clickTab, loginAndGoToUrl } from "../../../support/helpers"
+import { clickTab, loginAndVisit } from "../../../support/helpers"
 import logAccessibilityViolations from "../../../support/logAccessibilityViolations"
 
 const loginAndGoToNotes = () => {
-  loginAndGoToUrl("bichard01@example.com", "/bichard/court-cases/0")
+  loginAndVisit("/bichard/court-cases/0")
   cy.contains("Notes").click()
 }
 
@@ -35,27 +33,6 @@ const insertCaseWithTriggerAndException = (courtCase?: Partial<CourtCase>) => {
 }
 
 describe("View notes", () => {
-  const users: Partial<User>[] = Array.from(Array(3)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`0${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7GeneralHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7Supervisor_grp" })
-    cy.clearCookies()
-    cy.viewport(1800, 720)
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -76,24 +53,16 @@ describe("View notes", () => {
     cy.task("insertCourtCasesWithNotes", {
       caseNotes: [
         [
-          {
-            user: "another.user",
-            text: "Test note 1"
-          },
-          {
-            user: "System",
-            text: "Test note 2"
-          }
+          { user: "GeneralHandler", text: "Test note 1" },
+          { user: "System", text: "Test note 2" }
         ]
       ],
-      force: "02"
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
 
-    cy.contains("Another User")
+    cy.contains("General Handler User")
     cy.contains("Test note 1")
     cy.contains("System")
     cy.contains("Test note 2")
@@ -103,25 +72,17 @@ describe("View notes", () => {
     cy.task("insertCourtCasesWithNotes", {
       caseNotes: [
         [
-          {
-            user: "another.user",
-            text: "Test note 1"
-          },
-          {
-            user: "System",
-            text: "Test note 2"
-          }
+          { user: "GeneralHandler", text: "Test note 1" },
+          { user: "System", text: "Test note 2" }
         ]
       ],
-      force: "02"
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
 
     cy.findByText("View system notes").click()
-    cy.should("not.contain", "bichard01")
+    cy.should("not.contain", "General Handler User")
     cy.should("not.contain", "Test note 1")
     cy.contains("System")
     cy.contains("Test note 2")
@@ -129,26 +90,17 @@ describe("View notes", () => {
     cy.findByText("View user notes").click()
     cy.should("not.contain", "System")
     cy.should("not.contain", "Test note 2")
-    cy.contains("Another User")
+    cy.contains("General Handler User")
     cy.contains("Test note 1")
   })
 
   it("Should display no user notes message", () => {
     cy.task("insertCourtCasesWithNotes", {
-      caseNotes: [
-        [
-          {
-            user: "System",
-            text: "Test note 2"
-          }
-        ]
-      ],
-      force: "02"
+      caseNotes: [[{ user: "System", text: "Test note 2" }]],
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
     cy.findByText("View user notes").click()
 
     cy.should("not.contain", "System")
@@ -158,23 +110,14 @@ describe("View notes", () => {
 
   it("Should display no system notes message", () => {
     cy.task("insertCourtCasesWithNotes", {
-      caseNotes: [
-        [
-          {
-            user: "bichard01",
-            text: "Test note 1"
-          }
-        ]
-      ],
-      force: "02"
+      caseNotes: [[{ user: "GeneralHandler", text: "Test note 1" }]],
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
     cy.findByText("View system notes").click()
 
-    cy.should("not.contain", "bichard01")
+    cy.should("not.contain", "General Handler User")
     cy.should("not.contain", "Test note 1")
     cy.contains("Case has no system notes.")
   })
@@ -182,24 +125,20 @@ describe("View notes", () => {
   it("Should display no notes message", () => {
     cy.task("insertCourtCasesWithNotes", {
       caseNotes: [[]],
-      force: "02"
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
     cy.contains("Case has no notes.")
   })
 
   it("Should not display the notes text area if the case is locked to another users", () => {
     cy.task("insertCourtCasesWithNotesAndLock", {
       caseNotes: [[]],
-      force: "02"
+      force: "01"
     })
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
 
-    clickTab("Notes")
+    loginAndGoToNotes()
     cy.contains("Case has no notes.")
     cy.get("#note-text").should("not.exist")
     cy.get("#add-note-button").should("not.exist")
@@ -208,14 +147,11 @@ describe("View notes", () => {
   it("Should display the notes text area if the case is locked by the user", () => {
     cy.task("insertCourtCasesWithNotes", {
       caseNotes: [[]],
-      force: "02"
+      force: "01"
     })
     cy.task("insertException", exception)
 
-    cy.login("bichard02@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
-
-    clickTab("Notes")
+    loginAndGoToNotes()
     cy.get("label").contains("Add a new note")
     cy.get("textarea").should("be.visible")
     cy.get("span").contains("You have 2000 characters remaining")
@@ -235,7 +171,7 @@ describe("View notes", () => {
   })
 
   it("Should be able to add a note when case is visible to the user and error locked by another user", () => {
-    insertCaseWithTriggerAndException({ orgForPoliceFilter: "01", errorLockedByUsername: "someone.else" })
+    insertCaseWithTriggerAndException({ orgForPoliceFilter: "01", errorLockedByUsername: "BichardForce01" })
     loginAndGoToNotes()
     cy.get("textarea").type("Dummy note")
     cy.get("button").contains("Add note").click()
@@ -248,7 +184,7 @@ describe("View notes", () => {
   })
 
   it("Should be able to add a note when case is visible to the user and trigger locked by another user", () => {
-    insertCaseWithTriggerAndException({ orgForPoliceFilter: "01", triggerLockedByUsername: "someone.else" })
+    insertCaseWithTriggerAndException({ orgForPoliceFilter: "01", triggerLockedByUsername: "BichardForce01" })
     loginAndGoToNotes()
     cy.get("textarea").type("Dummy note")
     cy.get("button").contains("Add note").click()

--- a/cypress/e2e/case-details/view-case-details/view-offence-matching-exceptions.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-offence-matching-exceptions.cy.ts
@@ -1,32 +1,7 @@
 import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
-import User from "services/entities/User"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import { clickTab } from "../../../support/helpers"
 
 describe("View offence matching exceptions", () => {
-  const users: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`0${idx}`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", { users, userGroups: ["B7NewUI_grp"] })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7GeneralHandler_grp" })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard02@example.com", groupName: "B7Supervisor_grp" })
-    cy.clearCookies()
-  })
-
-  beforeEach(() => {
-    cy.task("clearCourtCases")
-  })
   ;[
     { asn: ExceptionCode.HO100304, firstOffenceBadge: "Unmatched" },
     { asn: ExceptionCode.HO100328, firstOffenceBadge: "Unmatched" },
@@ -42,11 +17,12 @@ describe("View offence matching exceptions", () => {
     { offenceReasonSequence: ExceptionCode.HO100333 }
   ].forEach(({ asn, offenceReasonSequence, firstOffenceBadge = "Matched", secondOffenceBadge = "Unmatched" }) => {
     it(`Should display the correct error for ${asn ?? offenceReasonSequence}`, () => {
+      cy.task("clearCourtCases")
       cy.task("insertCourtCaseWithFieldsWithExceptions", {
         case: {
           errorLockedByUsername: null,
           triggerLockedByUsername: null,
-          orgForPoliceFilter: "02"
+          orgForPoliceFilter: "01"
         },
         exceptions: {
           asn,
@@ -54,7 +30,7 @@ describe("View offence matching exceptions", () => {
         }
       })
 
-      cy.login("bichard02@example.com", "password")
+      cy.loginAs("Supervisor")
       cy.visit("/bichard/court-cases/0")
 
       clickTab("Offences")

--- a/cypress/e2e/case-details/view-case-details/view-offences.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-offences.cy.ts
@@ -1,28 +1,9 @@
-import hashedPassword from "../../../fixtures/hashedPassword"
-
 describe("“next offence” and “previous offence” buttons", () => {
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-  })
-
   beforeEach(() => {
-    cy.login("bichard01@example.com", "password")
+    cy.task("clearCourtCases")
     cy.task("clearTriggers")
     cy.task("clearCourtCases")
+    cy.loginAs("GeneralHandler")
   })
 
   it("Should show next offence when next button is clicked if its not the last offence", () => {

--- a/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-resolution-status.cy.ts
@@ -1,29 +1,7 @@
-import User from "../../../../src/services/entities/User"
-import hashedPassword from "../../../fixtures/hashedPassword"
-
 describe("View resolution status", () => {
-  before(() => {
-    cy.task("clearCourtCases")
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ] as Partial<User>[],
-      userGroups: ["B7NewUI_grp"]
-    })
-    cy.task("insertIntoUserGroup", { emailAddress: "bichard01@example.com", groupName: "B7TriggerHandler_grp" })
-    cy.clearCookies()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
+    cy.loginAs("TriggerHandler")
   })
 
   describe("Resolution status badge", () => {
@@ -40,7 +18,6 @@ describe("View resolution status", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
       cy.visit("/bichard/court-cases/0")
 
       cy.get(".moj-badge-submitted").contains("Submitted").should("exist").should("be.visible")
@@ -60,7 +37,6 @@ describe("View resolution status", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
       cy.visit("/bichard/court-cases/0")
 
       cy.get(".moj-badge-resolved").contains("Resolved").should("exist").should("be.visible")
@@ -89,8 +65,6 @@ describe("View resolution status", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
-
       cy.visit("/bichard/court-cases/0")
       cy.get(".moj-badge-resolved").should("not.exist")
 
@@ -111,7 +85,6 @@ describe("View resolution status", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
       cy.visit("/bichard/court-cases/0")
 
       cy.get(".moj-badge-resolved").contains("Resolved").should("exist").should("be.visible")
@@ -131,7 +104,6 @@ describe("View resolution status", () => {
         }
       ])
 
-      cy.login("bichard01@example.com", "password")
       cy.visit("/bichard/court-cases/0")
 
       cy.get(".moj-badge-resolved").contains("Resolved").should("exist").should("be.visible")

--- a/cypress/e2e/case-details/view-case-details/view-summary-box.cy.ts
+++ b/cypress/e2e/case-details/view-case-details/view-summary-box.cy.ts
@@ -1,7 +1,7 @@
 import CourtCase from "services/entities/CourtCase"
 import dummyAho from "../../../../test/test-data/error_list_aho.json"
 import { TestTrigger } from "../../../../test/utils/manageTriggers"
-import { defaultSetup } from "../../../support/helpers"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("View Court Case Details Summary Box", () => {
   const trigger: TestTrigger = {
@@ -32,15 +32,13 @@ describe("View Court Case Details Summary Box", () => {
   }
 
   before(() => {
-    defaultSetup()
     cy.task("clearCourtCases")
     cy.clearCookies()
   })
 
   it("displays the required fields", () => {
     insertCaseWithTriggerAndException()
-    cy.login("bichard01@example.com", "password")
-    cy.visit("/bichard/court-cases/0")
+    loginAndVisit("/bichard/court-cases/0")
 
     cy.contains("ASN")
     cy.contains("asn-value")

--- a/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/filterCases.cy.ts
@@ -1,7 +1,6 @@
 import { TriggerCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/TriggerCode"
 import { addDays, format, subDays } from "date-fns"
 import { TestTrigger } from "../../../../test/utils/manageTriggers"
-import hashedPassword from "../../../fixtures/hashedPassword"
 import a11yConfig from "../../../support/a11yConfig"
 import {
   confirmFiltersAppliedContains,
@@ -48,26 +47,9 @@ function tableRowShouldNotContain(tableRow: number, ...reasonCodes: string[]) {
 }
 
 describe("Filtering cases", () => {
-  before(() => {
-    cy.task("clearUsers")
-    cy.task("insertUsers", {
-      users: [
-        {
-          username: "Bichard01",
-          visibleForces: ["0011111"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-    })
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
-    cy.login("bichard01@example.com", "password")
+    cy.loginAs("GeneralHandler")
   })
 
   it("Should be accessible with conditional radio buttons opened", () => {
@@ -710,7 +692,7 @@ describe("Filtering cases", () => {
     cy.get('*[class^="moj-filter-tags"]').contains("Exceptions")
 
     confirmMultipleFieldsDisplayed([`Case00000`, `Case00002`])
-    confirmMultipleFieldsNotDisplayed([`Case00001`, `Case00003`])
+    confirmMultipleFieldsNotDisplayed([`Case00001`, `Case00003`]) //TODO
 
     // Filter for both triggers and exceptions
     cy.get(`label[for="all-reason"]`).click()
@@ -730,7 +712,7 @@ describe("Filtering cases", () => {
         resolutionTimestamp,
         errorResolvedTimestamp: resolutionTimestamp,
         orgForPoliceFilter: force,
-        errorResolvedBy: "Bichard01",
+        errorResolvedBy: "GeneralHandler",
         errorStatus: "Resolved"
       }
     ])
@@ -756,7 +738,11 @@ describe("Filtering cases", () => {
 
   it("Should filter cases by locked state", () => {
     cy.task("insertCourtCasesWithFields", [
-      { errorLockedByUsername: "Bichard01", triggerLockedByUsername: "Bichard01", orgForPoliceFilter: "011111" },
+      {
+        errorLockedByUsername: "BichardForce01",
+        triggerLockedByUsername: "BichardForce01",
+        orgForPoliceFilter: "011111"
+      },
       { orgForPoliceFilter: "011111" }
     ])
 
@@ -825,9 +811,17 @@ describe("Filtering cases", () => {
   describe("Filtering cases allocated to me", () => {
     it("Should filter cases that I hold the trigger lock for", () => {
       cy.task("insertCourtCasesWithFields", [
-        { errorLockedByUsername: "Bichard01", triggerLockedByUsername: "Bichard01", orgForPoliceFilter: "011111" },
+        {
+          errorLockedByUsername: "GeneralHandler",
+          triggerLockedByUsername: "GeneralHandler",
+          orgForPoliceFilter: "011111"
+        },
         { orgForPoliceFilter: "011111" },
-        { errorLockedByUsername: "Bichard02", triggerLockedByUsername: "Bichard02", orgForPoliceFilter: "011111" },
+        {
+          errorLockedByUsername: "BichardForce02",
+          triggerLockedByUsername: "BichardForce02",
+          orgForPoliceFilter: "011111"
+        },
         { orgForPoliceFilter: "011111" }
       ])
 
@@ -840,7 +834,6 @@ describe("Filtering cases", () => {
       cy.get("#search").click()
 
       cy.contains("Case00000")
-      cy.contains("Bichard01")
       confirmMultipleFieldsNotDisplayed(["Case00001", "Case00002", "Case00003"])
     })
   })

--- a/cypress/e2e/case-list/filter-cases/filterChips.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/filterChips.cy.ts
@@ -1,33 +1,15 @@
-import hashedPassword from "../../../fixtures/hashedPassword"
 import {
   confirmFiltersAppliedContains,
   filterByCaseAge,
   filterByDateRange,
+  loginAndVisit,
   removeFilterChip
 } from "../../../support/helpers"
 
 describe("Case list", () => {
   context("When filters applied", () => {
-    before(() => {
-      cy.task("clearUsers")
-      cy.task("insertUsers", {
-        users: [
-          {
-            username: "Bichard01",
-            visibleForces: ["011111"],
-            forenames: "Bichard Test User",
-            surname: "01",
-            email: "bichard01@example.com",
-            password: hashedPassword
-          }
-        ],
-        userGroups: ["B7NewUI_grp", "B7GeneralHandler_grp"]
-      })
-    })
-
     beforeEach(() => {
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard")
+      loginAndVisit()
     })
 
     it("Should display no filters chips and a placeholder message as the default state", () => {

--- a/cypress/e2e/case-list/filter-cases/reasons.roles.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/reasons.roles.cy.ts
@@ -1,56 +1,34 @@
-import { UserGroup } from "types/UserGroup"
-import { newUserLogin } from "../../../support/helpers"
-
-const navigateAndShowFilters = () => {
-  cy.visit("/bichard")
-}
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Reasons filters", () => {
-  before(() => {
-    cy.task("clearUsers")
-  })
-
-  afterEach(() => {
-    cy.task("clearUsers")
-  })
-
   it("should not render the reasons component if no user group is specified", () => {
-    newUserLogin({})
-    navigateAndShowFilters()
+    loginAndVisit("NoGroups")
 
     cy.get("#filter-panel .reasons").should("not.exist")
   })
 
   it("should display all options for supervisors", () => {
-    newUserLogin({
-      groups: [UserGroup.Supervisor]
-    })
-    navigateAndShowFilters()
+    loginAndVisit("Supervisor")
 
     cy.get("#filter-panel .reasons .triggers").should("exist")
     cy.get("#filter-panel .reasons .exceptions").should("exist")
   })
 
   it("should display all options for general handlers", () => {
-    newUserLogin({ groups: [UserGroup.GeneralHandler] })
-    navigateAndShowFilters()
+    loginAndVisit()
 
     cy.get("#filter-panel .reasons .triggers").should("exist")
     cy.get("#filter-panel .reasons .exceptions").should("exist")
   })
 
   it("should not render the reasons component for exception handlers", () => {
-    newUserLogin({ groups: [UserGroup.ExceptionHandler] })
-    navigateAndShowFilters()
+    loginAndVisit("ExceptionHandler")
 
     cy.get("#filter-panel .reasons").should("not.exist")
   })
 
   it("should render the correct reasons if a user has conflicting groups", () => {
-    newUserLogin({
-      groups: [UserGroup.Supervisor, UserGroup.ExceptionHandler]
-    })
-    navigateAndShowFilters()
+    loginAndVisit("MultigroupSupervisor")
 
     cy.get("#filter-panel .reasons .triggers").should("exist")
     cy.get("#filter-panel .reasons .exceptions").should("exist")

--- a/cypress/e2e/case-list/filter-cases/searchPanel.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/searchPanel.cy.ts
@@ -1,11 +1,9 @@
-import { defaultSetup } from "../../../support/helpers"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Case list", () => {
   context("search panel", () => {
     it("Should correctly show chips when the panel is hidden and visible", () => {
-      defaultSetup()
-      cy.login("bichard01@example.com", "password")
-      cy.visit("/bichard")
+      loginAndVisit()
 
       // Check that no chips exist on load
       cy.get("#filter-button").contains("Hide search panel").should("exist")

--- a/cypress/e2e/case-list/orgsAndForces.cy.ts
+++ b/cypress/e2e/case-list/orgsAndForces.cy.ts
@@ -1,22 +1,13 @@
-import {
-  confirmMultipleFieldsDisplayed,
-  confirmMultipleFieldsNotDisplayed,
-  defaultSetup,
-  loginAndGoToUrl
-} from "../../support/helpers"
+import { confirmMultipleFieldsDisplayed, confirmMultipleFieldsNotDisplayed, loginAndVisit } from "../../support/helpers"
 
 describe("How orgs and forces are presented", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
 
   it("Should display a case for the user's org", () => {
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("tr").not(":first").get("td:nth-child(5)").contains(`Case00000`)
   })
@@ -32,7 +23,7 @@ describe("How orgs and forces are presented", () => {
       { orgForPoliceFilter: caseNotVisible, ptiurn: "NotExpected" }
     ])
 
-    loginAndGoToUrl("bichard02@example.com")
+    loginAndVisit("BichardForce02")
 
     confirmMultipleFieldsDisplayed(["expected1", "expected2", "expected3"])
     confirmMultipleFieldsNotDisplayed(["NotExpected"])
@@ -48,7 +39,7 @@ describe("How orgs and forces are presented", () => {
       { orgForPoliceFilter: caseNotVisible, ptiurn: "NotExpected" }
     ])
 
-    loginAndGoToUrl("bichard02@example.com")
+    loginAndVisit("BichardForce02")
 
     confirmMultipleFieldsDisplayed(["expected"])
     confirmMultipleFieldsNotDisplayed(["NotExpected"])
@@ -62,7 +53,7 @@ describe("How orgs and forces are presented", () => {
       { courtCode: caseNotVisible, ptiurn: "NotExpected" }
     ])
 
-    loginAndGoToUrl("bichard02@example.com")
+    loginAndVisit("BichardForce02")
 
     confirmMultipleFieldsDisplayed(["expected"])
     confirmMultipleFieldsNotDisplayed(["NotExpected"])
@@ -76,7 +67,7 @@ describe("How orgs and forces are presented", () => {
       { orgForPoliceFilter: "013A1" }
     ])
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00000")
     cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00001")
@@ -93,7 +84,7 @@ describe("How orgs and forces are presented", () => {
       { orgForPoliceFilter: "011111" }
     ])
 
-    loginAndGoToUrl("bichard011111@example.com")
+    loginAndVisit("Bichard011111")
 
     cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00000").should("not.exist")
     cy.get("tr").not(":first").get("td:nth-child(5)").contains("Case00001").should("not.exist")

--- a/cypress/e2e/case-list/pagination.cy.ts
+++ b/cypress/e2e/case-list/pagination.cy.ts
@@ -1,12 +1,8 @@
 import a11yConfig from "../../support/a11yConfig"
-import { confirmFiltersAppliedContains, defaultSetup, loginAndGoToUrl } from "../../support/helpers"
+import { confirmFiltersAppliedContains, loginAndVisit } from "../../support/helpers"
 import logAccessibilityViolations from "../../support/logAccessibilityViolations"
 
 describe("Pagination", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -14,7 +10,7 @@ describe("Pagination", () => {
   it("Should be accessible", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 100, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.injectAxe()
 
@@ -27,7 +23,7 @@ describe("Pagination", () => {
   it("lets users select how many cases to show per page", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 200, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("tbody tr").should("have.length", 50)
     cy.get("tr").contains("Case00000").should("exist")
@@ -56,7 +52,7 @@ describe("Pagination", () => {
   it("keeps roughly the same position in the case list when changing page size", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 100, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(".cases-per-page").first().select("50")
     cy.get("tbody tr").should("have.length", 50)
@@ -80,14 +76,14 @@ describe("Pagination", () => {
       { orgForPoliceFilter: "011111" },
       { orgForPoliceFilter: "011111" }
     ])
-    loginAndGoToUrl(undefined, "/bichard?page=5")
+    loginAndVisit("/bichard?page=5")
     cy.url().should("match", /\/bichard\?page=1/)
   })
 
   it("doesn't show navigation options when there is only one page", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 3, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(".moj-pagination__list li").should("not.exist")
   })
@@ -95,7 +91,7 @@ describe("Pagination", () => {
   it("has correct pagination information when there is only one page", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 3, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("p.moj-pagination__results").should("contain.text", "Showing 1 to 3 of 3 cases")
   })
@@ -103,7 +99,7 @@ describe("Pagination", () => {
   it("lets users navigate back and forth between pages using the page numbers", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 250, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(".cases-per-page").first().select("25")
 
@@ -130,7 +126,7 @@ describe("Pagination", () => {
   it("lets users navigate back and forth between pages using the next and previous arrows", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 250, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(".cases-per-page").first().select("25")
 
@@ -157,7 +153,7 @@ describe("Pagination", () => {
   it("has correct pagination information on page 3 out of 5", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 250, force: "01" })
 
-    loginAndGoToUrl(undefined, "/bichard?page=3")
+    loginAndVisit("/bichard?page=3")
 
     cy.get("p.moj-pagination__results").first().should("contain.text", "Showing 101 to 150 of 250 cases")
     cy.get("tr").contains("Case00100").should("exist")
@@ -169,12 +165,12 @@ describe("Pagination", () => {
       numToInsert: 100,
       force: "01",
       otherFields: {
-        errorLockedByUsername: "Bichard01",
-        triggerLockedByUsername: "Bichard01"
+        errorLockedByUsername: "GeneralHandler",
+        triggerLockedByUsername: "GeneralHandler"
       }
     })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("label[for='my-cases-filter']").click()
     cy.get("#search").click()

--- a/cypress/e2e/case-list/persistAppliedFilters.cy.ts
+++ b/cypress/e2e/case-list/persistAppliedFilters.cy.ts
@@ -1,10 +1,6 @@
-import { defaultSetup, loginAndGoToUrl } from "../../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 describe("Persist applied filters", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -12,7 +8,7 @@ describe("Persist applied filters", () => {
   it("Should persist applied filters", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 100, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("#keywords").type("Defendant Name")
     cy.get("#search").click()
@@ -28,7 +24,7 @@ describe("Persist applied filters", () => {
   it("Should clear the applied filters", () => {
     cy.task("insertMultipleDummyCourtCases", { numToInsert: 100, force: "01" })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("#keywords").type("Defendant Name")
     cy.get("#search").click()

--- a/cypress/e2e/case-list/persistSearchPanel.cy.ts
+++ b/cypress/e2e/case-list/persistSearchPanel.cy.ts
@@ -1,31 +1,17 @@
-import { ResolutionStatus } from "types/ResolutionStatus"
-import { defaultSetup, loginAndGoToUrl } from "../../support/helpers"
-
-const caseTriggers: { code: string; status: ResolutionStatus }[][] = [
-  [
-    {
-      code: "TRPR0001",
-      status: "Unresolved"
-    }
-  ]
-]
-
-before(() => {
-  defaultSetup()
-})
+import { loginAndVisit } from "../../support/helpers"
 
 beforeEach(() => {
   cy.task("clearCourtCases")
 })
 
 it("Should show search panel by default after logging in", () => {
-  loginAndGoToUrl()
+  loginAndVisit()
 
   cy.contains("Apply filters")
 })
 
 it("When the user refreshes the page, the search panel should stay closed", () => {
-  loginAndGoToUrl()
+  loginAndVisit()
   cy.get("#filter-button").contains("Hide search panel").click()
   cy.get("#filter-button").contains("Show search panel")
 
@@ -35,12 +21,12 @@ it("When the user refreshes the page, the search panel should stay closed", () =
 
 it("When the user applies a filter, the search panel should stay open", () => {
   cy.task("insertDummyCourtCasesWithTriggers", {
-    caseTriggers,
+    caseTriggers: [[{ code: "TRPR0001", status: "Unresolved" }]],
     orgCode: "01",
-    triggersLockedByUsername: "Bichard01"
+    triggersLockedByUsername: "BichardForce01"
   })
 
-  loginAndGoToUrl()
+  loginAndVisit()
 
   cy.contains("Exceptions").click()
   cy.get("button[id=search]").click()
@@ -48,7 +34,7 @@ it("When the user applies a filter, the search panel should stay open", () => {
 })
 
 it("The filter panel state should reset to its default after one week from its initial activation", () => {
-  loginAndGoToUrl()
+  loginAndVisit()
 
   cy.get("#filter-button").contains("Hide search panel").click()
   cy.get("#filter-button").contains("Show search panel")
@@ -57,7 +43,7 @@ it("The filter panel state should reset to its default after one week from its i
   const currentDate = new Date()
   currentDate.setDate(currentDate.getDate() - 7)
   cy.window().then((win) => {
-    win.localStorage.setItem("is-filter-panel-visible-Bichard01", currentDate.toISOString())
+    win.localStorage.setItem("is-filter-panel-visible-GeneralHandler", currentDate.toISOString())
   })
   cy.visit("/bichard")
   cy.get("#filter-button").contains("Hide search panel")

--- a/cypress/e2e/case-list/relevantResolvedCases.cy.ts
+++ b/cypress/e2e/case-list/relevantResolvedCases.cy.ts
@@ -1,17 +1,8 @@
 import { subHours } from "date-fns"
 import CourtCase from "services/entities/CourtCase"
-import {
-  confirmMultipleFieldsDisplayed,
-  confirmMultipleFieldsNotDisplayed,
-  defaultSetup,
-  loginAndGoToUrl
-} from "../../support/helpers"
+import { confirmMultipleFieldsDisplayed, confirmMultipleFieldsNotDisplayed, loginAndVisit } from "../../support/helpers"
 
 describe("Only shows relevant resolved cases to the user", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -38,7 +29,7 @@ describe("Only shows relevant resolved cases to the user", () => {
     })
     cy.task("insertCourtCasesWithFields", cases)
 
-    loginAndGoToUrl("supervisor@example.com")
+    loginAndVisit("Supervisor")
 
     confirmMultipleFieldsDisplayed(["Case00002", "Case00005"])
     confirmMultipleFieldsNotDisplayed(["Case00000", "Case00001", "Case00003", "Case00004"])
@@ -53,12 +44,12 @@ describe("Only shows relevant resolved cases to the user", () => {
   it("shows handlers resolved cases that only they resolved exceptions for", () => {
     const casesConfig = [
       { force: "011111", resolved: true, resolvedBy: "Supervisor" },
-      { force: "011111", resolved: true, resolvedBy: "Bichard01" },
+      { force: "011111", resolved: true, resolvedBy: "GeneralHandler" },
       { force: "011111", resolved: false },
-      { force: "02", resolved: true, resolvedBy: "Bichard02" },
+      { force: "02", resolved: true, resolvedBy: "BichardForce02" },
       { force: "03", resolved: false },
       { force: "011111", resolved: false },
-      { force: "011111", resolved: true, resolvedBy: "Bichard01" }
+      { force: "011111", resolved: true, resolvedBy: "GeneralHandler" }
     ]
     const cases: Partial<CourtCase>[] = casesConfig.map((caseConfig, errorId) => {
       const resolutionDate = subHours(new Date(), Math.random() * 100)
@@ -74,7 +65,7 @@ describe("Only shows relevant resolved cases to the user", () => {
     })
     cy.task("insertCourtCasesWithFields", cases)
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(`label[for="resolved"]`).click()
     cy.get("#search").click()
@@ -85,13 +76,13 @@ describe("Only shows relevant resolved cases to the user", () => {
 
   it("shows handlers resolved cases that only they resolved triggers for", () => {
     const casesConfig = [
-      { force: "011111", resolved: true, resolvedBy: "Supervisor" },
-      { force: "011111", resolved: true, resolvedBy: "Bichard01" },
-      { force: "011111", resolved: false },
-      { force: "02", resolved: true, resolvedBy: "Bichard02" },
+      { force: "01", resolved: true, resolvedBy: "Supervisor" },
+      { force: "01", resolved: true, resolvedBy: "GeneralHandler" },
+      { force: "01", resolved: false },
+      { force: "02", resolved: true, resolvedBy: "BichardForce02" },
       { force: "03", resolved: false },
-      { force: "011111", resolved: false },
-      { force: "011111", resolved: true, resolvedBy: "Bichard01" }
+      { force: "01", resolved: false },
+      { force: "01", resolved: true, resolvedBy: "GeneralHandler" }
     ]
     const cases: Partial<CourtCase>[] = casesConfig.map((caseConfig, errorId) => {
       const resolutionDate = subHours(new Date(), Math.random() * 100)
@@ -114,7 +105,6 @@ describe("Only shows relevant resolved cases to the user", () => {
           caseId: caseConfig.errorId,
           triggers: [
             {
-              triggerId: caseConfig.errorId,
               triggerCode: "TRPR0010",
               status: "Resolved",
               createdAt: new Date("2023-03-07T10:22:34.000Z"),
@@ -125,7 +115,7 @@ describe("Only shows relevant resolved cases to the user", () => {
         })
       })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get(`label[for="resolved"]`).click()
     cy.get("#search").click()

--- a/cypress/e2e/case-list/roles.cy.ts
+++ b/cypress/e2e/case-list/roles.cy.ts
@@ -3,8 +3,7 @@ import {
   confirmCaseNotDisplayed,
   confirmReasonDisplayed,
   confirmReasonNotDisplayed,
-  defaultSetup,
-  loginAndGoToUrl
+  loginAndVisit
 } from "../../support/helpers"
 
 describe("Shows relevant information to a user's role", () => {
@@ -75,10 +74,6 @@ describe("Shows relevant information to a user's role", () => {
     }
   ]
 
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task(
       "insertCourtCasesWithFields",
@@ -106,13 +101,13 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Shouldn't show cases to a user with no groups", () => {
-    loginAndGoToUrl("nogroups@example.com")
+    loginAndVisit("NoGroups")
 
     cy.findByText("There are no court cases to show").should("exist")
   })
 
   it("Should only show cases with triggers to a trigger handler", () => {
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     confirmCaseDisplayed("Case00001")
     confirmCaseDisplayed("Case00002")
@@ -121,7 +116,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should only show cases with exceptions to an exception handler", () => {
-    loginAndGoToUrl("exceptionhandler@example.com")
+    loginAndVisit("ExceptionHandler")
 
     confirmCaseDisplayed("Case00000")
     confirmCaseDisplayed("Case00002")
@@ -130,7 +125,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should show all cases to a general handler", () => {
-    loginAndGoToUrl("generalhandler@example.com")
+    loginAndVisit("GeneralHandler")
 
     confirmCaseDisplayed("Case00000")
     confirmCaseDisplayed("Case00001")
@@ -138,7 +133,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should show all cases to a supervisor", () => {
-    loginAndGoToUrl("supervisor@example.com")
+    loginAndVisit("Supervisor")
 
     confirmCaseDisplayed("Case00000")
     confirmCaseDisplayed("Case00001")
@@ -146,7 +141,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should only show triggers in the reason column to a trigger handler", () => {
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     confirmReasonDisplayed("TRPR0010")
     confirmReasonDisplayed("TRPR0011")
@@ -156,7 +151,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should only show exceptions in the reason column to an exception handler", () => {
-    loginAndGoToUrl("exceptionhandler@example.com")
+    loginAndVisit("ExceptionHandler")
 
     confirmReasonNotDisplayed("TRPR0010")
     confirmReasonNotDisplayed("TRPR0011")
@@ -166,7 +161,7 @@ describe("Shows relevant information to a user's role", () => {
   })
 
   it("Should show both triggers and exceptions in the reason column to a general handler", () => {
-    loginAndGoToUrl("generalhandler@example.com")
+    loginAndVisit("GeneralHandler")
 
     confirmReasonDisplayed("TRPR0010")
     confirmReasonDisplayed("TRPR0011")

--- a/cypress/e2e/case-list/sortingCases.cy.ts
+++ b/cypress/e2e/case-list/sortingCases.cy.ts
@@ -1,4 +1,4 @@
-import { defaultSetup, loginAndGoToUrl } from "../../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 const checkCasesOrder = (expectedOrder: number[]) => {
   cy.get("tbody td:nth-child(5)").each((element, index) => {
@@ -13,10 +13,6 @@ const checkPtiurnOrder = (expectedOrder: string[]) => {
 }
 
 describe("Sorting cases", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -36,7 +32,7 @@ describe("Sorting cases", () => {
       }))
     ])
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     // Sorted by court date
     checkCasesOrder([1, 4, 0, 3, 2, 5])
@@ -50,7 +46,7 @@ describe("Sorting cases", () => {
       { courtName: "CCCC", orgForPoliceFilter: "011111" }
     ])
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.get("#court-name-sort").find(".unorderedArrow").click()
     cy.get("#court-name-sort").parent().siblings().get('*[class^="icon"]').get(".upArrow").should("exist")
@@ -88,7 +84,7 @@ describe("Sorting cases", () => {
       }))
     ])
 
-    loginAndGoToUrl()
+    loginAndVisit()
     // Sort ascending by defendant name
     cy.get("#defendant-name-sort").click()
 
@@ -105,7 +101,7 @@ describe("Sorting cases", () => {
       }))
     )
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     // Sort ascending by court name
     cy.get("#court-name-sort").click()
@@ -132,7 +128,7 @@ describe("Sorting cases", () => {
       }))
     )
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     // Sort ascending by PTIURN
     cy.get("#ptiurn-sort").find(".unorderedArrow").click()

--- a/cypress/e2e/case-list/triggers.cy.ts
+++ b/cypress/e2e/case-list/triggers.cy.ts
@@ -1,4 +1,4 @@
-import { defaultSetup, loginAndGoToUrl } from "../../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 // Unresolved and user has permission to see them (e.g. not Exception Handlers)
 describe("When I can see triggers on cases", () => {
@@ -12,10 +12,6 @@ describe("When I can see triggers on cases", () => {
       }
     })
 
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "011111" }])
@@ -23,7 +19,7 @@ describe("When I can see triggers on cases", () => {
 
   it("Should display individual triggers without a count", () => {
     cy.task("insertTriggers", { caseId: 0, triggers: makeTriggers() })
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get(".trigger-description")
       .contains(/\(\d+\)/) // any number between parentheses
@@ -32,14 +28,14 @@ describe("When I can see triggers on cases", () => {
 
   it("Should group duplicate triggers", () => {
     cy.task("insertTriggers", { caseId: 0, triggers: makeTriggers(1) })
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get("table").find(".trigger-description").should("have.length", 1)
   })
 
   it("Should include a count for grouped triggers", () => {
     cy.task("insertTriggers", { caseId: 0, triggers: makeTriggers(2) })
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get(".trigger-description")
       .contains(/\(\d+\)/) // any number between parentheses
@@ -53,7 +49,7 @@ describe("When I can see triggers on cases", () => {
     })
 
     cy.task("insertTriggers", { caseId: 0, triggers })
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get(".trigger-description:contains('TRPR0001')")
       .contains(/\(\d+\)/) // any number between parentheses
@@ -67,7 +63,7 @@ describe("When I can see triggers on cases", () => {
   it("Should display the correct count for grouped triggers", () => {
     const triggers = makeTriggers(1, 12)
     cy.task("insertTriggers", { caseId: 0, triggers })
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get(".trigger-description:contains('TRPR0001')")
       .contains(/\(\d+\)/) // any number between parentheses

--- a/cypress/e2e/case-list/unlocking.cy.ts
+++ b/cypress/e2e/case-list/unlocking.cy.ts
@@ -1,6 +1,6 @@
 import { TriggerCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/TriggerCode"
 import { TestTrigger } from "../../../test/utils/manageTriggers"
-import { defaultSetup, loginAndGoToUrl } from "../../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 const unlockCase = (
   caseToUnlockNumber: number,
@@ -47,10 +47,6 @@ const checkLockStatus = (
 }
 
 describe("Case unlocked badge", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
@@ -66,12 +62,12 @@ describe("Case unlocked badge", () => {
       }
     ])
 
-    loginAndGoToUrl("exceptionhandler@example.com")
+    loginAndVisit("ExceptionHandler")
 
     cy.get("#keywords").type("NAME Defendant")
     cy.contains("Apply filters").click()
 
-    cy.get("button.locked-by-tag").contains("Exception Handler User 0111").click()
+    cy.get("button.locked-by-tag").contains("Exception Handler User").click()
     cy.get("#unlock").click()
     cy.get("span.moj-badge").contains("Case unlocked").should("exist")
   })
@@ -96,18 +92,18 @@ describe("Case unlocked badge", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    loginAndGoToUrl("triggerhandler@example.com")
+    loginAndVisit("TriggerHandler")
 
     cy.get("#keywords").type("NAME Defendant")
     cy.contains("Apply filters").click()
 
-    cy.get("button.locked-by-tag").contains("Trigger Handler User 0111").click()
+    cy.get("button.locked-by-tag").contains("Trigger Handler User").click()
     cy.get("#unlock").click()
     cy.get("span.moj-badge").contains("Case unlocked").should("exist")
   })
 
   it("Should unlock a case that is locked to the user", () => {
-    const lockUsernames = ["Bichard01", "Bichard02"]
+    const lockUsernames = ["GeneralHandler", "BichardForce01"]
     cy.task(
       "insertCourtCasesWithFields",
       lockUsernames.map((username) => ({
@@ -129,27 +125,27 @@ describe("Case unlocked badge", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
     // Exception lock
-    checkLockStatus(0, 1, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
+    checkLockStatus(0, 1, "General Handler", ["exist", undefined], ["exist", undefined])
     // Trigger lock
-    checkLockStatus(0, 2, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
+    checkLockStatus(0, 2, "General Handler", ["exist", undefined], ["exist", undefined])
     // User should not see unlock button when a case assigned to another user
-    checkLockStatus(1, 1, "Bichard Test User 02", ["not.exist", undefined], ["exist", undefined])
+    checkLockStatus(1, 1, "Bichard Test User Force 01", ["not.exist", undefined], ["exist", undefined])
     // Unlock the exception assigned to the user
-    unlockCase(1, "Bichard Test User 01", "Exceptions")
+    unlockCase(1, "General Handler", "Exceptions")
     checkLockStatus(0, 1, "", ["not.exist", undefined], ["not.exist", undefined])
-    checkLockStatus(0, 2, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
-    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User 02"], ["exist", undefined])
+    checkLockStatus(0, 2, "General Handler", ["exist", undefined], ["exist", undefined])
+    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User Force 01"], ["exist", undefined])
     // Unlock the trigger assigned to the user
-    unlockCase(2, "Bichard Test User 01", "Triggers")
+    unlockCase(2, "General Handler", "Triggers")
     checkLockStatus(0, 2, "", ["not.exist", undefined], ["not.exist", undefined])
-    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User 02"], ["exist", undefined])
+    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User Force 01"], ["exist", undefined])
   })
 
   it("shows who has locked a case in the 'locked by' column", () => {
-    const lockUsernames = ["Bichard01", "Bichard02", null, "A really really really long.name"]
+    const lockUsernames = ["BichardForce01", "BichardForce02", null, "A really really really long.name"]
     cy.task(
       "insertCourtCasesWithFields",
       lockUsernames.map((username) => ({
@@ -171,20 +167,20 @@ describe("Case unlocked badge", () => {
     cy.task("insertTriggers", { caseId: 2, triggers })
     cy.task("insertTriggers", { caseId: 3, triggers })
 
-    loginAndGoToUrl()
+    loginAndVisit()
 
-    checkLockStatus(0, 1, "", ["have.text", "Bichard Test User 01"], ["exist", undefined])
+    checkLockStatus(0, 1, "", ["have.text", "Bichard Test User Force 01"], ["exist", undefined])
     cy.get("tbody").eq(0).find("tr:nth-child(2) td:nth-child(7)").should("contain.text", "TRPR0001")
-    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User 02"], ["exist", undefined])
+    checkLockStatus(1, 1, "", ["have.text", "Bichard Test User Force 02"], ["exist", undefined])
     cy.get("tbody").eq(1).find("tr:nth-child(2) td:nth-child(7)").should("contain.text", "TRPR0001")
     checkLockStatus(2, 1, "", ["not.exist", undefined], ["not.exist", undefined])
     cy.get("tbody").eq(2).find(`tr:nth-child(2) td:nth-child(7)`).should("contain.text", "TRPR0001")
-    checkLockStatus(3, 1, "", ["have.text", "A Really Really Really Long Name"], ["exist", undefined])
+    checkLockStatus(3, 1, "", ["have.text", "A Really Really Really Long Name User"], ["exist", undefined])
     cy.get("tbody").eq(3).find(`tr:nth-child(2) td:nth-child(7)`).should("contain.text", "TRPR0001")
   })
 
   it("Should unlock any case as a supervisor user", () => {
-    const lockUsernames = ["Bichard01", "Bichard02"]
+    const lockUsernames = ["BichardForce01", "BichardForce02"]
     cy.task(
       "insertCourtCasesWithFields",
       lockUsernames.map((username) => ({
@@ -207,15 +203,15 @@ describe("Case unlocked badge", () => {
     ]
     cy.task("insertTriggers", { caseId: 0, triggers })
 
-    loginAndGoToUrl("supervisor@example.com")
-    checkLockStatus(0, 1, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
-    checkLockStatus(0, 2, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
-    checkLockStatus(1, 1, "Bichard Test User 01", ["exist", undefined], ["exist", undefined])
+    loginAndVisit("Supervisor")
+    checkLockStatus(0, 1, "Bichard Test User Force 01", ["exist", undefined], ["exist", undefined])
+    checkLockStatus(0, 2, "Bichard Test User Force 01", ["exist", undefined], ["exist", undefined])
+    checkLockStatus(1, 1, "Bichard Test User Force 01", ["exist", undefined], ["exist", undefined])
 
     // Unlock both cases
-    unlockCase(1, "Bichard Test User 01", "Exceptions")
-    unlockCase(1, "Bichard Test User 01", "Triggers")
-    unlockCase(2, "Bichard Test User 02", "Exceptions")
+    unlockCase(1, "Bichard Test User Force 01", "Exceptions")
+    unlockCase(1, "Bichard Test User Force 01", "Triggers")
+    unlockCase(2, "Bichard Test User Force 02", "Exceptions")
 
     checkLockStatus(0, 1, "", ["not.exist", undefined], ["not.exist", undefined])
     checkLockStatus(0, 2, "", ["not.exist", undefined], ["not.exist", undefined])

--- a/cypress/e2e/csrf.cy.ts
+++ b/cypress/e2e/csrf.cy.ts
@@ -1,16 +1,12 @@
-import { defaultSetup, loginAndGoToUrl } from "../support/helpers"
+import { loginAndVisit } from "../support/helpers"
 
 describe("Case list", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
 
   it("should respond with forbidden response code when CSRF tokens are invalid", () => {
-    loginAndGoToUrl()
+    loginAndVisit()
     cy.checkCsrf("/bichard")
     cy.checkCsrf("/bichard/court-cases/0")
     cy.checkCsrf("/bichard/court-cases/0/reallocate")

--- a/cypress/e2e/generalFeedback.cy.ts
+++ b/cypress/e2e/generalFeedback.cy.ts
@@ -1,6 +1,5 @@
 import SurveyFeedback from "services/entities/SurveyFeedback"
-import hashedPassword from "../fixtures/hashedPassword"
-import { expectToHaveNumberOfFeedbacks } from "../support/helpers"
+import { expectToHaveNumberOfFeedbacks, loginAndVisit } from "../support/helpers"
 
 const submitAFeedback = () => {
   cy.findByText("feedback").click()
@@ -11,37 +10,14 @@ const submitAFeedback = () => {
 }
 
 describe("General Feedback Form", () => {
-  const expectedUserId = 0
-
   beforeEach(() => {
     cy.viewport(1280, 720)
     cy.task("clearAllFeedbacksFromDatabase")
-    cy.task("clearUsers")
 
-    cy.task("insertUsers", {
-      users: [
-        {
-          id: expectedUserId,
-          username: "Bichard01",
-          visibleForces: ["01"],
-          forenames: "Bichard Test User",
-          surname: "01",
-          email: "bichard01@example.com",
-          password: hashedPassword
-        }
-      ],
-      userGroups: ["B7NewUI_grp"]
-    })
-    cy.login("bichard01@example.com", "password")
-  })
-
-  afterEach(() => {
-    cy.task("clearAllFeedbacksFromDatabase")
-    cy.task("clearUsers")
+    loginAndVisit()
   })
 
   it("Should be able to submit a feedback that is anonymous", () => {
-    cy.visit("/bichard")
     cy.findByText("feedback").click()
     cy.get("h2").contains("Share your feedback").should("exist")
 
@@ -59,13 +35,12 @@ describe("General Feedback Form", () => {
   })
 
   it("Should be able to submit a feedback that is not anonymous", () => {
-    cy.visit("/bichard")
     submitAFeedback()
     cy.task("getAllFeedbacksFromDatabase").then((result) => {
       const feedbackResults = result as SurveyFeedback[]
       const feedback = feedbackResults[0]
       expect(feedback.feedbackType).equal(0)
-      expect(feedback.userId).equal(expectedUserId)
+      expect(feedback.user.username).equal("GeneralHandler")
     })
   })
 

--- a/cypress/e2e/header.cy.ts
+++ b/cypress/e2e/header.cy.ts
@@ -1,31 +1,15 @@
-import hashedPassword from "../fixtures/hashedPassword"
+import { loginAndVisit } from "../support/helpers"
 
 describe("Home", () => {
   context("720p resolution", () => {
     beforeEach(() => {
       cy.task("clearCourtCases")
-      cy.task("clearUsers")
       cy.viewport(1280, 720)
     })
 
     context("top-nav", () => {
-      it("as a user that is not part of the 'UserManager' group, I should have access to these nav items", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `generalhandler2`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `generalhandler2@example.com`,
-              password:
-                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
-            }
-          ],
-          userGroups: ["B7NewUI_grp"]
-        })
-        cy.login("generalhandler2@example.com", "password")
-        cy.visit("/bichard")
+      it("as a user that is not part of the 'UserManager' group, I should have access to the correct nav items", () => {
+        loginAndVisit()
 
         cy.contains("nav a", "Case list").should("have.attr", "href", "/bichard/")
         cy.contains("nav a", "Reports").should("not.exist")
@@ -35,21 +19,7 @@ describe("Home", () => {
       })
 
       it("as a user who is part of the 'UserManager' group, I should have access to these nav items", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `Bichard01`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `bichard01@example.com`,
-              password: hashedPassword
-            }
-          ],
-          userGroups: ["B7UserManager_grp", "B7NewUI_grp"]
-        })
-        cy.login("bichard01@example.com", "password")
-        cy.visit("/bichard")
+        loginAndVisit("UserManager")
 
         cy.contains("nav a", "Case list").should("have.attr", "href", "/bichard/")
         cy.contains("nav a", "Reports").should("not.exist")
@@ -59,22 +29,7 @@ describe("Home", () => {
       })
 
       it("as a user that is part of the Supervisor group, I should have access to these nav items", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `supervisorUser`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `supervisorUser@example.com`,
-              password:
-                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
-            }
-          ],
-          userGroups: ["B7NewUI_grp", "B7Supervisor_grp"]
-        })
-        cy.login("supervisorUser@example.com", "password")
-        cy.visit("/bichard")
+        loginAndVisit("Supervisor")
 
         cy.contains("nav a", "Case list").should("have.attr", "href", "/bichard/")
         cy.contains("nav a", "Reports").should("have.attr", "href", "/bichard-ui/ReturnToReportIndex")
@@ -83,85 +38,21 @@ describe("Home", () => {
         cy.contains("nav a", "Sign out").should("have.attr", "href", "/users/logout/")
       })
 
-      it("as a user that is part of all groups except Supervisor, I should not have access to the Reports tab", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `notSupervisorUser`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `notSupervisorUser@example.com`,
-              password:
-                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
-            }
-          ],
-          userGroups: [
-            "B7Allocator_grp",
-            "B7Audit_grp",
-            "B7ExceptionHandler_grp",
-            "B7GeneralHandler_grp",
-            "B7TriggerHandler_grp",
-            "B7UserManager_grp",
-            "B7AuditLoggingManager_grp",
-            "B7SuperUserManager_grp",
-            "B7NewUI_grp"
-          ]
-        })
-        cy.login("notSupervisorUser@example.com", "password")
-        cy.visit("/bichard")
+      it("as a user that is not a Supervisor, I should not have access to the Reports tab", () => {
+        loginAndVisit("GeneralHandler")
 
         cy.contains("nav a", "Reports").should("not.exist")
       })
 
-      it("as a user that is part of all groups except User Manager and Super User Manager, I should not have access to the User Manager tab", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `notUserManager`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `notUserManager@example.com`,
-              password:
-                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
-            }
-          ],
-          userGroups: [
-            "B7Allocator_grp",
-            "B7Audit_grp",
-            "B7ExceptionHandler_grp",
-            "B7GeneralHandler_grp",
-            "B7TriggerHandler_grp",
-            "B7Supervisor_grp",
-            "B7AuditLoggingManager_grp",
-            "B7NewUI_grp"
-          ]
-        })
-        cy.login("notUserManager@example.com", "password")
-        cy.visit("/bichard")
+      it("as a user that is not a User Manager, I should not have access to the User Manager tab", () => {
+        loginAndVisit("Supervisor")
 
         cy.contains("nav a", "User management").should("not.exist")
       })
     })
     context("phase banner", () => {
       it("displays a phase banner", () => {
-        cy.task("insertUsers", {
-          users: [
-            {
-              username: `generalhandler2`,
-              visibleForces: [`01`],
-              forenames: "Bichard Test User",
-              surname: `01`,
-              email: `generalhandler2@example.com`,
-              password:
-                "$argon2id$v=19$m=15360,t=2,p=1$CK/shCsqcAng1U81FDzAxA$UEPw1XKYaTjPwKtoiNUZGW64skCaXZgHrtNraZxwJPw"
-            }
-          ],
-          userGroups: ["B7NewUI_grp"]
-        })
-        cy.login("generalhandler2@example.com", "password")
-        cy.visit("/bichard")
+        loginAndVisit("GeneralHandler")
 
         cy.contains("Beta")
       })

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -1,32 +1,28 @@
 import { TestTrigger } from "../../test/utils/manageTriggers"
 import a11yConfig from "../support/a11yConfig"
-import { defaultSetup, loginAndGoToUrl } from "../support/helpers"
+import { loginAndVisit } from "../support/helpers"
 import logAccessibilityViolations from "../support/logAccessibilityViolations"
 
 describe("Case list", () => {
-  before(() => {
-    defaultSetup()
-  })
-
   beforeEach(() => {
     cy.task("clearCourtCases")
   })
 
   it("will not find a password in the NEXT_DATA", () => {
-    loginAndGoToUrl()
+    loginAndVisit()
 
     cy.window().its("__NEXT_DATA__.props.pageProps.user.password").should("not.exist")
   })
 
   context("when there are 0 cases", () => {
     it("Should display 0 cases and the user's username when no cases are added", () => {
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.findByText("There are no court cases to show").should("exist")
     })
 
     it("Should not show pagination buttons when there are 0 cases", () => {
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.findByText("Previous page").should("not.exist")
       cy.findByText("Next page").should("not.exist")
@@ -35,7 +31,7 @@ describe("Case list", () => {
     })
 
     it("Should display 0 cases when there are no cases 'locked to me' and hide the bottom pagination bar ", () => {
-      const lockUsernames = ["Bichard02", "Bichard03", null, "A really really really long.name"]
+      const lockUsernames = ["BichardForce02", "BichardForce03", null, "A really really really long.name"]
       cy.task(
         "insertCourtCasesWithFields",
         lockUsernames.map((username) => ({
@@ -45,7 +41,7 @@ describe("Case list", () => {
         }))
       )
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get(".govuk-checkboxes__item").contains("View cases locked to me").click()
       cy.contains("Apply filters").click()
@@ -57,7 +53,7 @@ describe("Case list", () => {
     })
 
     it("Should be accessible", () => {
-      loginAndGoToUrl()
+      loginAndVisit()
       cy.injectAxe()
 
       // Wait for the page to fully load
@@ -70,7 +66,7 @@ describe("Case list", () => {
   context("when there are multiple cases", () => {
     it("Should be accessible", () => {
       cy.task("insertMultipleDummyCourtCases", { numToInsert: 50, force: "01" })
-      loginAndGoToUrl()
+      loginAndVisit()
       cy.injectAxe()
 
       // Wait for the page to fully load
@@ -81,7 +77,7 @@ describe("Case list", () => {
 
     it("Should display all the headings with sorting or not", () => {
       cy.task("insertCourtCasesWithFields", [{ orgForPoliceFilter: "01" }])
-      loginAndGoToUrl()
+      loginAndVisit()
       cy.get("#defendant-name-sort").contains("Defendant name").should("have.attr", "href")
       cy.get("#court-date-sort").contains("Court date").should("have.attr", "href")
       cy.get("#court-name-sort").contains("Court name").should("have.attr", "href")
@@ -93,7 +89,7 @@ describe("Case list", () => {
 
     it("Should display multiple cases", () => {
       cy.task("insertMultipleDummyCourtCases", { numToInsert: 50, force: "01" })
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.findByText(`Case00000`).should("exist")
       cy.findByText(`Case00001`).should("exist")
@@ -102,20 +98,19 @@ describe("Case list", () => {
       cy.findByText(`Case00004`).should("exist")
 
       it("Should not show pagination buttons when there are 0 cases", () => {
-        loginAndGoToUrl()
+        loginAndVisit()
 
         cy.get(".moj-pagination__item").should("not.exist")
       })
 
       it("Should display appropriate pagination results when there are 0 cases", () => {
-        cy.login("bichard01@example.com", "password")
-        cy.visit("/bichard")
+        loginAndVisit()
 
         cy.get("p.moj-pagination__results").should("contain.text", "Showing 0 cases")
       })
 
       it("Should be accessible", () => {
-        loginAndGoToUrl()
+        loginAndVisit()
         cy.injectAxe()
 
         // Wait for the page to fully load
@@ -130,7 +125,7 @@ describe("Case list", () => {
         {
           errorStatus: "Resolved",
           resolutionTimestamp: new Date(),
-          errorResolvedBy: "Bichard01",
+          errorResolvedBy: "GeneralHandler",
           errorResolvedTimestamp: new Date(),
           orgForPoliceFilter: "01"
         },
@@ -138,7 +133,7 @@ describe("Case list", () => {
         { resolutionTimestamp: null, orgForPoliceFilter: "01" }
       ])
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get(`label[for="resolved"]`).click()
       cy.get("#search").contains("Apply filters").click()
@@ -156,7 +151,7 @@ describe("Case list", () => {
         { errorStatus: "Submitted", orgForPoliceFilter: "01" }
       ])
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get("#search").contains("Apply filters").click()
 
@@ -182,7 +177,7 @@ describe("Case list", () => {
             text: "System note 2"
           },
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 1"
           },
           {
@@ -192,22 +187,22 @@ describe("Case list", () => {
         ],
         [
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 2"
           },
           {
-            user: "bichard02",
+            user: "BichardForce02",
             text: "Test note 3"
           },
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 4"
           }
         ]
       ]
       cy.task("insertCourtCasesWithNotes", { caseNotes: caseNotes, force: "01" })
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get("tr").not(":first").eq(0).get("td:nth-child(5)").contains(`Case00000`)
       cy.get("tr").not(":first").eq(0).get("td:nth-child(6)").should("be.empty")
@@ -218,7 +213,7 @@ describe("Case list", () => {
     it("Should be able to navigate to the case details page and back", () => {
       cy.task("insertMultipleDummyCourtCases", { numToInsert: 3, force: "01" })
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.findByText("Defendant Name 0")
         .should("have.attr", "href")
@@ -248,7 +243,7 @@ describe("Case list", () => {
             text: "System note 2"
           },
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 1"
           },
           {
@@ -258,22 +253,22 @@ describe("Case list", () => {
         ],
         [
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 2"
           },
           {
-            user: "bichard02",
+            user: "BichardForce02",
             text: "Test note 3"
           },
           {
-            user: "bichard01",
+            user: "BichardForce01",
             text: "Test note 4"
           }
         ]
       ]
       cy.task("insertCourtCasesWithNotes", { caseNotes: caseNotes, force: "01" })
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get("tr").not(":first").eq(1).get("td:nth-child(6)").contains(`1 note`).should("exist").trigger("click")
       cy.contains(`Test note 1`).should("exist")
@@ -314,7 +309,7 @@ describe("Case list", () => {
       ]
       cy.task("insertTriggers", { caseId: 0, triggers })
 
-      loginAndGoToUrl()
+      loginAndVisit()
 
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100310 (2)")
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100322")

--- a/cypress/fixtures/canManuallyResolveAndSubmitTestData.json
+++ b/cypress/fixtures/canManuallyResolveAndSubmitTestData.json
@@ -52,7 +52,7 @@
     "canManuallyResolveAndSubmit": false,
     "exceptionLockedByAnotherUser": false,
     "exceptionStatus": "Unresolved",
-    "loggedInAs": "GeneralHandler",
+    "loggedInAs": "NoExceptionsFeatureFlag",
     "exceptionsFeatureFlagEnabled": false
   }
 ]

--- a/cypress/fixtures/users.ts
+++ b/cypress/fixtures/users.ts
@@ -1,0 +1,118 @@
+import User from "services/entities/User"
+import { UserGroup } from "../../src/types/UserGroup"
+import hashedPassword from "./hashedPassword"
+
+const numberedUsers = () => {
+  const newUsers: Record<string, Partial<User> & { groups: UserGroup[] }> = {}
+  for (let i = 1; i < 5; i++) {
+    const user = {
+      username: `BichardForce0${i}`,
+      visibleForces: [`00${i}`],
+      visibleCourts: [`${i}C`],
+      forenames: "Bichard Test User",
+      surname: `Force 0${i}`,
+      email: `bichard.force.0${i}@example.com`,
+      password: hashedPassword,
+      groups: [UserGroup.NewUI, UserGroup.GeneralHandler]
+    }
+    newUsers[user.username] = user
+  }
+  return newUsers
+}
+
+const users: Record<string, Partial<User> & { groups: UserGroup[] }> = {
+  GeneralHandler: {
+    username: "GeneralHandler",
+    visibleForces: ["01"],
+    forenames: "General Handler",
+    surname: "User",
+    email: "generalhandler@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.GeneralHandler, UserGroup.NewUI]
+  },
+  "A really really really long.name": {
+    username: "A really really really long.name",
+    visibleForces: ["01"],
+    forenames: "A Really Really Really Long Name",
+    surname: "User",
+    email: "longname@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.GeneralHandler, UserGroup.NewUI]
+  },
+  Bichard011111: {
+    username: "Bichard011111",
+    visibleForces: ["0011111"],
+    forenames: "Bichard Test",
+    surname: "User",
+    email: "bichard011111@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.GeneralHandler]
+  },
+  TriggerHandler: {
+    username: "TriggerHandler",
+    visibleForces: ["01"],
+    forenames: "Trigger Handler",
+    surname: "User",
+    email: "triggerhandler@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.TriggerHandler]
+  },
+  ExceptionHandler: {
+    username: "ExceptionHandler",
+    visibleForces: ["01"],
+    forenames: "Exception Handler",
+    surname: "User",
+    email: "exceptionhandler@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.ExceptionHandler]
+  },
+  Supervisor: {
+    username: "Supervisor",
+    visibleForces: ["01"],
+    forenames: "Supervisor",
+    surname: "User",
+    email: "supervisor@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.Supervisor]
+  },
+  UserManager: {
+    username: "UserManager",
+    visibleForces: ["01"],
+    forenames: "UserManager",
+    surname: "User",
+    email: "usermanager@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.UserManager]
+  },
+  MultigroupSupervisor: {
+    username: "MultigroupSupervisor",
+    visibleForces: ["01"],
+    forenames: "MultigroupSupervisor",
+    surname: "User",
+    email: "multigroupsupervisor@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI, UserGroup.Supervisor, UserGroup.ExceptionHandler]
+  },
+  NoGroups: {
+    username: "NoGroups",
+    visibleForces: ["01"],
+    forenames: "No Groups",
+    surname: "User",
+    email: "nogroups@example.com",
+    password: hashedPassword,
+    groups: [UserGroup.NewUI]
+  },
+  NoExceptionsFeatureFlag: {
+    username: "NoExceptionsFeatureFlag",
+    visibleForces: ["01"],
+    forenames: "No Exceptions Feature Flag",
+    surname: "User",
+    email: "noexceptionsfeatureflag@example.com",
+    password: hashedPassword,
+    featureFlags: { exceptionsEnabled: false },
+    groups: [UserGroup.NewUI, UserGroup.GeneralHandler]
+  },
+  ...numberedUsers()
+}
+
+export default users

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -1,10 +1,7 @@
 import SurveyFeedback from "services/entities/SurveyFeedback"
-import User from "services/entities/User"
 import CaseDetailsTab from "types/CaseDetailsTab"
-import { UserGroup } from "types/UserGroup"
-import { userAccess } from "utils/userPermissions"
 import CourtCase from "../../src/services/entities/CourtCase"
-import hashedPassword from "../fixtures/hashedPassword"
+import users from "../fixtures/users"
 
 export function confirmFiltersAppliedContains(filterTag: string) {
   cy.get(".moj-filter-tags").contains(filterTag)
@@ -51,35 +48,29 @@ export const filterByDateRange = (dateFrom: string, dateTo: string) => {
   cy.get(`label[for="date-to"]`).type(dateTo)
 }
 
-export const loginAndGoToUrl = (emailAddress = "bichard01@example.com", url = "/bichard") => {
-  cy.login(emailAddress, "password")
+export const loginAndVisit = (userArg?: string, urlArg?: string) => {
+  let user = "GeneralHandler"
+  let url = "/bichard"
+
+  if (userArg && !urlArg) {
+    if (userArg in users) {
+      user = userArg
+    } else if (userArg.startsWith("/")) {
+      url = userArg
+    } else {
+      throw new Error("Invalid arguments to loginAndVisit")
+    }
+  } else if (urlArg && userArg) {
+    user = userArg
+    url = urlArg
+  }
+
+  cy.loginAs(user)
   cy.visit(url)
 }
 
 export const clickTab = (tab: CaseDetailsTab) => {
   cy.get(".moj-sub-navigation a").contains(tab).click()
-}
-
-export const newUserLogin = ({ user, groups }: { user?: string; groups?: UserGroup[] }) => {
-  user = user ?? (groups?.map((g) => g.toLowerCase()).join("") || "nogroups")
-  const email = `${user}@example.com`
-
-  cy.task("insertUsers", {
-    users: [
-      {
-        username: user,
-        visibleForces: ["01"],
-        forenames: "Bichard Test User",
-        surname: "01",
-        email: email,
-        password: hashedPassword,
-        hasAccessTo: userAccess({ groups: groups ?? [] })
-      }
-    ],
-    userGroups: [UserGroup.NewUI, ...(groups ?? [])]
-  })
-
-  cy.login(email, "password")
 }
 
 export const confirmCaseDisplayed = (PTIURN: string) => {
@@ -103,92 +94,6 @@ export const expectToHaveNumberOfFeedbacks = (number: number) => {
     const feedbackResults = result as SurveyFeedback[]
     expect(feedbackResults.length).equal(number)
   })
-}
-
-export const setupDefaultUsers = () => {
-  const defaultUsers: Partial<User>[] = Array.from(Array(5)).map((_value, idx) => {
-    return {
-      username: `Bichard0${idx}`,
-      visibleForces: [`00${idx}`],
-      visibleCourts: [`${idx}C`],
-      forenames: "Bichard Test User",
-      surname: `0${idx}`,
-      email: `bichard0${idx}@example.com`,
-      password: hashedPassword
-    }
-  })
-  defaultUsers.push({
-    username: `Bichard011111`,
-    visibleForces: [`0011111`],
-    forenames: "Bichard Test User",
-    surname: `011111`,
-    email: `bichard011111@example.com`,
-    password: hashedPassword
-  })
-  defaultUsers.push({
-    username: `TriggerHandler`,
-    visibleForces: [`0011111`],
-    forenames: "Trigger Handler User",
-    surname: `011111`,
-    email: `triggerhandler@example.com`,
-    password: hashedPassword
-  })
-  defaultUsers.push({
-    username: `ExceptionHandler`,
-    visibleForces: [`0011111`],
-    forenames: "Exception Handler User",
-    surname: `011111`,
-    email: `exceptionhandler@example.com`,
-    password: hashedPassword
-  })
-  defaultUsers.push({
-    username: `GeneralHandler`,
-    visibleForces: [`0011111`],
-    forenames: "General Handler User",
-    surname: `011111`,
-    email: `generalhandler@example.com`,
-    password: hashedPassword
-  })
-  defaultUsers.push({
-    username: `Supervisor`,
-    visibleForces: [`0011111`],
-    forenames: "Sup",
-    surname: "User",
-    email: "supervisor@example.com",
-    password: hashedPassword
-  })
-  defaultUsers.push({
-    username: `NoGroups`,
-    visibleForces: [`0011111`],
-    forenames: "No",
-    surname: "Groups",
-    email: "nogroups@example.com",
-    password: hashedPassword
-  })
-
-  return defaultUsers
-}
-
-export const defaultSetup = () => {
-  const defaultUsers = setupDefaultUsers()
-  cy.task("clearAllFeedbacksFromDatabase")
-  cy.task("clearUsers")
-  cy.task("insertUsers", { users: defaultUsers, userGroups: ["B7NewUI_grp"] })
-  defaultUsers
-    .filter((u) => u.forenames === "Bichard Test User")
-    .map((user) => {
-      cy.task("insertIntoUserGroup", { emailAddress: user.email, groupName: "B7GeneralHandler_grp" })
-    })
-  cy.task("insertIntoUserGroup", { emailAddress: "triggerhandler@example.com", groupName: "B7TriggerHandler_grp" })
-  cy.task("insertIntoUserGroup", {
-    emailAddress: "exceptionhandler@example.com",
-    groupName: "B7ExceptionHandler_grp"
-  })
-  cy.task("insertIntoUserGroup", {
-    emailAddress: "generalhandler@example.com",
-    groupName: "B7GeneralHandler_grp"
-  })
-  cy.task("insertIntoUserGroup", { emailAddress: "supervisor@example.com", groupName: "B7Supervisor_grp" })
 }
 
 export const verifyUpdatedMessage = (args: {

--- a/cypress/support/logAccessibilityViolations.ts
+++ b/cypress/support/logAccessibilityViolations.ts
@@ -2,6 +2,7 @@
 import { Result } from "axe-core"
 
 const logAccessibilityViolations = (violations: Result[]) => {
+  console.log(violations)
   const violationData = violations.map(({ id, impact, description, nodes }) => ({
     id,
     impact,

--- a/scripts/insert-dummy-court-case.ts
+++ b/scripts/insert-dummy-court-case.ts
@@ -2,8 +2,8 @@ import { insertCourtCasesWithFields } from "../test/utils/insertCourtCases"
 
 insertCourtCasesWithFields([
   {
-    errorLockedByUsername: "Bichard01",
-    triggerLockedByUsername: "Bichard01",
+    errorLockedByUsername: "BichardForce01",
+    triggerLockedByUsername: "BichardForce01",
     orgForPoliceFilter: "02"
   }
 ])

--- a/scripts/seed-data.ts
+++ b/scripts/seed-data.ts
@@ -45,7 +45,7 @@ getDataSource().then(async (dataSource) => {
     .map((courtCase) => courtCase.notes)
     .flat()
 
-  await Promise.all(courtCases.map((courtCase) => insertLockUsers(courtCase)))
+  await Promise.all(courtCases.map((courtCase) => insertLockUsers(courtCase, true)))
   await Promise.all(courtCaseNotes.map((courtCaseNote) => insertNoteUser(courtCaseNote)))
 
   await insertManyIntoDynamoTable(auditLogs)

--- a/src/services/entities/SurveyFeedback.ts
+++ b/src/services/entities/SurveyFeedback.ts
@@ -1,6 +1,8 @@
-import { Column, Entity, PrimaryColumn } from "typeorm"
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn, type Relation } from "typeorm"
 import type { SurveyFeedbackResponse, SwitchingFeedbackResponse } from "types/SurveyFeedback"
 import { SurveyFeedbackType } from "../../types/SurveyFeedback"
+// eslint-disable-next-line import/no-cycle
+import User from "./User"
 import dateTransformer from "./transformers/dateTransformer"
 import jsonTransformer from "./transformers/jsonTransformer"
 
@@ -20,4 +22,8 @@ export default class SurveyFeedback {
 
   @Column({ name: "created_at", type: "timestamp", transformer: dateTransformer })
   createdAt!: Date
+
+  @ManyToOne(() => User, (user) => user.surveyFeedback)
+  @JoinColumn({ name: "user_id", referencedColumnName: "id" })
+  user!: Relation<User>
 }

--- a/src/services/entities/User.ts
+++ b/src/services/entities/User.ts
@@ -6,6 +6,8 @@ import delimitedString from "./transformers/delimitedString"
 import jsonTransformer from "./transformers/jsonTransformer"
 // eslint-disable-next-line import/no-cycle
 import Note from "./Note"
+// eslint-disable-next-line import/no-cycle
+import SurveyFeedback from "./SurveyFeedback"
 
 @Entity({ name: "users" })
 export default class User {
@@ -42,6 +44,10 @@ export default class User {
   @OneToMany(() => Note, (note) => note.user)
   @JoinColumn({ name: "user_id" })
   notes!: Relation<Note>[]
+
+  @OneToMany(() => SurveyFeedback, (surveyFeedback) => surveyFeedback.user)
+  @JoinColumn({ name: "user_id" })
+  surveyFeedback!: Relation<User>[]
 
   groups: UserGroup[] = []
 

--- a/test/services/addNote.integration.test.ts
+++ b/test/services/addNote.integration.test.ts
@@ -16,7 +16,7 @@ const existingCourtCasesDbObject = {
   orgForPoliceFilter: "36FPA1".padEnd(6, " "),
   errorId: 0
 }
-const currentUsername = "username"
+const currentUsername = "GeneralHandler"
 
 describe("addNote", () => {
   let dataSource: DataSource
@@ -64,7 +64,7 @@ describe("addNote", () => {
     await insertCourtCasesWithFields([
       {
         messageId: uuid(),
-        errorLockedByUsername: "DisplayPartialUser",
+        errorLockedByUsername: "BichardForce01",
         triggerLockedByUsername: currentUsername,
         ...existingCourtCasesDbObject
       }
@@ -86,8 +86,8 @@ describe("addNote", () => {
       {
         ...existingCourtCasesDbObject,
         messageId: uuid(),
-        errorLockedByUsername: "DisplayPartialUser",
-        triggerLockedByUsername: "another user"
+        errorLockedByUsername: "BichardForce01",
+        triggerLockedByUsername: "BichardForce02"
       }
     ])
 

--- a/test/services/amendCourtCase.integration.test.ts
+++ b/test/services/amendCourtCase.integration.test.ts
@@ -1,3 +1,4 @@
+import parseAhoXml from "@moj-bichard7-developers/bichard7-next-core/core/phase1/parse/parseAhoXml/parseAhoXml"
 import fs from "fs"
 import amendCourtCase from "services/amendCourtCase"
 import CourtCase from "services/entities/CourtCase"
@@ -10,7 +11,6 @@ import createForceOwner from "utils/createForceOwner"
 import getCourtCase from "../../src/services/getCourtCase"
 import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases, insertCourtCasesWithFields } from "../utils/insertCourtCases"
-import parseAhoXml from "@moj-bichard7-developers/bichard7-next-core/core/phase1/parse/parseAhoXml/parseAhoXml"
 
 jest.mock("services/getCourtCase")
 jest.mock("services/updateCourtCaseAho")
@@ -20,7 +20,7 @@ jest.mock("utils/createForceOwner")
 jest.setTimeout(60 * 60 * 1000)
 
 describe("amend court case", () => {
-  const userName = "Bichard01"
+  const userName = "BichardForce01"
   const orgCode = "36FPA1"
   const user = {
     username: userName,
@@ -80,7 +80,7 @@ describe("amend court case", () => {
 
   it("Should amend the court case when the lock is held by the current user", async () => {
     const inputCourtCase = await getDummyCourtCase({
-      errorLockedByUsername: "Bichard01",
+      errorLockedByUsername: "BichardForce01",
       triggerLockedByUsername: null,
       errorCount: 1,
       errorStatus: "Unresolved",
@@ -185,7 +185,7 @@ describe("amend court case", () => {
   it("Should not update the db if the error is locked by somebody else", async () => {
     const [errorLockedBySomeoneElse, triggerLockedBySomeoneElse] = await insertCourtCasesWithFields([
       {
-        errorLockedByUsername: "Bichard02",
+        errorLockedByUsername: "BichardForce02",
         triggerLockedByUsername: user.username,
         errorCount: 1,
         triggerCount: 1,
@@ -197,7 +197,7 @@ describe("amend court case", () => {
       },
       {
         errorLockedByUsername: user.username,
-        triggerLockedByUsername: "Bichard02",
+        triggerLockedByUsername: "BichardForce02",
         errorCount: 1,
         triggerCount: 1,
         phase: 1,

--- a/test/services/entities/CourtCase.test.ts
+++ b/test/services/entities/CourtCase.test.ts
@@ -98,10 +98,10 @@ describe("CourtCase", () => {
       const courtCase = new CourtCase()
       courtCase.triggerStatus = triggers as ResolutionStatus
       courtCase.errorStatus = exceptions as ResolutionStatus
-      courtCase.triggerLockedByUsername = triggersLockedByAnotherUser === "are" ? "Bichard02" : ""
-      courtCase.errorLockedByUsername = exceptionLockedByAnotherUser === "are" ? "Bichard02" : ""
+      courtCase.triggerLockedByUsername = triggersLockedByAnotherUser === "are" ? "BichardForce02" : ""
+      courtCase.errorLockedByUsername = exceptionLockedByAnotherUser === "are" ? "BichardForce02" : ""
 
-      const result = courtCase.canReallocate("Bichard01")
+      const result = courtCase.canReallocate("BichardForce01")
 
       expect(result).toBe(expectedResult)
     }

--- a/test/services/listCourtCases/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases/listCourtCases.integration.test.ts
@@ -92,7 +92,7 @@ describe("listCourtCases", () => {
           text: "System note 2"
         },
         {
-          user: "bichard01",
+          user: "BichardForce01",
           text: "Test note 1"
         },
         {
@@ -102,15 +102,15 @@ describe("listCourtCases", () => {
       ],
       [
         {
-          user: "bichard01",
+          user: "BichardForce01",
           text: "Test note 2"
         },
         {
-          user: "bichard02",
+          user: "BichardForce02",
           text: "Test note 3"
         },
         {
-          user: "bichard01",
+          user: "BichardForce01",
           text: "Test note 2"
         }
       ]
@@ -162,15 +162,15 @@ describe("listCourtCases", () => {
     it("shouldn't return more cases than the specified maxPageItems when cases have notes", async () => {
       const caseNote: { user: string; text: string }[] = [
         {
-          user: "bichard01",
+          user: "BichardForce01",
           text: "Test note 2"
         },
         {
-          user: "bichard02",
+          user: "BichardForce02",
           text: "Test note 3"
         },
         {
-          user: "bichard01",
+          user: "BichardForce01",
           text: "Test note 2"
         }
       ]
@@ -389,9 +389,21 @@ describe("listCourtCases", () => {
   describe("filter by cases allocated to me", () => {
     it("Should list cases that are locked to me", async () => {
       await insertCourtCasesWithFields([
-        { errorLockedByUsername: "User1", triggerLockedByUsername: "User1", orgForPoliceFilter: orgCode },
-        { errorLockedByUsername: "User2", triggerLockedByUsername: "User2", orgForPoliceFilter: orgCode },
-        { errorLockedByUsername: "User3", triggerLockedByUsername: "User3", orgForPoliceFilter: orgCode }
+        {
+          errorLockedByUsername: "BichardForce01",
+          triggerLockedByUsername: "BichardForce01",
+          orgForPoliceFilter: orgCode
+        },
+        {
+          errorLockedByUsername: "BichardForce02",
+          triggerLockedByUsername: "BichardForce02",
+          orgForPoliceFilter: orgCode
+        },
+        {
+          errorLockedByUsername: "BichardForce03",
+          triggerLockedByUsername: "BichardForce03",
+          orgForPoliceFilter: orgCode
+        }
       ])
 
       const resultBefore = await listCourtCases(
@@ -405,19 +417,19 @@ describe("listCourtCases", () => {
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
       expect(casesBefore).toHaveLength(3)
-      expect(casesBefore[0].errorLockedByUsername).toStrictEqual("User1")
-      expect(casesBefore[0].triggerLockedByUsername).toStrictEqual("User1")
-      expect(casesBefore[1].errorLockedByUsername).toStrictEqual("User2")
-      expect(casesBefore[1].triggerLockedByUsername).toStrictEqual("User2")
-      expect(casesBefore[2].errorLockedByUsername).toStrictEqual("User3")
-      expect(casesBefore[2].triggerLockedByUsername).toStrictEqual("User3")
+      expect(casesBefore[0].errorLockedByUsername).toStrictEqual("BichardForce01")
+      expect(casesBefore[0].triggerLockedByUsername).toStrictEqual("BichardForce01")
+      expect(casesBefore[1].errorLockedByUsername).toStrictEqual("BichardForce02")
+      expect(casesBefore[1].triggerLockedByUsername).toStrictEqual("BichardForce02")
+      expect(casesBefore[2].errorLockedByUsername).toStrictEqual("BichardForce03")
+      expect(casesBefore[2].triggerLockedByUsername).toStrictEqual("BichardForce03")
       expect(totalCasesBefore).toEqual(3)
 
       const resultAfter = await listCourtCases(
         dataSource,
         {
           maxPageItems: "100",
-          allocatedToUserName: "User1"
+          allocatedToUserName: "BichardForce01"
         },
         testUser
       )
@@ -425,16 +437,16 @@ describe("listCourtCases", () => {
       const { result: casesAfter, totalCases: totalCasesAfter } = resultAfter as ListCourtCaseResult
 
       expect(casesAfter).toHaveLength(1)
-      expect(casesAfter[0].errorLockedByUsername).toStrictEqual("User1")
-      expect(casesAfter[0].triggerLockedByUsername).toStrictEqual("User1")
+      expect(casesAfter[0].errorLockedByUsername).toStrictEqual("BichardForce01")
+      expect(casesAfter[0].triggerLockedByUsername).toStrictEqual("BichardForce01")
       expect(totalCasesAfter).toEqual(1)
     })
 
     it("Should list cases that have triggers locked to me", async () => {
       await insertCourtCasesWithFields([
-        { triggerLockedByUsername: "User1", orgForPoliceFilter: orgCode },
-        { triggerLockedByUsername: "User2", orgForPoliceFilter: orgCode },
-        { triggerLockedByUsername: "User3", orgForPoliceFilter: orgCode }
+        { triggerLockedByUsername: "BichardForce01", orgForPoliceFilter: orgCode },
+        { triggerLockedByUsername: "BichardForce02", orgForPoliceFilter: orgCode },
+        { triggerLockedByUsername: "BichardForce03", orgForPoliceFilter: orgCode }
       ])
 
       const resultBefore = await listCourtCases(
@@ -448,16 +460,16 @@ describe("listCourtCases", () => {
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
       expect(casesBefore).toHaveLength(3)
-      expect(casesBefore[0].triggerLockedByUsername).toStrictEqual("User1")
-      expect(casesBefore[1].triggerLockedByUsername).toStrictEqual("User2")
-      expect(casesBefore[2].triggerLockedByUsername).toStrictEqual("User3")
+      expect(casesBefore[0].triggerLockedByUsername).toStrictEqual("BichardForce01")
+      expect(casesBefore[1].triggerLockedByUsername).toStrictEqual("BichardForce02")
+      expect(casesBefore[2].triggerLockedByUsername).toStrictEqual("BichardForce03")
       expect(totalCasesBefore).toEqual(3)
 
       const resultAfter = await listCourtCases(
         dataSource,
         {
           maxPageItems: "100",
-          allocatedToUserName: "User1"
+          allocatedToUserName: "BichardForce01"
         },
         testUser
       )
@@ -465,15 +477,15 @@ describe("listCourtCases", () => {
       const { result: casesAfter, totalCases: totalCasesAfter } = resultAfter as ListCourtCaseResult
 
       expect(casesAfter).toHaveLength(1)
-      expect(casesAfter[0].triggerLockedByUsername).toStrictEqual("User1")
+      expect(casesAfter[0].triggerLockedByUsername).toStrictEqual("BichardForce01")
       expect(totalCasesAfter).toEqual(1)
     })
 
     it("Should list cases that have errors locked to me", async () => {
       await insertCourtCasesWithFields([
-        { errorLockedByUsername: "User1", orgForPoliceFilter: orgCode },
-        { errorLockedByUsername: "User2", orgForPoliceFilter: orgCode },
-        { errorLockedByUsername: "User3", orgForPoliceFilter: orgCode }
+        { errorLockedByUsername: "BichardForce01", orgForPoliceFilter: orgCode },
+        { errorLockedByUsername: "BichardForce02", orgForPoliceFilter: orgCode },
+        { errorLockedByUsername: "BichardForce03", orgForPoliceFilter: orgCode }
       ])
 
       const resultBefore = await listCourtCases(
@@ -487,16 +499,16 @@ describe("listCourtCases", () => {
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
       expect(casesBefore).toHaveLength(3)
-      expect(casesBefore[0].errorLockedByUsername).toStrictEqual("User1")
-      expect(casesBefore[1].errorLockedByUsername).toStrictEqual("User2")
-      expect(casesBefore[2].errorLockedByUsername).toStrictEqual("User3")
+      expect(casesBefore[0].errorLockedByUsername).toStrictEqual("BichardForce01")
+      expect(casesBefore[1].errorLockedByUsername).toStrictEqual("BichardForce02")
+      expect(casesBefore[2].errorLockedByUsername).toStrictEqual("BichardForce03")
       expect(totalCasesBefore).toEqual(3)
 
       const resultAfter = await listCourtCases(
         dataSource,
         {
           maxPageItems: "100",
-          allocatedToUserName: "User1"
+          allocatedToUserName: "BichardForce01"
         },
         testUser
       )
@@ -504,7 +516,7 @@ describe("listCourtCases", () => {
       const { result: casesAfter, totalCases: totalCasesAfter } = resultAfter as ListCourtCaseResult
 
       expect(casesAfter).toHaveLength(1)
-      expect(casesAfter[0].errorLockedByUsername).toStrictEqual("User1")
+      expect(casesAfter[0].errorLockedByUsername).toStrictEqual("BichardForce01")
       expect(totalCasesAfter).toEqual(1)
     })
   })
@@ -888,7 +900,11 @@ describe("listCourtCases", () => {
   describe("Filter cases by locked status", () => {
     it("Should filter cases that are locked ", async () => {
       await insertCourtCasesWithFields([
-        { errorLockedByUsername: "Bichard01", triggerLockedByUsername: "Bichard01", orgForPoliceFilter: orgCode },
+        {
+          errorLockedByUsername: "BichardForce01",
+          triggerLockedByUsername: "BichardForce01",
+          orgForPoliceFilter: orgCode
+        },
         { orgForPoliceFilter: orgCode }
       ])
 
@@ -911,8 +927,8 @@ describe("listCourtCases", () => {
     it("Should filter cases that are unlocked ", async () => {
       const lockedCase = {
         errorId: 0,
-        errorLockedByUsername: "bichard01",
-        triggerLockedByUsername: "bichard01"
+        errorLockedByUsername: "BichardForce01",
+        triggerLockedByUsername: "BichardForce01"
       }
       const unlockedCase = {
         errorId: 1
@@ -940,11 +956,11 @@ describe("listCourtCases", () => {
       await insertCourtCasesWithFields([
         {
           errorId: 0,
-          errorLockedByUsername: "bichard01"
+          errorLockedByUsername: "BichardForce01"
         },
         {
           errorId: 1,
-          triggerLockedByUsername: "bichard01"
+          triggerLockedByUsername: "BichardForce01"
         },
         {
           errorId: 2

--- a/test/services/lockCourtCase.integration.test.ts
+++ b/test/services/lockCourtCase.integration.test.ts
@@ -21,7 +21,7 @@ jest.mock("services/queries/courtCasesByOrganisationUnitQuery")
 
 describe("lock court case", () => {
   let dataSource: DataSource
-  const lockedByName = "some user"
+  const lockedByName = "BichardForce04"
   const user = {
     username: lockedByName,
     visibleForces: ["36FPA1"],

--- a/test/services/reallocateCourtCase/reallocateCourtCaseToForce.integration.test.ts
+++ b/test/services/reallocateCourtCase/reallocateCourtCaseToForce.integration.test.ts
@@ -120,7 +120,7 @@ describe("reallocate court case to another force", () => {
     it("Should reallocate the case to a new force, generate system notes and unlock the case", async () => {
       const newForceCode = "04"
       const expectedForceOwner = `${newForceCode}YZ00`
-      const userName = "UserName"
+      const userName = "GeneralHandler"
       const [courtCase] = await insertCourtCasesWithFields([
         {
           orgForPoliceFilter: oldForceCode,
@@ -185,7 +185,7 @@ describe("reallocate court case to another force", () => {
     it("Should reallocate the case to a new force, generate system notes, user note, and unlock the case", async () => {
       const newForceCode = "04"
       const expectedForceOwner = `${newForceCode}YZ00`
-      const userName = "UserName"
+      const userName = "GeneralHandler"
       const [courtCase] = await insertCourtCasesWithFields([
         {
           orgForPoliceFilter: oldForceCode,
@@ -202,7 +202,13 @@ describe("reallocate court case to another force", () => {
         hasAccessTo: hasAccessToAll
       } as Partial<User> as User
 
-      const result = await reallocateCourtCaseToForce(dataSource, courtCaseId, user, newForceCode, "Dummy user note")
+      const result = await reallocateCourtCaseToForce(
+        dataSource,
+        courtCaseId,
+        user,
+        newForceCode,
+        "GeneralHandler note"
+      )
       expect(isError(result)).toBe(false)
 
       const record = await dataSource.getRepository(CourtCase).findOne({ where: { errorId: courtCaseId } })
@@ -233,7 +239,7 @@ describe("reallocate court case to another force", () => {
       expect(notes[1].noteText).toEqual(`${userName}: Case reallocated to new force owner: ${expectedForceOwner}`)
 
       expect(notes[2].userId).toEqual(userName)
-      expect(notes[2].noteText).toEqual("Dummy user note")
+      expect(notes[2].noteText).toEqual("GeneralHandler note")
 
       const events = await fetchAuditLogEvents(courtCase.messageId)
       expect(events).toHaveLength(4)
@@ -252,7 +258,7 @@ describe("reallocate court case to another force", () => {
 
   it("Should call functions in order", async () => {
     const newForceCode = "04"
-    const userName = "UserName"
+    const userName = "GeneralHandler"
     await insertCourtCasesWithFields([
       {
         orgForPoliceFilter: oldForceCode,
@@ -290,7 +296,7 @@ describe("reallocate court case to another force", () => {
 
   it("Should not add reallocation trigger (TRPR0028) when case has unresolved exceptions", async () => {
     const newForceCode = "04"
-    const userName = "UserName"
+    const userName = "GeneralHandler"
     await insertCourtCasesWithFields([
       {
         orgForPoliceFilter: oldForceCode,
@@ -329,7 +335,7 @@ describe("reallocate court case to another force", () => {
       ])
 
       const user = {
-        username: "Dummy User",
+        username: "GeneralHandler",
         visibleForces: [oldForceCode],
         visibleCourts: [],
         hasAccessTo: hasAccessToAll
@@ -353,7 +359,7 @@ describe("reallocate court case to another force", () => {
 
   describe("when the case is locked by another user", () => {
     it("Should return an error and not perform any of reallocation steps", async () => {
-      const anotherUser = "Someone Else"
+      const anotherUser = "BichardForce02"
       const [courtCase] = await insertCourtCasesWithFields([
         {
           orgForPoliceFilter: oldForceCode,
@@ -364,7 +370,7 @@ describe("reallocate court case to another force", () => {
       ])
 
       const user = {
-        username: "Dummy User",
+        username: "GeneralHandler",
         visibleForces: [oldForceCode],
         visibleCourts: [],
         hasAccessTo: hasAccessToAll
@@ -376,8 +382,8 @@ describe("reallocate court case to another force", () => {
       const record = await dataSource.getRepository(CourtCase).findOne({ where: { errorId: courtCaseId } })
       const actualCourtCase = record as CourtCase
       expect(actualCourtCase.orgForPoliceFilter).toStrictEqual(`${oldForceCode}    `)
-      expect(actualCourtCase.errorLockedByUsername).toStrictEqual("Someone Else")
-      expect(actualCourtCase.triggerLockedByUsername).toStrictEqual("Someone Else")
+      expect(actualCourtCase.errorLockedByUsername).toStrictEqual(anotherUser)
+      expect(actualCourtCase.triggerLockedByUsername).toStrictEqual(anotherUser)
       expect(actualCourtCase.updatedHearingOutcome).toBeNull()
       expect(actualCourtCase.notes).toHaveLength(0)
 
@@ -388,7 +394,7 @@ describe("reallocate court case to another force", () => {
 
   describe("when there is an unexpected error", () => {
     const user = {
-      username: "Dummy User",
+      username: "GeneralHandler",
       visibleForces: [oldForceCode],
       visibleCourts: [],
       hasAccessTo: hasAccessToAll

--- a/test/services/resolveCourtCase.integration.test.ts
+++ b/test/services/resolveCourtCase.integration.test.ts
@@ -40,7 +40,7 @@ const expectToBeUnresolved = (courtCase: CourtCase) => {
 describe("resolveCourtCase", () => {
   let dataSource: DataSource
   const visibleForce = "36"
-  const resolverUsername = "Resolver User"
+  const resolverUsername = "GeneralHandler"
   const user = {
     visibleCourts: [],
     visibleForces: [visibleForce],
@@ -272,7 +272,7 @@ describe("resolveCourtCase", () => {
     })
 
     it("Should not resolve a case when the case is locked by another user", async () => {
-      const anotherUser = "Another User"
+      const anotherUser = "BichardForce02"
       const [courtCase] = await insertCourtCasesWithFields([
         {
           errorLockedByUsername: anotherUser,

--- a/test/services/resolveTriggers.integration.test.ts
+++ b/test/services/resolveTriggers.integration.test.ts
@@ -26,7 +26,7 @@ describe("resolveTriggers", () => {
     eventCode: string,
     eventType: string,
     triggers: string[],
-    username = "triggerResolver01"
+    username = "TriggerHandler"
   ) => {
     return {
       category: "information",
@@ -49,10 +49,10 @@ describe("resolveTriggers", () => {
     }
   }
 
-  const createTriggersResolvedEvent = (triggers: string[], username = "triggerResolver01") =>
+  const createTriggersResolvedEvent = (triggers: string[], username = "TriggerHandler") =>
     createTriggersEvent("triggers.resolved", "Trigger marked as resolved by user", triggers, username)
 
-  const createAllTriggersResolvedEvent = (triggers: string[], username = "triggerResolver01") =>
+  const createAllTriggersResolvedEvent = (triggers: string[], username = "TriggerHandler") =>
     createTriggersEvent("triggers.all-resolved", "All triggers marked as resolved", triggers, username)
 
   const triggerUnlockedEvent = {
@@ -60,7 +60,7 @@ describe("resolveTriggers", () => {
     eventSource: AUDIT_LOG_EVENT_SOURCE,
     eventType: "Trigger unlocked",
     timestamp: expect.anything(),
-    user: "triggerResolver01",
+    user: "TriggerHandler",
     eventCode: "triggers.unlocked",
     attributes: {
       auditLogVersion: 2
@@ -82,7 +82,7 @@ describe("resolveTriggers", () => {
   })
 
   describe("Mark trigger as resolved", () => {
-    const resolverUsername = "triggerResolver01"
+    const resolverUsername = "TriggerHandler"
     const visibleForce = "36"
     const user = {
       visibleCourts: [],
@@ -253,7 +253,7 @@ describe("resolveTriggers", () => {
       const reResolverUser = {
         visibleCourts: [],
         visibleForces: [visibleForce],
-        username: "triggerResolver02",
+        username: "BichardForce02",
         hasAccessTo: hasAccessToAll
       } as Partial<User> as User
 
@@ -302,7 +302,7 @@ describe("resolveTriggers", () => {
     })
 
     it("Shouldn't resolve a trigger locked by someone else", async () => {
-      const lockHolderUsername = "triggerResolver02"
+      const lockHolderUsername = "BichardForce02"
       const [courtCase] = await insertCourtCasesWithFields([
         {
           triggerLockedByUsername: lockHolderUsername,

--- a/test/services/resubmitCourtCase.integration.test.ts
+++ b/test/services/resubmitCourtCase.integration.test.ts
@@ -7,10 +7,10 @@ import insertNotes from "services/insertNotes"
 import sendToQueue from "services/mq/sendToQueue"
 import resubmitCourtCase from "services/resubmitCourtCase"
 import { DataSource } from "typeorm"
+import { hasAccessToAll } from "../helpers/hasAccessTo"
 import offenceSequenceException from "../test-data/HO100302_1.json"
 import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
-import { hasAccessToAll } from "../helpers/hasAccessTo"
 
 jest.mock("services/mq/sendToQueue")
 jest.mock("services/insertNotes")
@@ -18,7 +18,7 @@ jest.mock("services/insertNotes")
 jest.setTimeout(60 * 60 * 1000)
 
 describe("resubmit court case", () => {
-  const userName = "UserName"
+  const userName = "GeneralHandler"
   let dataSource: DataSource
 
   beforeAll(async () => {
@@ -73,7 +73,11 @@ describe("resubmit court case", () => {
     expect(sendToQueue).toHaveBeenCalledTimes(1)
     expect(insertNotes).toHaveBeenCalledTimes(2)
     expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
-      { errorId: inputCourtCase.errorId, noteText: "UserName: Portal Action: Resubmitted Message.", userId: "System" }
+      {
+        errorId: inputCourtCase.errorId,
+        noteText: "GeneralHandler: Portal Action: Resubmitted Message.",
+        userId: "System"
+      }
     ])
 
     // assert that the xml in the db is as we expect
@@ -135,7 +139,11 @@ describe("resubmit court case", () => {
     expect(sendToQueue).toHaveBeenCalledTimes(1)
     expect(insertNotes).toHaveBeenCalledTimes(2)
     expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
-      { errorId: inputCourtCase.errorId, noteText: "UserName: Portal Action: Resubmitted Message.", userId: "System" }
+      {
+        errorId: inputCourtCase.errorId,
+        noteText: "GeneralHandler: Portal Action: Resubmitted Message.",
+        userId: "System"
+      }
     ])
 
     // parse the retreived case to aho format so we can assert on the values
@@ -217,7 +225,11 @@ describe("resubmit court case", () => {
     expect(sendToQueue).toHaveBeenCalledTimes(1)
     expect(insertNotes).toHaveBeenCalledTimes(2)
     expect(insertNotes).toHaveBeenCalledWith(expect.anything(), [
-      { errorId: inputCourtCase.errorId, noteText: "UserName: Portal Action: Resubmitted Message.", userId: "System" }
+      {
+        errorId: inputCourtCase.errorId,
+        noteText: "GeneralHandler: Portal Action: Resubmitted Message.",
+        userId: "System"
+      }
     ])
 
     // parse the retreived case to aho format so we can assert on the values

--- a/test/services/unlockCourtCase.integration.test.ts
+++ b/test/services/unlockCourtCase.integration.test.ts
@@ -15,7 +15,6 @@ import { hasAccessToAll } from "../helpers/hasAccessTo"
 import deleteFromDynamoTable from "../utils/deleteFromDynamoTable"
 import deleteFromEntity from "../utils/deleteFromEntity"
 import { insertCourtCasesWithFields } from "../utils/insertCourtCases"
-import { deleteUsers } from "../utils/manageUsers"
 
 jest.mock("services/updateLockStatusToUnlocked")
 jest.mock("services/storeAuditLogEvents")
@@ -23,7 +22,7 @@ jest.mock("services/queries/courtCasesByOrganisationUnitQuery")
 
 describe("unlock court case", () => {
   let dataSource: DataSource
-  const lockedByName = "some user"
+  const lockedByName = "BichardForce04"
   const user = {
     username: lockedByName,
     visibleForces: ["36FPA1"],
@@ -38,7 +37,6 @@ describe("unlock court case", () => {
 
   beforeEach(async () => {
     await deleteFromEntity(CourtCase)
-    await deleteUsers()
     await deleteFromDynamoTable("auditLogTable", "messageId")
     await deleteFromDynamoTable("auditLogEventsTable", "_id")
     ;(updateLockStatusToUnlocked as jest.Mock).mockImplementation(

--- a/test/services/updateCourtCaseStatus.integration.test.ts
+++ b/test/services/updateCourtCaseStatus.integration.test.ts
@@ -1,16 +1,16 @@
+import MockDate from "mockdate"
+import User from "services/entities/User"
+import { isError } from "services/mq/types/Result"
+import updateCourtCaseStatus from "services/updateCourtCaseStatus"
 import { DataSource, UpdateResult } from "typeorm"
+import { ResolutionStatus } from "types/ResolutionStatus"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 import deleteFromEntity from "../utils/deleteFromEntity"
 import { getDummyCourtCase, insertCourtCases } from "../utils/insertCourtCases"
-import updateCourtCaseStatus from "services/updateCourtCaseStatus"
-import { isError } from "services/mq/types/Result"
-import { ResolutionStatus } from "types/ResolutionStatus"
-import User from "services/entities/User"
-import MockDate from "mockdate"
 
 const courtCaseId = 0
-const testUser = { username: "Test user" } as User
+const testUser = { username: "GeneralHandler" } as User
 
 const insertRecord = async (
   errorLockedByUsername: string | null = null,
@@ -65,7 +65,7 @@ describe("updateCourtCaseStatus", () => {
 
   describe("Updating error status", () => {
     it("Should not update the case if its locked by another user", async () => {
-      const errorLockedByUsername = "Another User"
+      const errorLockedByUsername = "BichardForce02"
       const [courtCase] = await insertRecord(errorLockedByUsername)
 
       const result = await updateCourtCaseStatus(dataSource, courtCase, "Error", "Submitted", testUser)

--- a/test/utils/insertCourtCases.ts
+++ b/test/utils/insertCourtCases.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
+import fs from "fs"
 import Note from "services/entities/Note"
 import Trigger from "services/entities/Trigger"
 import { ResolutionStatus } from "types/ResolutionStatus"
@@ -7,15 +9,13 @@ import { v4 as uuid } from "uuid"
 import CourtCase from "../../src/services/entities/CourtCase"
 import getDataSource from "../../src/services/getDataSource"
 import createAuditLogRecord from "../helpers/createAuditLogRecord"
+import CustomExceptions from "../test-data/CustomExceptions.json"
 import DummyMultipleOffencesAho from "../test-data/HO100102_1.json"
 import DummyCustomOffences from "../test-data/HO100102_1_multiple_offences.json"
-import CustomExceptions from "../test-data/CustomExceptions.json"
 import DummyCourtCase from "./DummyCourtCase"
 import { insertLockUsers } from "./insertLockUsers"
 import insertManyIntoDynamoTable from "./insertManyIntoDynamoTable"
 import { insertNoteUser } from "./insertNoteUser"
-import fs from "fs"
-import { ExceptionCode } from "@moj-bichard7-developers/bichard7-next-core/core/types/ExceptionCode"
 
 const getAhoWithMultipleOffences = (offenceCount: number) => {
   const offenceXml = fs.readFileSync("test/test-data/offence.xml").toString()
@@ -119,8 +119,8 @@ const insertDummyCourtCasesWithNotesAndLock = async (
   return insertCourtCasesWithFields(
     caseNotes.map((notes, index) => ({
       orgForPoliceFilter: orgCode,
-      errorLockedByUsername: "random user",
-      triggerLockedByUsername: "another random user",
+      errorLockedByUsername: "BichardForce03",
+      triggerLockedByUsername: "BichardForce03",
       notes: notes.map(
         (note, _) =>
           ({
@@ -158,9 +158,9 @@ const insertDummyCourtCasesWithTriggers = async (
 }
 
 export {
-  getDummyCourtCase,
-  getAhoWithMultipleOffences,
   getAhoWithCustomExceptions,
+  getAhoWithMultipleOffences,
+  getDummyCourtCase,
   insertCourtCases,
   insertCourtCasesWithFields,
   insertDummyCourtCasesWithNotes,

--- a/test/utils/insertNoteUser.ts
+++ b/test/utils/insertNoteUser.ts
@@ -1,10 +1,8 @@
-import { InsertResult } from "typeorm"
 import Note from "services/entities/Note"
-import { getDummyUser } from "./manageUsers"
-import { insertUsers } from "./manageUsers"
+import { getDummyUser, insertUsers } from "./manageUsers"
 import { formatForenames, formatSurname } from "./userName"
 
-export const insertNoteUser = async (lockedCase: Note): Promise<InsertResult> => {
+export const insertNoteUser = async (lockedCase: Note): Promise<null> => {
   const username = lockedCase.userId
   const [forenames, surname] = username.split(".")
   const user = await getDummyUser({

--- a/test/utils/manageExceptions.ts
+++ b/test/utils/manageExceptions.ts
@@ -21,7 +21,7 @@ export default async (
         errorReport: () =>
           `(CASE WHEN (error_report = '') THEN '${errorReport}' ELSE error_report || ', ' || '${errorReport}' END)`
       }),
-      errorResolvedBy: exceptionResolved === "Resolved" ? username ?? "Dummy UserName" : null,
+      errorResolvedBy: exceptionResolved === "Resolved" ? username ?? "BichardForce03" : null,
       errorResolvedTimestamp: exceptionResolved === "Resolved" ? new Date() : null,
       errorStatus: exceptionResolved ?? "Unresolved"
     })

--- a/test/utils/manageFeedbackSurveys.ts
+++ b/test/utils/manageFeedbackSurveys.ts
@@ -1,4 +1,5 @@
 import SurveyFeedback from "services/entities/SurveyFeedback"
+import User from "services/entities/User"
 import getDataSource from "services/getDataSource"
 import { InsertResult } from "typeorm"
 
@@ -7,9 +8,14 @@ const deleteFeedback = async () => {
   return dataSource.manager.query(`DELETE FROM br7own.survey_feedback;`)
 }
 
-const insertFeedback = async (feedback: Partial<SurveyFeedback>): Promise<InsertResult> => {
+const insertFeedback = async (feedback: Partial<SurveyFeedback> & { username: string }): Promise<InsertResult> => {
+  const dataSource = await getDataSource()
+  const user = await dataSource.getRepository(User).findOne({ where: { username: feedback.username } })
+  if (!user) {
+    throw new Error("Nonexistent user in insertFeedback")
+  }
   return (await getDataSource()).getRepository(SurveyFeedback).insert({
-    userId: 0,
+    userId: user.id,
     response: {},
     feedbackType: 0,
     ...feedback
@@ -17,7 +23,9 @@ const insertFeedback = async (feedback: Partial<SurveyFeedback>): Promise<Insert
 }
 
 const getAllFeedbacksFromDatabase = async (): Promise<SurveyFeedback[]> => {
-  const feedbacks = await (await getDataSource()).getRepository(SurveyFeedback).find()
+  const feedbacks = await (await getDataSource()).getRepository(SurveyFeedback).find({
+    relations: { user: true }
+  })
 
   return feedbacks
 }

--- a/test/utils/manageTriggers.ts
+++ b/test/utils/manageTriggers.ts
@@ -25,16 +25,17 @@ const insertTriggers = async (caseId: number, triggers: TestTrigger[], username?
     .values(
       triggers.map((t) => ({
         resolvedAt: t.status === "Resolved" ? new Date() : null,
-        resolvedBy: t.status === "Resolved" ? username ?? "Dummy User" : null,
+        resolvedBy: t.status === "Resolved" ? username ?? "GeneralHandler" : null,
         errorId: caseId,
         ...t
       }))
     )
     .execute()
 
+  const triggerResolutionUser = triggers.map((t) => t.resolvedBy)[0] ?? "GeneralHandler"
   const allResolvedTriggers = triggers.filter((t) => t.status === "Resolved")
   const allTriggersResolved = allResolvedTriggers.length === triggers.length
-  const triggerResolvedBy = allTriggersResolved ? username ?? "Dummy User" : null
+  const triggerResolvedBy = allTriggersResolved ? username ?? triggerResolutionUser : null
 
   await dataSource
     .createQueryBuilder()


### PR DESCRIPTION
This is a bit of an epic refactor of the Cypress and integration tests which:
 - stops them from wiping out the users in the database (and making your local Bichard unusable)
 - standardises setting up new users so you don't have to manually create them in all of the tests
 - creates a shortcut which creates (if necessary) the user, logs in as them and visits a URL