### PR TITLE
Fix ASN field entering/deleting chars with forward slashes

### DIFF
--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
@@ -235,7 +235,6 @@ describe("ASN", () => {
     cy.get("input#asn").clear()
     cy.get("input#asn").type("1101ZD01448754K")
     cy.get("input#asn").should("have.value", "11/01ZD/01/448754K")
-
     cy.get("input#asn").then(($el) => ($el[0] as unknown as HTMLInputElement).setSelectionRange(5, 5))
     cy.get("input#asn").type("{backspace}")
     cy.get("input#asn").should("have.prop", "selectionStart", 4)
@@ -258,9 +257,6 @@ describe("ASN", () => {
     cy.get("input#asn").clear()
     cy.get("input#asn").type("1101Z01448754K")
     cy.get("input#asn").should("have.value", "11/01Z0/14/48754K")
-
-    // 11/01Z60/14/48754K
-
     cy.get("input#asn").then(($el) => ($el[0] as unknown as HTMLInputElement).setSelectionRange(5, 5))
     cy.get("input#asn").type("D")
     cy.get("input#asn").should("have.prop", "selectionStart", 6)

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
@@ -218,6 +218,40 @@ describe("ASN", () => {
     })
   })
 
+  it("Should be able to edit ASN field if HO100321 is raised", () => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        errorCount: 1,
+        errorLockedByUsername: "GeneralHandler"
+      }
+    ])
+
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("#asn").clear()
+    cy.get("#asn").type("1101ZD0100000448754K")
+
+    cy.get("button").contains("Submit exception(s)").click()
+
+    cy.contains(
+      "Are you sure you want to submit the amended details to the PNC and mark the exception(s) as resolved?"
+    ).should("exist")
+    cy.get("button").contains("Submit exception(s)").click()
+
+    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
+    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
+
+    verifyUpdatedMessage({
+      expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
+      updatedMessageNotHaveContent: ["<br7:ArrestSummonsNumber>AAAAAAAAAAAAAAAAAAAA</br7:ArrestSummonsNumber>"],
+      updatedMessageHaveContent: ["<br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>"]
+    })
+  })
+
   it("Should keep the cursor in right place in the input field when the character from the middle is deleted", () => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [
@@ -260,40 +294,6 @@ describe("ASN", () => {
     cy.get("input#asn").then(($el) => ($el[0] as unknown as HTMLInputElement).setSelectionRange(5, 5))
     cy.get("input#asn").type("D")
     cy.get("input#asn").should("have.prop", "selectionStart", 6)
-  })
-
-  it("Should be able to edit ASN field if HO100321 is raised", () => {
-    cy.task("clearCourtCases")
-    cy.task("insertCourtCasesWithFields", [
-      {
-        orgForPoliceFilter: "01",
-        hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
-        updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
-        errorCount: 1,
-        errorLockedByUsername: "GeneralHandler"
-      }
-    ])
-
-    loginAndVisit("/bichard/court-cases/0")
-
-    cy.get("#asn").clear()
-    cy.get("#asn").type("1101ZD0100000448754K")
-
-    cy.get("button").contains("Submit exception(s)").click()
-
-    cy.contains(
-      "Are you sure you want to submit the amended details to the PNC and mark the exception(s) as resolved?"
-    ).should("exist")
-    cy.get("button").contains("Submit exception(s)").click()
-
-    cy.contains("GeneralHandler: Portal Action: Update Applied. Element: asn. New Value: 1101ZD0100000448754K")
-    cy.contains("GeneralHandler: Portal Action: Resubmitted Message.")
-
-    verifyUpdatedMessage({
-      expectedCourtCase: { errorId: 0, errorStatus: "Submitted" },
-      updatedMessageNotHaveContent: ["<br7:ArrestSummonsNumber>AAAAAAAAAAAAAAAAAAAA</br7:ArrestSummonsNumber>"],
-      updatedMessageHaveContent: ["<br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>"]
-    })
   })
 
   it("Should divide ASN into sections when user types or pastes asn into the input field ", () => {

--- a/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
+++ b/cypress/e2e/case-details/handle-triggers-and-exceptions/edit-fields-with-exceptions/edit-asn.cy.ts
@@ -218,6 +218,54 @@ describe("ASN", () => {
     })
   })
 
+  it("Should keep the cursor in right place in the input field when the character from the middle is deleted", () => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        errorCount: 1,
+        errorLockedByUsername: "GeneralHandler"
+      }
+    ])
+
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("input#asn").clear()
+    cy.get("input#asn").type("1101ZD01448754K")
+    cy.get("input#asn").should("have.value", "11/01ZD/01/448754K")
+
+    cy.get("input#asn").then(($el) => ($el[0] as unknown as HTMLInputElement).setSelectionRange(5, 5))
+    cy.get("input#asn").type("{backspace}")
+    cy.get("input#asn").should("have.prop", "selectionStart", 4)
+  })
+
+  it("Should keep the cursor in right place in the input field when the character is added in the middle", () => {
+    cy.task("clearCourtCases")
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "01",
+        hearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        updatedHearingOutcome: AsnExceptionHO100321.hearingOutcomeXml,
+        errorCount: 1,
+        errorLockedByUsername: "GeneralHandler"
+      }
+    ])
+
+    loginAndVisit("/bichard/court-cases/0")
+
+    cy.get("input#asn").clear()
+    cy.get("input#asn").type("1101Z01448754K")
+    cy.get("input#asn").should("have.value", "11/01Z0/14/48754K")
+
+    // 11/01Z60/14/48754K
+
+    cy.get("input#asn").then(($el) => ($el[0] as unknown as HTMLInputElement).setSelectionRange(5, 5))
+    cy.get("input#asn").type("D")
+    cy.get("input#asn").should("have.prop", "selectionStart", 6)
+  })
+
   it("Should be able to edit ASN field if HO100321 is raised", () => {
     cy.task("clearCourtCases")
     cy.task("insertCourtCasesWithFields", [

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -32,6 +32,7 @@ export const AsnField = () => {
 
   const asnInputRef = useRef<HTMLInputElement>(null)
 
+  // Do **not** add Tab to this list. It will break accessibility!
   const disabledKeys = useMemo(
     () => [
       "ArrowLeft",

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -4,11 +4,16 @@ import EditableFieldTableRow from "components/EditableFields/EditableFieldTableR
 import ErrorMessage from "components/EditableFields/ErrorMessage"
 import { useCourtCase } from "context/CourtCaseContext"
 import { useCurrentUser } from "context/CurrentUserContext"
-import { KeyboardEvent, useState } from "react"
+import { ChangeEvent, KeyboardEvent, useLayoutEffect, useMemo, useRef, useState } from "react"
 import Asn from "services/Asn"
 import isAsnFormatValid from "utils/exceptions/isAsnFormatValid"
 import isAsnException from "utils/exceptions/isException/isAsnException"
 import { AsnInput } from "./AsnField.styles"
+
+type Selection = {
+  start: number | null
+  end: number | null
+}
 
 export const AsnField = () => {
   const { courtCase, amendments, amend } = useCourtCase()
@@ -22,26 +27,97 @@ export const AsnField = () => {
   const [isValidAsn, setIsValidAsn] = useState<boolean>(isAsnFormatValid(amendedAsn))
   const [isSavedAsn, setIsSavedAsn] = useState<boolean>(false)
   const [asnChanged, setAsnChanged] = useState<boolean>(false)
+  const [selection, setSelection] = useState<Selection>()
   const [key, setKey] = useState<string>("")
 
+  const asnInputRef = useRef<HTMLInputElement>(null)
+
+  const disabledKeys = useMemo(
+    () => [
+      "ArrowLeft",
+      "ArrowRight",
+      "ArrowUp",
+      "ArrowDown",
+      "MetaLeft",
+      "MetaRight",
+      "ControlLeft",
+      "ControlRight",
+      "AltLeft",
+      "AltRight",
+      "ShiftLeft",
+      "ShiftRight",
+      "Delete"
+    ],
+    []
+  )
+
+  useLayoutEffect(() => {
+    if (!selection) {
+      return
+    }
+
+    // Handles if we delete the first character. Stops the cursor from going to the end of the input.
+    if (selection.start === 0 && selection.end === 0 && key === "Backspace") {
+      asnInputRef?.current?.setSelectionRange(0, 0)
+      return
+    }
+
+    // Handles selecting all and press Backspace.
+    if (selection.start === null || selection.end === null) {
+      return
+    }
+
+    // Handles jumping the `/` as the user types.
+    if (
+      Asn.divideAsn(amendedAsn).split("")[selection.start] === "/" &&
+      key !== "Backspace" &&
+      !disabledKeys.includes(key)
+    ) {
+      asnInputRef?.current?.setSelectionRange(selection.start + 1, selection.end + 1)
+      return
+    }
+
+    // Handles jumping the `/` if we're using Backspace (deleting) input.
+    if (
+      Asn.divideAsn(amendedAsn).split("")[selection.start - 1] === "/" &&
+      key === "Backspace" &&
+      !disabledKeys.includes(key)
+    ) {
+      asnInputRef?.current?.setSelectionRange(selection.start - 1, selection.end - 1)
+      return
+    }
+
+    // Tracks the position on Backspace
+    if (key === "Backspace" && asnInputRef?.current?.selectionStart !== 1) {
+      asnInputRef?.current?.setSelectionRange(selection.start, selection.end)
+      return
+    }
+
+    // Tracks the movement of the cursor on change.
+    asnInputRef?.current?.setSelectionRange(selection.start, selection.end)
+  }, [selection, amendedAsn, key, disabledKeys])
+
   const handleOnKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.code === "Backspace") {
+    if (e.code === "Backspace" || disabledKeys.includes(e.code)) {
       setKey(e.code)
     } else {
       setKey("")
     }
+
+    if (disabledKeys.includes("Space")) {
+      e.preventDefault()
+    }
+
+    const { selectionStart, selectionEnd } = e.currentTarget
+    setSelection({ start: selectionStart, end: selectionEnd })
   }
 
-  const handleAsnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const inputAsnValue = e.target.value.toUpperCase()
+  const handleAsnChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { value: inputAsnValue, selectionStart, selectionEnd } = e.target
 
-    if (key === "Backspace") {
-      const asnWithSlashes = Asn.divideAsn(inputAsnValue)
-      amend("asn")(Asn.deleteAsn(asnWithSlashes).replace(/\//g, ""))
-    } else {
-      const asnWithoutSlashes = inputAsnValue.replace(/\//g, "")
-      amend("asn")(asnWithoutSlashes)
-    }
+    amend("asn")(inputAsnValue.toUpperCase().replace(/\//g, ""))
+
+    setSelection({ start: selectionStart, end: selectionEnd })
     setAsnChanged(true)
     setIsSavedAsn(false)
     setIsValidAsn(isAsnFormatValid(inputAsnValue))
@@ -58,9 +134,6 @@ export const AsnField = () => {
     isAsnException(courtCase.aho.Exceptions) &&
     currentUser.featureFlags?.exceptionsEnabled
 
-  const asn =
-    amendedAsn.includes("/") || (amendedAsn.length <= 2 && key === "Backspace") ? amendedAsn : Asn.divideAsn(amendedAsn)
-
   return (
     <EditableFieldTableRow
       className={"asn-row"}
@@ -75,11 +148,12 @@ export const AsnField = () => {
       <div>
         <div>
           <AsnInput
+            ref={asnInputRef}
             className={`asn-input`}
             id={"asn"}
             name={"asn"}
             onChange={handleAsnChange}
-            value={asn}
+            value={Asn.divideAsn(amendedAsn.toUpperCase())}
             error={!isValidAsn}
             onKeyDown={handleOnKeyDown}
             onCopy={handleOnCopy}

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -98,6 +98,15 @@ export const AsnField = () => {
     asnInputRef?.current?.setSelectionRange(selection.start, selection.end)
   }, [selection, amendedAsn, key, disabledKeys])
 
+  const amendAsn = (asn: string, selectionStart: number | null, selectionEnd: number | null) => {
+    amend("asn")(asn.toUpperCase().replace(/\//g, ""))
+
+    setSelection({ start: selectionStart, end: selectionEnd })
+    setAsnChanged(true)
+    setIsSavedAsn(false)
+    setIsValidAsn(isAsnFormatValid(asn.toUpperCase()))
+  }
+
   const handleOnKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.code === "Backspace" || disabledKeys.includes(e.code)) {
       setKey(e.code)
@@ -111,15 +120,6 @@ export const AsnField = () => {
 
     const { selectionStart, selectionEnd } = e.currentTarget
     setSelection({ start: selectionStart, end: selectionEnd })
-  }
-
-  const amendAsn = (asn: string, selectionStart: number | null, selectionEnd: number | null) => {
-    amend("asn")(asn.toUpperCase().replace(/\//g, ""))
-
-    setSelection({ start: selectionStart, end: selectionEnd })
-    setAsnChanged(true)
-    setIsSavedAsn(false)
-    setIsValidAsn(isAsnFormatValid(asn.toUpperCase()))
   }
 
   const handleAsnChange = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -4,7 +4,7 @@ import EditableFieldTableRow from "components/EditableFields/EditableFieldTableR
 import ErrorMessage from "components/EditableFields/ErrorMessage"
 import { useCourtCase } from "context/CourtCaseContext"
 import { useCurrentUser } from "context/CurrentUserContext"
-import { ChangeEvent, KeyboardEvent, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { ChangeEvent, ClipboardEvent, KeyboardEvent, useLayoutEffect, useMemo, useRef, useState } from "react"
 import Asn from "services/Asn"
 import isAsnFormatValid from "utils/exceptions/isAsnFormatValid"
 import isAsnException from "utils/exceptions/isException/isAsnException"
@@ -113,15 +113,25 @@ export const AsnField = () => {
     setSelection({ start: selectionStart, end: selectionEnd })
   }
 
-  const handleAsnChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    const { value: inputAsnValue, selectionStart, selectionEnd } = e.target
-
-    amend("asn")(inputAsnValue.toUpperCase().replace(/\//g, ""))
+  const amendAsn = (asn: string, selectionStart: number | null, selectionEnd: number | null) => {
+    amend("asn")(asn.toUpperCase().replace(/\//g, ""))
 
     setSelection({ start: selectionStart, end: selectionEnd })
     setAsnChanged(true)
     setIsSavedAsn(false)
-    setIsValidAsn(isAsnFormatValid(inputAsnValue))
+    setIsValidAsn(isAsnFormatValid(asn.toUpperCase()))
+  }
+
+  const handleAsnChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { value: inputAsnValue, selectionStart, selectionEnd } = e.target
+    amendAsn(inputAsnValue, selectionStart, selectionEnd)
+  }
+
+  const handleOnPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    const asnFromClipboard = e.clipboardData.getData("text")
+    const asnFromClipboardWithSlashes = Asn.divideAsn(asnFromClipboard)
+    amendAsn(asnFromClipboard, asnFromClipboardWithSlashes.length, asnFromClipboardWithSlashes.length)
   }
 
   const handleOnCopy = () => {
@@ -157,6 +167,7 @@ export const AsnField = () => {
             value={Asn.divideAsn(amendedAsn.toUpperCase())}
             error={!isValidAsn}
             onKeyDown={handleOnKeyDown}
+            onPaste={handleOnPaste}
             onCopy={handleOnCopy}
             onCut={handleOnCopy}
           />

--- a/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
+++ b/src/features/CourtCaseDetails/Tabs/Panels/EditableFields/AsnField.tsx
@@ -105,7 +105,7 @@ export const AsnField = () => {
       setKey("")
     }
 
-    if (disabledKeys.includes("Space")) {
+    if (e.code === "Space") {
       e.preventDefault()
     }
 

--- a/src/services/Asn.ts
+++ b/src/services/Asn.ts
@@ -69,23 +69,6 @@ class Asn {
       })
       .join("")
   }
-
-  static deleteAsn = (asn: string): string => {
-    switch (asn.length) {
-      case 11:
-        asn = asn.substring(0, 10)
-        break
-      case 8:
-        asn = asn.substring(0, 7)
-        break
-      case 3:
-        asn = asn.substring(0, 2)
-        break
-      default:
-        break
-    }
-    return asn
-  }
 }
 
 export default Asn


### PR DESCRIPTION
### Issues:

- When a user typed the whole ASN and then decided to amend a character in the middle, the cursor would jump to the end with every attempt.
- When a user pastes the ASN into the field, the cursor moves a few characters back in the input field.

### Solution:

- Now, we keep track of the cursor position and keep it in place.