### PR TITLE
add typography.ts file to store font types

### DIFF
--- a/src/components/EditableFields/ErrorMessage.styles.tsx
+++ b/src/components/EditableFields/ErrorMessage.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components"
 import { gdsRed } from "utils/colours"
 import Image from "next/image"
+import { gdsTransport, arial, sansSerif } from "utils/typography"
 
 const ErrorMessageContainer = styled.div`
   display: flex;
@@ -8,7 +9,7 @@ const ErrorMessageContainer = styled.div`
   margin-top: 1rem;
 `
 const Message = styled.span`
-  font-family: "GDS Transport", arial, sans-serif;
+  font-family: ${gdsTransport}, ${arial}, ${sansSerif};
   font-size: 20px;
   color: ${gdsRed};
 `

--- a/src/components/EditableFields/SuccessMessage.styles.tsx
+++ b/src/components/EditableFields/SuccessMessage.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components"
 import { gdsGreen } from "utils/colours"
+import { gdsTransport, arial, sansSerif } from "utils/typography"
 
 const SuccessMessageContainer = styled.div`
   display: flex;
@@ -7,7 +8,7 @@ const SuccessMessageContainer = styled.div`
   margin-top: 1rem;
 `
 const Message = styled.span`
-  font-family: "GDS Transport", arial, sans-serif;
+  font-family: ${gdsTransport}, ${arial}, ${sansSerif};
   font-size: 20px;
   color: ${gdsGreen};
 `

--- a/src/components/FeedbackHeaderLinks.styles.tsx
+++ b/src/components/FeedbackHeaderLinks.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components"
 import { gdsBlack } from "utils/colours"
+import { nta, arial, sansSerif } from "utils/typography"
 
 const LinksRow = styled.div`
   display: flex;
@@ -15,7 +16,7 @@ const SkipLink = styled.button`
   cursor: pointer;
   background: transparent;
   border: none;
-  font-family: "nta", Arial, sans-serif;
+  font-family: ${nta}, ${arial}, ${sansSerif};
   font-size: 1em;
   position: relative;
   line-height: 1.25;

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -1,0 +1,6 @@
+const gdsTransport = "GDS Transport"
+const arial = "arial"
+const sansSerif = "sans-serif"
+const nta = "nta"
+
+export { gdsTransport, arial, sansSerif, nta }


### PR DESCRIPTION
created typography.ts file to store font names. This makes them globally available, eliminating the need to be hardcoded  