### PR TITLE
Bugfix: Resolution status badge

### DIFF
--- a/src/features/CourtCaseDetails/Header.tsx
+++ b/src/features/CourtCaseDetails/Header.tsx
@@ -14,10 +14,10 @@ import { DisplayFullCourtCase } from "types/display/CourtCases"
 import { isLockedByCurrentUser } from "utils/caseLocks"
 import { gdsLightGrey, gdsMidGrey, textPrimary } from "utils/colours"
 import Form from "../../components/Form"
-import { ResolutionStatus } from "../../types/ResolutionStatus"
 import ResolutionStatusBadge from "../CourtCaseList/tags/ResolutionStatusBadge"
 import { ButtonContainer, LockedTagContainer, StyledButton, StyledSecondaryButton } from "./Header.styles"
 import LockStatusTag from "./LockStatusTag"
+import getResolutionStatus from "../../utils/getResolutionStatus"
 
 interface Props {
   canReallocate: boolean
@@ -32,18 +32,6 @@ const getUnlockPath = (courtCase: DisplayFullCourtCase): URLSearchParams => {
     params.set("unlockTrigger", courtCase.errorId?.toString())
   }
   return params
-}
-
-const getResolutionStatus = (courtCase: DisplayFullCourtCase): ResolutionStatus | undefined => {
-  if (courtCase.errorStatus === "Submitted") {
-    return "Submitted"
-  } else if (
-    (courtCase.errorStatus === "Resolved" && courtCase.triggerStatus === "Resolved") ||
-    (!courtCase.errorStatus && courtCase.triggerStatus === "Resolved") ||
-    (!courtCase.triggerStatus && courtCase.errorStatus === "Resolved")
-  ) {
-    return "Resolved"
-  }
 }
 
 const Header: React.FC<Props> = ({ canReallocate }: Props) => {
@@ -80,9 +68,7 @@ const Header: React.FC<Props> = ({ canReallocate }: Props) => {
         </Heading>
         <Heading as="h2" size="MEDIUM">
           {courtCase.defendantName}
-          {getResolutionStatus(courtCase) ? (
-            <ResolutionStatusBadge resolutionStatus={getResolutionStatus(courtCase) || "Unresolved"} />
-          ) : null}
+          {<ResolutionStatusBadge resolutionStatus={getResolutionStatus(courtCase)} />}
           <Badge
             isRendered={caseIsViewOnly}
             label="View only"

--- a/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
@@ -9,6 +9,7 @@ import { CaseDetailsRow } from "./CaseDetailsRow/CaseDetailsRow"
 import { ExceptionsLockTag, ExceptionsReasonCell } from "./ExceptionsColumns"
 import { ExtraReasonRow } from "./ExtraReasonRow"
 import { TriggersLockTag, TriggersReasonCell } from "./TriggersColumns"
+import getResolutionStatus from "../../../utils/getResolutionStatus"
 
 interface Props {
   courtCase: DisplayPartialCourtCase
@@ -30,8 +31,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
     errorReport,
     triggerLockedByUsername,
     triggerLockedByUserFullName,
-    triggers,
-    errorStatus
+    triggers
   } = courtCase
 
   const { basePath, query } = useRouter()
@@ -96,7 +96,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
         courtCase={courtCase}
         reasonCell={exceptionsReasonCell || triggersReasonCell}
         lockTag={exceptionsLockTag || triggersLockTag}
-        resolutionStatus={errorStatus ?? "Unresolved"}
+        resolutionStatus={getResolutionStatus(courtCase)}
         previousPath={previousPath}
       />
       {exceptionsLockTag && triggersLockTag && triggersReasonCell && (

--- a/src/utils/getResolutionStatus.test.ts
+++ b/src/utils/getResolutionStatus.test.ts
@@ -1,0 +1,21 @@
+import { DisplayPartialCourtCase } from "../types/display/CourtCases"
+import getResolutionStatus from "./getResolutionStatus"
+
+describe("getResolutionStatus", () => {
+  it.each([
+    { errorStatus: "Submitted", resolutionTimestamp: null, expectedResolutionStatus: "Submitted" },
+    { errorStatus: "Resolved", resolutionTimestamp: new Date(), expectedResolutionStatus: "Resolved" },
+    { errorStatus: null, resolutionTimestamp: new Date(), expectedResolutionStatus: "Resolved" },
+    { errorStatus: null, resolutionTimestamp: null, expectedResolutionStatus: "Unresolved" },
+    { errorStatus: "Resolved", resolutionTimestamp: null, expectedResolutionStatus: "Unresolved" }
+  ])(
+    "generates resolution status $expectedResolutionStatus when resolutionTimestamp is $resolutionTimestamp and errorStatus is $errorStatus",
+    (test) => {
+      const courtCase = {
+        errorStatus: test.errorStatus,
+        resolutionTimestamp: test.resolutionTimestamp
+      } as unknown as DisplayPartialCourtCase
+      expect(getResolutionStatus(courtCase)).toEqual(test.expectedResolutionStatus)
+    }
+  )
+})

--- a/src/utils/getResolutionStatus.ts
+++ b/src/utils/getResolutionStatus.ts
@@ -1,0 +1,7 @@
+import { ResolutionStatus } from "../types/ResolutionStatus"
+import { DisplayFullCourtCase, DisplayPartialCourtCase } from "../types/display/CourtCases"
+
+const getResolutionStatus = (courtCase: DisplayFullCourtCase | DisplayPartialCourtCase): ResolutionStatus =>
+  courtCase.errorStatus === "Submitted" ? "Submitted" : courtCase.resolutionTimestamp ? "Resolved" : "Unresolved"
+
+export default getResolutionStatus


### PR DESCRIPTION
### Context
The case list page incorrectly displays the resolved status when a case is partially resolved because the status badge is generated from exception status and not from the overall case resolution status.

### Changes
- Use the same logic that is implemented on the case details page