### PR TITLE
Update document tsx to prevent FOUC

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -58,13 +58,20 @@ class GovUkDocument extends Document<DocumentProps> {
     // include styles from both styled-components
     try {
       ctx.renderPage = () => {
-        return originalRenderPage({})
+        return originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />)
+        })
       }
 
       const initialProps = await Document.getInitialProps(ctx)
       const additionalProps = {
         nonce,
-        styles: [initialProps.styles, sheet.getStyleElement()]
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        )
       }
 
       return {


### PR DESCRIPTION
`ServerStyleSheet` stopped working recently - this updates the implementation so that content always appears styled in the first instance rather than needing to wait for JS to finish loading and executing.