### PR TITLE
Enable ASN input field to automatically format input into sections within the text field

### DIFF
--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
@@ -67,7 +67,7 @@ describe("ASN", () => {
     cy.get("#asn").should("not.exist")
   })
 
-  it("Should be not be able to edit ASN field if ASN exception is not raised", () => {
+  it("Should not be able to edit ASN field if ASN exception is not raised", () => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
       {
@@ -198,6 +198,26 @@ describe("ASN", () => {
     })
   })
 
+  it("Should divide ASN into sections when user types or pastes asn into the input field ", () => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        errorCount: 1,
+        errorLockedByUsername: "GeneralHandler"
+      }
+    ])
+
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("#asn").clear()
+    cy.get("#asn").type("1101ZD0100000448754K")
+
+    cy.get("#asn").should("have.value", "11/01ZD/01/00000448754K")
+  })
+
   it("should display the updated ASN after submission along with CORRECTION badge", () => {
     loginAndVisit("/bichard/court-cases/0")
 
@@ -218,7 +238,7 @@ describe("ASN", () => {
 
     cy.get("#asn").type("asdf")
 
-    cy.get(".Defendant-details-table").contains("Invalid ASN format")
+    cy.get(".Defendant-details-table").contains("Enter ASN in the correct format")
   })
 
   it("Should not be able to edit ASN field if case is not locked by the current user", () => {

--- a/src/components/EditableFields/InputField.tsx
+++ b/src/components/EditableFields/InputField.tsx
@@ -15,7 +15,7 @@ const InputField: React.FC<EditableInputFieldProps> = ({ value, inputLabel, hint
       {value}
       <InitialInputValueBadge />
       <br />
-      <Label>{inputLabel}</Label>
+      <Label className="govuk-label">{inputLabel}</Label>
       {hintText &&
         hintText.split("\\n").map((hint, key) => {
           return <HintText key={key}>{hint}</HintText>

--- a/src/components/EditableFields/InputField.tsx
+++ b/src/components/EditableFields/InputField.tsx
@@ -17,7 +17,7 @@ const InputField: React.FC<EditableInputFieldProps> = ({ value, inputLabel, hint
       <br />
       <Label>{inputLabel}</Label>
       {hintText &&
-        hintText.split("\n").map((hint, key) => {
+        hintText.split("\\n").map((hint, key) => {
           return <HintText key={key}>{hint}</HintText>
         })}
       {children}

--- a/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.styles.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.styles.tsx
@@ -1,4 +1,3 @@
-import { Input } from "govuk-react"
 import styled from "styled-components"
 
 const DefendantDetailTable = styled.div`
@@ -7,8 +6,4 @@ const DefendantDetailTable = styled.div`
   }
 `
 
-const AsnInput = styled(Input)`
-  width: 18rem;
-`
-
-export { AsnInput, DefendantDetailTable }
+export { DefendantDetailTable }

--- a/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.styles.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/DefendantDetails.styles.tsx
@@ -8,7 +8,7 @@ const DefendantDetailTable = styled.div`
 `
 
 const AsnInput = styled(Input)`
-  width: 15rem;
+  width: 18rem;
 `
 
 export { AsnInput, DefendantDetailTable }

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.styles.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.styles.tsx
@@ -1,0 +1,17 @@
+import styled from "styled-components"
+import { Input } from "govuk-react"
+
+const AsnInputContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  .checkmark {
+    margin-left: 0.5rem;
+  }
+`
+
+const AsnInput = styled(Input)`
+  width: 16rem;
+`
+
+export { AsnInputContainer, AsnInput }

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -6,9 +6,11 @@ import { useCourtCase } from "context/CourtCaseContext"
 import { useCallback, useEffect, useState, KeyboardEvent, ClipboardEvent } from "react"
 import Asn from "services/Asn"
 import isAsnFormatValid from "utils/isAsnFormatValid"
-import { AsnInput } from "../DefendantDetails.styles"
 import isAsnException from "utils/exceptions/isException/isAsnException"
 import { useCurrentUser } from "context/CurrentUserContext"
+import { CheckmarkIcon } from "../../CourtCaseDetailsSingleTab.styles"
+import { CHECKMARK_ICON_URL } from "utils/icons"
+import { AsnInputContainer, AsnInput } from "./AsnField.styles"
 
 interface AsnFieldProps {
   stopLeavingFn: (newValue: boolean) => void
@@ -127,18 +129,29 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
             <span className="govuk-visually-hidden">{"Error:"}</span> {"Invalid ASN format"}
           </p>
         )}
-        <AsnInput
-          className={`asn-input`}
-          id={"asn"}
-          name={"asn"}
-          onChange={handleAsnChange}
-          value={amendments.asn ?? ""}
-          error={!isValidAsn}
-          onKeyDown={handleOnKeyDown}
-          onPaste={handleOnPaste}
-          onCopy={handleOnCopy}
-          onCut={handleOnCopy}
-        />
+        <AsnInputContainer>
+          <AsnInput
+            className={`asn-input`}
+            id={"asn"}
+            name={"asn"}
+            onChange={handleAsnChange}
+            value={amendments.asn ?? ""}
+            error={!isValidAsn}
+            onKeyDown={handleOnKeyDown}
+            onPaste={handleOnPaste}
+            onCopy={handleOnCopy}
+            onCut={handleOnCopy}
+          />
+          {isValidAsn && (
+            <CheckmarkIcon
+              className={`checkmark-icon checkmark`}
+              src={CHECKMARK_ICON_URL}
+              width={30}
+              height={30}
+              alt="Checkmark icon"
+            />
+          )}
+        </AsnInputContainer>
       </div>
       <SaveLinkButton id={"save-asn"} onClick={handleAsnSave} disabled={isSaveAsnBtnDisabled()} />
     </EditableFieldTableRow>

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -61,22 +61,24 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
     }
   }
 
+  const handleOnKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.code === "Backspace") {
+      setKey(e.code)
+    }
+  }
+
   const handleAsnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const InputAsnValue = e.target.value.toUpperCase()
+    const inputAsnValue = e.target.value.toUpperCase()
 
     if (key === "Backspace") {
-      const asnWithSlashes = Asn.divideAsn(InputAsnValue)
+      const asnWithSlashes = Asn.divideAsn(inputAsnValue)
       amend("asn")(Asn.deleteAsn(asnWithSlashes))
     } else {
-      const asnWithoutSlashes = InputAsnValue.replace(/\//g, "")
+      const asnWithoutSlashes = inputAsnValue.replace(/\//g, "")
       amend("asn")(asnWithoutSlashes)
     }
 
-    setIsValidAsn(isAsnFormatValid(InputAsnValue))
-  }
-
-  const handleOnKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    setKey(e.code)
+    setIsValidAsn(isAsnFormatValid(inputAsnValue))
   }
 
   const handleOnPaste = (e: ClipboardEvent<HTMLInputElement>) => {

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -116,6 +116,11 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
     amend("asn")(splitAsn(asnFromClipboard))
   }
 
+  const handleOnCopy = () => {
+    const copiedAsn = document.getSelection()?.toString().replace(/\//g, "")
+    navigator.clipboard.writeText(copiedAsn ?? "")
+  }
+
   const isSaveAsnBtnDisabled = (): boolean => {
     const formattedAsn = asnString.includes("/") ? asnString : splitAsn(asnString)
     if (updatedAhoAsn === formattedAsn) {
@@ -158,6 +163,8 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
           error={!isValidAsn}
           onKeyDown={handleOnKeyDown}
           onPaste={handleOnPaste}
+          onCopy={handleOnCopy}
+          onCut={handleOnCopy}
         />
       </div>
       <SaveLinkButton id={"save-asn"} onClick={handleAsnSave} disabled={isSaveAsnBtnDisabled()} />

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -44,7 +44,7 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
   const [updatedAhoAsn, setUpdatedAhoAsn] = useState<string>(splitUpdatedAhoAsn)
 
   const [isAsnChanged, setIsAsnChanged] = useState<boolean>(false)
-  const [isValidAsn, setIsValidAsn] = useState<boolean>(isAsnFormatValid(updatedAhoAsn.replace(/\//g, "")))
+  const [isValidAsn, setIsValidAsn] = useState<boolean>(isAsnFormatValid(updatedAhoAsn))
   const [savedAsn, setSavedAsn] = useState<boolean>(false)
   const [asnString, setAsnString] = useState<string>(updatedAhoAsn ?? "")
   const [pageLoad, setPageLoad] = useState<boolean>(false)
@@ -101,10 +101,9 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
       asn = asn + "/"
     }
 
-    const unsplitAsn = asn.replace(/\//g, "")
-    setIsValidAsn(isAsnFormatValid(unsplitAsn))
+    setIsValidAsn(isAsnFormatValid(asn))
     setIsAsnChanged(true)
-    setAsnString(unsplitAsn)
+    setAsnString(asn)
     amend("asn")(asn)
   }
 
@@ -115,8 +114,10 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
   const handleOnPaste = (e: ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault()
     const asnFromClipboard = e.clipboardData.getData("text")
-    amend("asn")(splitAsn(asnFromClipboard))
     setIsValidAsn(isAsnFormatValid(asnFromClipboard))
+    setIsAsnChanged(true)
+    setAsnString(asn)
+    amend("asn")(splitAsn(asnFromClipboard))
   }
 
   const isSaveAsnBtnDisabled = (): boolean => {
@@ -144,8 +145,6 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
       hasExceptions={isAsnEditable}
       isEditable={isAsnEditable}
       inputLabel={"Enter the ASN"}
-      // hintText={`Last 2 digits of year / 4 divisional ID location characters / 2 digits from owning force / 4 \
-      // digits / 1 check letter\nExample: 22 49AB 49 1234 C`}
       hintText="Last 2 digits of year / 4 divisional ID location characters / 2 digits from owning force / 4 digits / 1 check letter\nExample: 22 49AB 49 1234 C"
     >
       <div className={isValidAsn ? "" : "govuk-form-group--error"}>

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -114,12 +114,12 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
       hasExceptions={isAsnEditable}
       isEditable={isAsnEditable}
       inputLabel={"Enter the ASN"}
-      hintText="Last 2 digits of year / 4 divisional ID location characters / 2 digits from owning force / 1 to 11 digits and 1 check letter \n Example: 22 49AB 49 1234 C"
+      hintText="ASN format: Last 2 digits of year / 4 divisional ID location characters / 2 digits from owning force / 1 to 11 digits and 1 check letter \n Example: 22/49AB/49/1234C"
     >
       <div className={isValidAsn ? "" : "govuk-form-group--error"}>
         {!isValidAsn && (
           <p id="event-name-error" className="govuk-error-message">
-            <span className="govuk-visually-hidden">{"Error:"}</span> {"Invalid ASN format"}
+            <span className="govuk-visually-hidden">{"Error:"}</span> {"Enter ASN in the correct format"}
           </p>
         )}
         <AsnInputContainer>

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -116,7 +116,7 @@ export const AsnField = ({ stopLeavingFn }: AsnFieldProps) => {
     const asnFromClipboard = e.clipboardData.getData("text")
     setIsValidAsn(isAsnFormatValid(asnFromClipboard))
     setIsAsnChanged(true)
-    setAsnString(asn)
+    setAsnString(asnFromClipboard)
     amend("asn")(splitAsn(asnFromClipboard))
   }
 

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -1,6 +1,8 @@
 const intOrString = (input: string): string => (input.match(/^\d*$/) ? input : "")
 
 class Asn {
+  public asn: string
+
   public year: string | undefined
 
   public force: string | undefined
@@ -12,6 +14,7 @@ class Asn {
   public sequence: number | undefined
 
   constructor(asn: string) {
+    this.asn = asn
     const asnString = asn.replace(/\//g, "")
     if (asnString) {
       this.year = asnString.slice(0, 2)
@@ -37,6 +40,20 @@ class Asn {
     return `${this.year}${this.force}${this.unit}${this.system}${
       this.sequence ?? "".toString().padStart(11, "0")
     }${this.checkCharacter()}`
+  }
+
+  splitAsn() {
+    return this.asn
+      .replace(/\//g, "")
+      .split("")
+      .map((el, i) => {
+        if (i === 1 || i === 5 || i === 7) {
+          return `${el}/`
+        } else {
+          return el
+        }
+      })
+      .join("")
   }
 }
 

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -12,12 +12,13 @@ class Asn {
   public sequence: number | undefined
 
   constructor(asn: string) {
-    if (asn) {
-      this.year = asn.slice(0, 2)
-      this.force = asn.slice(2, 4)
-      this.unit = asn.slice(4, 6)
-      this.system = asn.slice(6, 8)
-      this.sequence = parseInt(asn.slice(8), 10)
+    const asnString = asn.replace(/\//g, "")
+    if (asnString) {
+      this.year = asnString.slice(0, 2)
+      this.force = asnString.slice(2, 4)
+      this.unit = asnString.slice(4, 6)
+      this.system = asnString.slice(6, 8)
+      this.sequence = parseInt(asnString.slice(8), 10)
     }
   }
 

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -15,7 +15,7 @@ class Asn {
 
   constructor(asn: string) {
     this.asn = asn
-    const asnString = asn.replace(/\//g, "")
+    const asnString = asn?.replace(/\//g, "")
     if (asnString) {
       this.year = asnString.slice(0, 2)
       this.force = asnString.slice(2, 4)

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -1,6 +1,12 @@
 const intOrString = (input: string): string => (input.match(/^\d*$/) ? input : "")
 
 class Asn {
+  static yearChars = 2
+
+  static forceAndUnitChars = 4
+
+  static systemChars = 2
+
   public asn: string
 
   public year: string | undefined
@@ -41,12 +47,6 @@ class Asn {
       this.sequence ?? "".toString().padStart(11, "0")
     }${this.checkCharacter()}`
   }
-
-  static yearChars = 2
-
-  static forceAndUnitChars = 4
-
-  static systemChars = 2
 
   static divideAsn = (asn: string): string => {
     if (!asn) {

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -42,7 +42,11 @@ class Asn {
     }${this.checkCharacter()}`
   }
 
-  static divideAsn = (asn: string) => {
+  static divideAsn = (asn: string): string => {
+    if (!asn) {
+      return ""
+    }
+
     return asn
       .replace(/\//g, "")
       .split("")

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -42,6 +42,12 @@ class Asn {
     }${this.checkCharacter()}`
   }
 
+  static yearChars = 2
+
+  static forceAndUnitChars = 4
+
+  static systemChars = 2
+
   static divideAsn = (asn: string): string => {
     if (!asn) {
       return ""
@@ -51,7 +57,11 @@ class Asn {
       .replace(/\//g, "")
       .split("")
       .map((el, i) => {
-        if (i === 1 || i === 5 || i === 7) {
+        if (
+          i === this.yearChars - 1 ||
+          i === this.yearChars + this.forceAndUnitChars - 1 ||
+          i === this.yearChars + this.forceAndUnitChars + this.systemChars - 1
+        ) {
           return `${el}/`
         } else {
           return el

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -42,8 +42,8 @@ class Asn {
     }${this.checkCharacter()}`
   }
 
-  splitAsn() {
-    return this.asn
+  static divideAsn = (asn: string) => {
+    return asn
       .replace(/\//g, "")
       .split("")
       .map((el, i) => {
@@ -54,6 +54,23 @@ class Asn {
         }
       })
       .join("")
+  }
+
+  static deleteAsn = (asn: string): string => {
+    switch (asn.length) {
+      case 11:
+        asn = asn.substring(0, 10)
+        break
+      case 8:
+        asn = asn.substring(0, 7)
+        break
+      case 3:
+        asn = asn.substring(0, 2)
+        break
+      default:
+        break
+    }
+    return asn
   }
 }
 

--- a/src/utils/isAsnFormatValid.test.ts
+++ b/src/utils/isAsnFormatValid.test.ts
@@ -1,0 +1,33 @@
+import isAsnFormatValid from "./isAsnFormatValid"
+
+describe("isAsnFormatValid", () => {
+  it("should return true when ASN is valid", () => {
+    const result = isAsnFormatValid("1101ZD0100000410836V")
+    expect(result).toBe(true)
+  })
+
+  it("should return true when ASN has slashes and is valid", () => {
+    const result = isAsnFormatValid("11/01ZD/01/00000410836V")
+    expect(result).toBe(true)
+  })
+
+  it("should return false when ASN has invalid check letter", () => {
+    const result = isAsnFormatValid("1101ZD0100000448754J")
+    expect(result).toBe(false)
+  })
+
+  it("should return true when ASN has valid check letter", () => {
+    const result = isAsnFormatValid("1101ZD0100000448754K")
+    expect(result).toBe(true)
+  })
+
+  it("Should return true when shortform ASN is valid", () => {
+    const result = isAsnFormatValid("1101ZD01410836V")
+    expect(result).toBe(true)
+  })
+
+  it("Should return true when shortform ASN is invalid", () => {
+    const result = isAsnFormatValid("1101ZD01410811A")
+    expect(result).toBe(false)
+  })
+})

--- a/src/utils/isAsnFormatValid.test.ts
+++ b/src/utils/isAsnFormatValid.test.ts
@@ -26,7 +26,7 @@ describe("isAsnFormatValid", () => {
     expect(result).toBe(true)
   })
 
-  it("Should return true when shortform ASN is invalid", () => {
+  it("Should return false when shortform ASN is invalid", () => {
     const result = isAsnFormatValid("1101ZD01410811A")
     expect(result).toBe(false)
   })

--- a/src/utils/isAsnFormatValid.ts
+++ b/src/utils/isAsnFormatValid.ts
@@ -1,9 +1,10 @@
 import Asn from "services/Asn"
 
 const isAsnFormatValid = (asn: string): boolean => {
+  const asnString = asn.replace(/\//g, "")
   const checkDigitRegex = `[A-HJ-NP-RT-Z]{1}`
-  const validFormat = new RegExp(`^\\d{2}[A-Z0-9]{6,7}\\d{11}${checkDigitRegex}$`).test(asn)
-  const validCheckDigit = new Asn(asn).checkCharacter() === asn?.slice(-1)
+  const validFormat = new RegExp(`^\\d{2}[A-Z0-9]{6,7}\\d{11}${checkDigitRegex}$`).test(asnString)
+  const validCheckDigit = new Asn(asnString).checkCharacter() === asnString?.slice(-1)
   return validFormat && validCheckDigit
 }
 

--- a/src/utils/isAsnFormatValid.ts
+++ b/src/utils/isAsnFormatValid.ts
@@ -2,8 +2,11 @@ import Asn from "services/Asn"
 
 const isAsnFormatValid = (asn: string): boolean => {
   const asnString = asn.replace(/\//g, "")
-  const checkDigitRegex = `[A-HJ-NP-RT-Z]{1}`
-  const validFormat = new RegExp(`^\\d{2}[A-Z0-9]{6,7}\\d{11}${checkDigitRegex}$`).test(asnString)
+  const year = `\\d{2}`
+  const forceAndUnit = `[A-Z0-9]{6,7}`
+  const sequence = `\\d{1,11}`
+  const checkLetterRegex = `[A-HJ-NP-RT-Z]{1}`
+  const validFormat = new RegExp(`^${year}${forceAndUnit}${sequence}${checkLetterRegex}$`).test(asnString)
   const validCheckDigit = new Asn(asnString).checkCharacter() === asnString?.slice(-1)
   return validFormat && validCheckDigit
 }

--- a/src/utils/isAsnFormatValid.ts
+++ b/src/utils/isAsnFormatValid.ts
@@ -1,7 +1,7 @@
 import Asn from "services/Asn"
 
 const isAsnFormatValid = (asn: string): boolean => {
-  const asnString = asn.replace(/\//g, "")
+  const asnString = asn?.replace(/\//g, "")
   const year = `\\d{2}`
   const forceAndUnit = `[A-Z0-9]{6,7}`
   const sequence = `\\d{1,11}`


### PR DESCRIPTION
User story - https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-1465

Features added:
- Divide ASN into sections when the user enters it into the ASN field, for example: 11/01ZD/01/00000448754K.
- Divide ASN into sections when user pastes ASN in the ASN field
- Remove divisions (slashes) when user copies ASN from the ASN field
- Allow users to provide shorter version of ASN
- Display a checkmark icon next to the input box when the typed ASN is in a valid format.

**Screenshots:**
**Longer version:**
<img width="1019" alt="Screenshot 2024-05-23 at 10 56 29 AM" src="https://github.com/ministryofjustice/bichard7-next-ui/assets/31739633/03f68f2c-39c1-479e-9f3b-6b346bac6cad">
**Shorter version:**
<img width="1019" alt="Screenshot 2024-05-23 at 10 57 14 AM" src="https://github.com/ministryofjustice/bichard7-next-ui/assets/31739633/d22a782f-221d-459d-8006-dcd95e18376d">
**Error:**
<img width="1019" alt="Screenshot 2024-05-23 at 10 56 39 AM" src="https://github.com/ministryofjustice/bichard7-next-ui/assets/31739633/f81117df-637d-4f02-bf76-14b02fdce359">
