### PR TITLE
Tidy up some of the types used in the case list search

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   moduleNameMapper: {
+    "^defaults$": "<rootDir>/src/defaults.ts",
     "^config$": "<rootDir>/src/config.ts",
     "^types/(.*)$": "<rootDir>/src/types/$1",
     "^lib/(.*)$": "<rootDir>/src/lib/$1",

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import defaults from "defaults"
 import ConditionalRender from "../ConditionalRender"
 import CasesPerPage from "./CasesPerPage"
 import { PaginationBar } from "./Pagination.styles"
@@ -5,13 +6,18 @@ import PaginationNavigation from "./PaginationNavigation"
 import PaginationResults from "./PaginationResults"
 
 interface Props {
-  pageNum: number
-  casesPerPage: number
+  pageNum?: number
+  casesPerPage?: number
   totalCases: number
   name?: string
 }
 
-const Pagination: React.FC<Props> = ({ pageNum, casesPerPage, totalCases, name }: Props) => {
+const Pagination: React.FC<Props> = ({
+  pageNum = 1,
+  casesPerPage = defaults.maxPageItems,
+  totalCases,
+  name
+}: Props) => {
   return (
     <ConditionalRender isRendered={totalCases > 0}>
       <PaginationBar id={`${name}-pagination-bar`} className={"pagination-bar"}>

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,5 @@
+const defaults = {
+  maxPageItems: 50
+}
+
+export default defaults

--- a/src/features/CourtCaseFilters/AppliedFilters.tsx
+++ b/src/features/CourtCaseFilters/AppliedFilters.tsx
@@ -10,7 +10,7 @@ import { formatStringDateAsDisplayedDate } from "utils/formattedDate"
 interface Props {
   filters: {
     reason?: Reason | null
-    defendantName?: string[]
+    defendantName?: string | null
     courtName?: string | null
     reasonCodes?: string[]
     ptiurn?: string | null
@@ -26,7 +26,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
 
   const hasAnyAppliedFilters = (): boolean =>
     (!!filters.reason && filters.reason !== Reason.All) ||
-    (filters.defendantName && filters.defendantName.length > 0) ||
+    !!filters.defendantName ||
     (filters.caseAge && filters.caseAge.length > 0) ||
     !!filters.courtName ||
     !!filters.reasonCodes?.length ||
@@ -71,19 +71,22 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
           <li>
             <p className="govuk-heading-s govuk-!-margin-bottom-0">{"Filters applied:"}</p>
           </li>
+
           <ConditionalRender isRendered={!!filters.reason && filters.reason !== Reason.All}>
             <li key={`${filters.reason}`}>
               <FilterTag tag={filters.reason ?? ""} href={removeFilterFromPath({ type: filters.reason ?? "" })} />
             </li>
           </ConditionalRender>
-          {filters.defendantName &&
-            filters.defendantName.map((defendantName) => {
-              return (
-                <li key={`${defendantName}`}>
-                  <FilterTag tag={defendantName} href={removeFilterFromPath({ defendantName })} />
-                </li>
-              )
-            })}
+
+          <ConditionalRender isRendered={!!filters.defendantName}>
+            <li key={`${filters.defendantName}`}>
+              <FilterTag
+                tag={filters.defendantName ?? ""}
+                href={removeFilterFromPath({ defendantName: filters.defendantName ?? "" })}
+              />
+            </li>
+          </ConditionalRender>
+
           <ConditionalRender isRendered={!!filters.courtName}>
             <li>
               <FilterTag
@@ -92,6 +95,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </ConditionalRender>
+
           <ConditionalRender isRendered={!!filters.reasonCodes}>
             {filters.reasonCodes?.map((reasonCode) => (
               <li key={`applied-filter-${reasonCode}`}>
@@ -99,11 +103,13 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               </li>
             ))}
           </ConditionalRender>
+
           <ConditionalRender isRendered={!!filters.ptiurn}>
             <li>
               <FilterTag tag={filters.ptiurn ?? ""} href={removeFilterFromPath({ ptiurn: filters.ptiurn ?? "" })} />
             </li>
           </ConditionalRender>
+
           {filters.caseAge &&
             filters.caseAge.map((slaDate) => {
               return (
@@ -112,6 +118,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
                 </li>
               )
             })}
+
           <ConditionalRender isRendered={!!filters.dateRange?.from && !!filters.dateRange.to}>
             <li>
               <FilterTag
@@ -122,6 +129,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </ConditionalRender>
+
           <ConditionalRender isRendered={!!filters.lockedState && filters.lockedState !== LockedState.All}>
             <li>
               <FilterTag
@@ -130,6 +138,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </ConditionalRender>
+
           <ConditionalRender isRendered={!!filters.caseState}>
             <li>
               <FilterTag
@@ -138,6 +147,7 @@ const AppliedFilters: React.FC<Props> = ({ filters }: Props) => {
               />
             </li>
           </ConditionalRender>
+
           <li>
             <p className="moj-filter__heading-action" id="clear-filters-applied">
               <a className="govuk-link govuk-link--no-visited-state" href="/bichard?keywords=">

--- a/src/features/CourtCaseFilters/CourtCaseFilter.tsx
+++ b/src/features/CourtCaseFilters/CourtCaseFilter.tsx
@@ -6,7 +6,7 @@ import TextFilter from "components/SearchFilters/TextFilter"
 import { useCurrentUser } from "context/CurrentUserContext"
 import { FormGroup } from "govuk-react"
 import { ChangeEvent, useReducer } from "react"
-import { CaseState, LockedState, Reason, SerializedCourtDateRange } from "types/CaseListQueryParams"
+import { CaseListQueryParams, LockedState, SerializedCourtDateRange } from "types/CaseListQueryParams"
 import type { Filter } from "types/CourtCaseFilter"
 import Permission from "types/Permission"
 import { anyFilterChips } from "utils/filterChips"
@@ -16,24 +16,15 @@ import { SelectedFiltersContainer } from "./CourtCaseFilter.styles"
 import FilterChipSection from "./FilterChipSection"
 import { filtersReducer } from "./reducers/filters"
 
-interface Props {
-  defendantName: string | null
-  courtName: string | null
-  reasonCodes: string[]
-  ptiurn: string | null
-  reason: Reason | null
-  caseAge: string[]
-  caseAgeCounts: Record<string, number>
-  dateRange: SerializedCourtDateRange | null
-  lockedState: string | null
-  caseState: CaseState | null
-  order: string | null
-  orderBy: string | null
-}
-
 const Divider = () => (
   <hr className="govuk-section-break govuk-section-break--m govuk-section-break govuk-section-break--visible" />
 )
+
+type Props = CaseListQueryParams & {
+  caseAge: string[]
+  caseAgeCounts: Record<string, number>
+  dateRange: SerializedCourtDateRange | null
+}
 
 const CourtCaseFilter: React.FC<Props> = ({
   reason,
@@ -48,7 +39,7 @@ const CourtCaseFilter: React.FC<Props> = ({
   caseState,
   order,
   orderBy
-}: Props) => {
+}) => {
   const lockedStateValue = lockedState ?? LockedState.All
   const initialFilterState: Filter = {
     caseAgeFilter: caseAge.map((slaDate) => {
@@ -63,7 +54,7 @@ const CourtCaseFilter: React.FC<Props> = ({
     caseStateFilter: caseState !== null ? { value: caseState, state: "Applied", label: caseState } : {},
     defendantNameSearch: defendantName !== null ? { value: defendantName, state: "Applied", label: defendantName } : {},
     courtNameSearch: courtName !== null ? { value: courtName, state: "Applied", label: courtName } : {},
-    reasonCodes: reasonCodes.map((reasonCode) => ({ value: reasonCode, state: "Applied", label: reasonCode })),
+    reasonCodes: reasonCodes?.map((reasonCode) => ({ value: reasonCode, state: "Applied", label: reasonCode })) ?? [],
     ptiurnSearch: ptiurn !== null ? { value: ptiurn, state: "Applied", label: ptiurn } : {},
     reasonFilter: reason !== null ? { value: reason, state: "Applied" } : {}
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,7 @@ interface Props {
   courtCases: DisplayPartialCourtCase[]
   order: QueryOrder
   reason: Reason | null
-  defendantName: string[]
+  defendantName: string | null
   ptiurn: string | null
   courtName: string | null
   reasonCodes: string[]
@@ -103,7 +103,7 @@ export const getServerSideProps = withMultipleServerSideProps(
       from,
       to
     })
-    const validatedDefendantName = validateQueryParams(defendantName) ? defendantName : undefined
+    const validatedDefendantName = validateQueryParams(defendantName) ? defendantName : null
     const validatedCourtName = validateQueryParams(courtName) ? courtName : undefined
     const validatedreasonCodes = validateQueryParams(reasonCodes)
       ? reasonCodes.split(" ").filter((reasonCode) => reasonCode != "")
@@ -207,7 +207,7 @@ export const getServerSideProps = withMultipleServerSideProps(
         page: parseInt(validatedPageNum, 10) || 1,
         casesPerPage: parseInt(validatedMaxPageItems, 10) || 5,
         reason: validatedReason,
-        defendantName: validatedDefendantName ? [validatedDefendantName] : [],
+        defendantName: validatedDefendantName ? validatedDefendantName : null,
         courtName: validatedCourtName ? validatedCourtName : null,
         reasonCodes: validatedreasonCodes,
         ptiurn: validatedPtiurn ? validatedPtiurn : null,
@@ -293,7 +293,7 @@ const Home: NextPage<Props> = (props) => {
               filter={
                 <CourtCaseFilter
                   reason={reason}
-                  defendantName={defendantName[0]}
+                  defendantName={defendantName}
                   courtName={courtName}
                   reasonCodes={reasonCodes}
                   ptiurn={ptiurn}

--- a/src/services/listCourtCases.ts
+++ b/src/services/listCourtCases.ts
@@ -13,7 +13,7 @@ import leftJoinAndSelectTriggersQuery from "./queries/leftJoinAndSelectTriggersQ
 const listCourtCases = async (
   connection: DataSource,
   {
-    pageNum,
+    page,
     maxPageItems,
     orderBy,
     order,
@@ -30,8 +30,8 @@ const listCourtCases = async (
   }: CaseListQueryParams,
   user: User
 ): PromiseResult<ListCourtCaseResult> => {
-  const pageNumValidated = (pageNum ? parseInt(pageNum, 10) : 1) - 1 // -1 because the db index starts at 0
-  const maxPageItemsValidated = maxPageItems ? parseInt(maxPageItems, 10) : 25
+  const pageNumValidated = (page ? page : 1) - 1 // -1 because the db index starts at 0
+  const maxPageItemsValidated = maxPageItems ? maxPageItems : 25
   const repository = connection.getRepository(CourtCase)
   let query = repository
     .createQueryBuilder("courtCase")

--- a/src/types/CaseListQueryParams.ts
+++ b/src/types/CaseListQueryParams.ts
@@ -26,18 +26,18 @@ export type SerializedCourtDateRange = {
 export type CaseState = "Resolved" | "Unresolved" | undefined
 
 export type CaseListQueryParams = {
-  orderBy?: string
-  order?: QueryOrder
-  reason?: Reason
-  defendantName?: string
-  courtName?: string
-  ptiurn?: string
-  pageNum?: string
-  maxPageItems: string
-  courtDateRange?: CourtDateRange | CourtDateRange[]
-  lockedState?: string
-  caseState?: CaseState
   allocatedToUserName?: string
+  caseState?: CaseState
+  courtDateRange?: CourtDateRange | CourtDateRange[]
+  courtName?: string
+  defendantName?: string
+  lockedState?: string
+  maxPageItems?: number
+  order?: QueryOrder
+  orderBy?: string
+  page?: number
+  ptiurn?: string
+  reason?: Reason
   reasonCodes?: string[]
   resolvedByUsername?: string
 }

--- a/src/utils/pagination/calculateLastPossiblePageNumber.ts
+++ b/src/utils/pagination/calculateLastPossiblePageNumber.ts
@@ -1,2 +1,4 @@
-export const calculateLastPossiblePageNumber = (totalCases: number, maxPageItems: number): number =>
+import defaults from "defaults"
+
+export const calculateLastPossiblePageNumber = (totalCases: number, maxPageItems = defaults.maxPageItems): number =>
   Math.ceil(totalCases / maxPageItems) || 1

--- a/test/services/listCourtCases/filterByReasonAndResolutionStatus.integration.test.ts
+++ b/test/services/listCourtCases/filterByReasonAndResolutionStatus.integration.test.ts
@@ -751,14 +751,7 @@ describe("Filter cases by resolution status", () => {
     ]
 
     it.each(testCases)("$description", async ({ filters, user, expectedCases }) => {
-      const result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          ...filters
-        },
-        user
-      )
+      const result = await listCourtCases(dataSource, { maxPageItems: 100, ...filters }, user)
 
       expect(isError(result)).toBeFalsy()
       const { result: cases } = result as ListCourtCaseResult

--- a/test/services/listCourtCases/listCourtCases.integration.test.ts
+++ b/test/services/listCourtCases/listCourtCases.integration.test.ts
@@ -62,7 +62,7 @@ describe("listCourtCases", () => {
   })
 
   it("Should call cases by organisation unit query", async () => {
-    await listCourtCases(dataSource, { maxPageItems: "1" }, testUser)
+    await listCourtCases(dataSource, { maxPageItems: 1 }, testUser)
 
     expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledTimes(1)
     expect(courtCasesByOrganisationUnitQuery).toHaveBeenCalledWith(expect.any(Object), testUser)
@@ -73,7 +73,7 @@ describe("listCourtCases", () => {
     const caseState = "Resolved"
     const excludedTriggersUser = Object.assign({ excludedTriggers: excludedTriggers }, testUser)
 
-    await listCourtCases(dataSource, { maxPageItems: "1", caseState: caseState }, excludedTriggersUser)
+    await listCourtCases(dataSource, { maxPageItems: 1, caseState: caseState }, excludedTriggersUser)
 
     expect(leftJoinAndSelectTriggersQuery).toHaveBeenCalledTimes(1)
     expect(leftJoinAndSelectTriggersQuery).toHaveBeenCalledWith(expect.any(Object), excludedTriggers, caseState)
@@ -120,7 +120,7 @@ describe("listCourtCases", () => {
     const query = await insertDummyCourtCasesWithNotes(caseNotes, orgCode)
     expect(isError(query)).toBe(false)
 
-    const result = await listCourtCases(dataSource, { maxPageItems: "100" }, testUser)
+    const result = await listCourtCases(dataSource, { maxPageItems: 100 }, testUser)
     expect(isError(result)).toBe(false)
     const { result: cases } = result as ListCourtCaseResult
 
@@ -135,7 +135,7 @@ describe("listCourtCases", () => {
     it("Should return all the cases if they number less than or equal to the specified maxPageItems", async () => {
       await insertCourtCasesWithFields(Array.from(Array(100)).map(() => ({ orgForPoliceFilter: "36FPA1" })))
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "100" }, testUser)
+      const result = await listCourtCases(dataSource, { maxPageItems: 100 }, testUser)
       expect(isError(result)).toBe(false)
       const { result: cases, totalCases } = result as ListCourtCaseResult
 
@@ -149,7 +149,7 @@ describe("listCourtCases", () => {
     it("shouldn't return more cases than the specified maxPageItems", async () => {
       await insertCourtCasesWithFields(Array.from(Array(100)).map(() => ({ orgForPoliceFilter: "36FPA1" })))
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10" }, testUser)
+      const result = await listCourtCases(dataSource, { maxPageItems: 10 }, testUser)
       expect(isError(result)).toBe(false)
       const { result: cases, totalCases } = result as ListCourtCaseResult
 
@@ -180,7 +180,7 @@ describe("listCourtCases", () => {
 
       await insertDummyCourtCasesWithNotes(caseNotes, "01")
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10" }, {
+      const result = await listCourtCases(dataSource, { maxPageItems: 10 }, {
         visibleForces: ["01"],
         visibleCourts: [],
         hasAccessTo: hasAccessToAll
@@ -212,7 +212,7 @@ describe("listCourtCases", () => {
 
       await insertDummyCourtCasesWithTriggers(caseTriggers, "01")
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10" }, {
+      const result = await listCourtCases(dataSource, { maxPageItems: 10 }, {
         visibleForces: ["01"],
         visibleCourts: [],
         hasAccessTo: hasAccessToAll
@@ -229,7 +229,7 @@ describe("listCourtCases", () => {
     it("Should return the next page of items", async () => {
       await insertCourtCasesWithFields(Array.from(Array(100)).map(() => ({ orgForPoliceFilter: "36FPA1" })))
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10", pageNum: "2" }, {
+      const result = await listCourtCases(dataSource, { maxPageItems: 10, page: 2 }, {
         visibleForces: ["36FPA1"],
         visibleCourts: [],
         hasAccessTo: hasAccessToAll
@@ -247,7 +247,7 @@ describe("listCourtCases", () => {
     it("Should return the last page of items correctly", async () => {
       await insertCourtCasesWithFields(Array.from(Array(100)).map(() => ({ orgForPoliceFilter: orgCode })))
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10", pageNum: "10" }, testUser)
+      const result = await listCourtCases(dataSource, { maxPageItems: 10, page: 10 }, testUser)
       expect(isError(result)).toBe(false)
       const { result: cases, totalCases } = result as ListCourtCaseResult
 
@@ -261,7 +261,7 @@ describe("listCourtCases", () => {
     it("shouldn't return any cases if the page number is greater than the total pages", async () => {
       await insertCourtCasesWithFields(Array.from(Array(100)).map(() => ({ orgForPoliceFilter: orgCode })))
 
-      const result = await listCourtCases(dataSource, { maxPageItems: "10", pageNum: "11" }, testUser)
+      const result = await listCourtCases(dataSource, { maxPageItems: 10, page: 11 }, testUser)
       expect(isError(result)).toBe(false)
       const { result: cases, totalCases } = result as ListCourtCaseResult
 
@@ -275,7 +275,7 @@ describe("listCourtCases", () => {
       ["BBBB", "CCCC", "AAAA"].map((courtName) => ({ courtName: courtName, orgForPoliceFilter: orgCode }))
     )
 
-    const resultAsc = await listCourtCases(dataSource, { maxPageItems: "100", orderBy: "courtName" }, testUser)
+    const resultAsc = await listCourtCases(dataSource, { maxPageItems: 100, orderBy: "courtName" }, testUser)
     expect(isError(resultAsc)).toBe(false)
     const { result: casesAsc, totalCases: totalCasesAsc } = resultAsc as ListCourtCaseResult
 
@@ -287,11 +287,7 @@ describe("listCourtCases", () => {
 
     const resultDesc = await listCourtCases(
       dataSource,
-      {
-        maxPageItems: "100",
-        orderBy: "courtName",
-        order: "desc"
-      },
+      { maxPageItems: 100, orderBy: "courtName", order: "desc" },
       testUser
     )
     expect(isError(resultDesc)).toBe(false)
@@ -315,7 +311,7 @@ describe("listCourtCases", () => {
       { courtDate: thirdDate, orgForPoliceFilter: orgCode }
     ])
 
-    const result = await listCourtCases(dataSource, { maxPageItems: "100", orderBy: "courtDate" }, testUser)
+    const result = await listCourtCases(dataSource, { maxPageItems: 100, orderBy: "courtDate" }, testUser)
     expect(isError(result)).toBe(false)
     const { result: cases, totalCases } = result as ListCourtCaseResult
 
@@ -327,11 +323,7 @@ describe("listCourtCases", () => {
 
     const resultDesc = await listCourtCases(
       dataSource,
-      {
-        maxPageItems: "100",
-        orderBy: "courtDate",
-        order: "desc"
-      },
+      { maxPageItems: 100, orderBy: "courtDate", order: "desc" },
       testUser
     )
     expect(isError(resultDesc)).toBe(false)
@@ -356,28 +348,14 @@ describe("listCourtCases", () => {
         { defendantName: defendantToIncludeWithPartialMatch, orgForPoliceFilter: orgCode }
       ])
 
-      let result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          defendantName: "WAYNE Bruce"
-        },
-        testUser
-      )
+      let result = await listCourtCases(dataSource, { maxPageItems: 100, defendantName: "WAYNE Bruce" }, testUser)
       expect(isError(result)).toBe(false)
       let { result: cases } = result as ListCourtCaseResult
 
       expect(cases).toHaveLength(1)
       expect(cases[0].defendantName).toStrictEqual(defendantToInclude)
 
-      result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          defendantName: "WAYNE B"
-        },
-        testUser
-      )
+      result = await listCourtCases(dataSource, { maxPageItems: 100, defendantName: "WAYNE B" }, testUser)
       expect(isError(result)).toBe(false)
       cases = (result as ListCourtCaseResult).result
 
@@ -407,13 +385,7 @@ describe("listCourtCases", () => {
         }
       ])
 
-      const resultBefore = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100"
-        },
-        testUser
-      )
+      const resultBefore = await listCourtCases(dataSource, { maxPageItems: 100 }, testUser)
       expect(isError(resultBefore)).toBe(false)
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
@@ -428,10 +400,7 @@ describe("listCourtCases", () => {
 
       const resultAfter = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          allocatedToUserName: "BichardForce01"
-        },
+        { maxPageItems: 100, allocatedToUserName: "BichardForce01" },
         testUser
       )
       expect(isError(resultAfter)).toBe(false)
@@ -450,13 +419,7 @@ describe("listCourtCases", () => {
         { triggerLockedByUsername: "BichardForce03", orgForPoliceFilter: orgCode }
       ])
 
-      const resultBefore = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100"
-        },
-        testUser
-      )
+      const resultBefore = await listCourtCases(dataSource, { maxPageItems: 100 }, testUser)
       expect(isError(resultBefore)).toBe(false)
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
@@ -468,10 +431,7 @@ describe("listCourtCases", () => {
 
       const resultAfter = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          allocatedToUserName: "BichardForce01"
-        },
+        { maxPageItems: 100, allocatedToUserName: "BichardForce01" },
         testUser
       )
       expect(isError(resultAfter)).toBe(false)
@@ -489,13 +449,7 @@ describe("listCourtCases", () => {
         { errorLockedByUsername: "BichardForce03", orgForPoliceFilter: orgCode }
       ])
 
-      const resultBefore = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100"
-        },
-        testUser
-      )
+      const resultBefore = await listCourtCases(dataSource, { maxPageItems: 100 }, testUser)
       expect(isError(resultBefore)).toBe(false)
       const { result: casesBefore, totalCases: totalCasesBefore } = resultBefore as ListCourtCaseResult
 
@@ -507,10 +461,7 @@ describe("listCourtCases", () => {
 
       const resultAfter = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          allocatedToUserName: "BichardForce01"
-        },
+        { maxPageItems: 100, allocatedToUserName: "BichardForce01" },
         testUser
       )
       expect(isError(resultAfter)).toBe(false)
@@ -536,10 +487,7 @@ describe("listCourtCases", () => {
 
       let result = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          courtName: "Magistrates' Courts London Croydon"
-        },
+        { maxPageItems: 100, courtName: "Magistrates' Courts London Croydon" },
         testUser
       )
       expect(isError(result)).toBe(false)
@@ -550,10 +498,7 @@ describe("listCourtCases", () => {
 
       result = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          courtName: "magistrates' courts london"
-        },
+        { maxPageItems: 100, courtName: "magistrates' courts london" },
         testUser
       )
       expect(isError(result)).toBe(false)
@@ -577,28 +522,14 @@ describe("listCourtCases", () => {
         { ptiurn: ptiurnToNotInclude, orgForPoliceFilter: orgCode }
       ])
 
-      let result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          ptiurn: "01ZD0303908"
-        },
-        testUser
-      )
+      let result = await listCourtCases(dataSource, { maxPageItems: 100, ptiurn: "01ZD0303908" }, testUser)
       expect(isError(result)).toBe(false)
       let { result: cases } = result as ListCourtCaseResult
 
       expect(cases).toHaveLength(1)
       expect(cases[0].ptiurn).toStrictEqual(ptiurnToInclude)
 
-      result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          ptiurn: "01ZD030390"
-        },
-        testUser
-      )
+      result = await listCourtCases(dataSource, { maxPageItems: 100, ptiurn: "01ZD030390" }, testUser)
       expect(isError(result)).toBe(false)
       cases = (result as ListCourtCaseResult).result
 
@@ -644,10 +575,7 @@ describe("listCourtCases", () => {
       // Searching for a full matched trigger code
       let result = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          reasonCodes: [triggerToInclude.triggerCode]
-        },
+        { maxPageItems: 100, reasonCodes: [triggerToInclude.triggerCode] },
         testUser
       )
 
@@ -658,14 +586,7 @@ describe("listCourtCases", () => {
       expect(cases[0].triggers[0].triggerCode).toStrictEqual(triggerToInclude.triggerCode)
 
       // Searching for a full matched error code
-      result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          reasonCodes: [errorToInclude]
-        },
-        testUser
-      )
+      result = await listCourtCases(dataSource, { maxPageItems: 100, reasonCodes: [errorToInclude] }, testUser)
 
       expect(isError(result)).toBe(false)
       cases = (result as ListCourtCaseResult).result
@@ -685,14 +606,7 @@ describe("listCourtCases", () => {
       await insertException(0, anotherErrorToInclude, `${anotherErrorToInclude}||ds:NextHearingDate`)
       await insertException(1, errorNotToInclude, `${errorNotToInclude}||ds:XMLField`)
 
-      let result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          reasonCodes: [errorToInclude]
-        },
-        testUser
-      )
+      let result = await listCourtCases(dataSource, { maxPageItems: 100, reasonCodes: [errorToInclude] }, testUser)
 
       expect(isError(result)).toBe(false)
       let { result: cases } = result as ListCourtCaseResult
@@ -702,14 +616,7 @@ describe("listCourtCases", () => {
         `HO100102||ds:NextHearingDate, ${errorToInclude}||ds:OrganisationUnitCode, ${anotherErrorToInclude}||ds:NextHearingDate`
       )
 
-      result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          reasonCodes: [anotherErrorToInclude]
-        },
-        testUser
-      )
+      result = await listCourtCases(dataSource, { maxPageItems: 100, reasonCodes: [anotherErrorToInclude] }, testUser)
 
       expect(isError(result)).toBe(false)
       cases = (result as ListCourtCaseResult).result
@@ -747,10 +654,7 @@ describe("listCourtCases", () => {
 
       const result = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          reasonCodes: [triggerToInclude.triggerCode, errorToInclude]
-        },
+        { maxPageItems: 100, reasonCodes: [triggerToInclude.triggerCode, errorToInclude] },
         testUser
       )
 
@@ -780,7 +684,7 @@ describe("listCourtCases", () => {
       const result = await listCourtCases(
         dataSource,
         {
-          maxPageItems: "100",
+          maxPageItems: 100,
           courtDateRange: { from: new Date("2008-01-01"), to: new Date("2008-12-31") }
         },
         testUser
@@ -809,7 +713,7 @@ describe("listCourtCases", () => {
       const result = await listCourtCases(
         dataSource,
         {
-          maxPageItems: "100",
+          maxPageItems: 100,
           courtDateRange: [
             { from: new Date("2008-01-26"), to: new Date("2008-01-26") },
             { from: new Date("2008-03-26"), to: new Date("2008-03-26") },
@@ -838,14 +742,7 @@ describe("listCourtCases", () => {
         { orgForPoliceFilter: orgCode }
       ])
 
-      const result = await listCourtCases(
-        dataSource,
-        {
-          maxPageItems: "100",
-          lockedState: LockedState.Locked
-        },
-        testUser
-      )
+      const result = await listCourtCases(dataSource, { maxPageItems: 100, lockedState: LockedState.Locked }, testUser)
 
       expect(isError(result)).toBeFalsy()
       const { result: cases } = result as ListCourtCaseResult
@@ -868,10 +765,7 @@ describe("listCourtCases", () => {
 
       const result = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          lockedState: LockedState.Unlocked
-        },
+        { maxPageItems: 100, lockedState: LockedState.Unlocked },
         testUser
       )
 
@@ -899,10 +793,7 @@ describe("listCourtCases", () => {
 
       const lockedResult = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          lockedState: LockedState.Locked
-        },
+        { maxPageItems: 100, lockedState: LockedState.Locked },
         testUser
       )
 
@@ -914,10 +805,7 @@ describe("listCourtCases", () => {
 
       const unlockedResult = await listCourtCases(
         dataSource,
-        {
-          maxPageItems: "100",
-          lockedState: LockedState.Unlocked
-        },
+        { maxPageItems: 100, lockedState: LockedState.Unlocked },
         testUser
       )
 


### PR DESCRIPTION
This is a start towards bringing some consistency to the data structures used in the case list query. This pr:
- Splits out the parsing of query params into its own function (ready to be improved further with zod)
- Uses the `CaseListQueryParams` type more consistently so we're not redefining that structure to pass in as props in other places
- Uses spreading in more places rather than explicitly passing in all of the attributes of the query params