### PR TITLE
Only display unresolved exceptions/triggers in case list

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -142,8 +142,13 @@ export default defineConfig({
           return true
         },
 
-        insertException(params: { caseId: number; exceptionCode: string; errorReport?: string }) {
-          return insertException(params.caseId, params.exceptionCode, params.errorReport)
+        insertException(params: {
+          caseId: number
+          exceptionCode: string
+          errorReport?: string
+          errorStatus?: ResolutionStatus
+        }) {
+          return insertException(params.caseId, params.exceptionCode, params.errorReport, params.errorStatus)
         },
 
         async getCourtCaseById(params: { caseId: number }) {

--- a/cypress/e2e/case-list/filter-cases/persistAppliedFilters.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/persistAppliedFilters.cy.ts
@@ -1,4 +1,4 @@
-import { loginAndVisit } from "../../support/helpers"
+import { loginAndVisit } from "../../../support/helpers"
 
 describe("Persist applied filters", () => {
   beforeEach(() => {

--- a/cypress/e2e/case-list/filter-cases/persistSearchPanel.cy.ts
+++ b/cypress/e2e/case-list/filter-cases/persistSearchPanel.cy.ts
@@ -1,4 +1,4 @@
-import { loginAndVisit } from "../../support/helpers"
+import { loginAndVisit } from "../../../support/helpers"
 
 beforeEach(() => {
   cy.task("clearCourtCases")

--- a/cypress/e2e/case-list/header.cy.ts
+++ b/cypress/e2e/case-list/header.cy.ts
@@ -1,4 +1,4 @@
-import { loginAndVisit } from "../support/helpers"
+import { loginAndVisit } from "../../support/helpers"
 
 describe("Home", () => {
   context("720p resolution", () => {

--- a/cypress/e2e/case-list/index.cy.ts
+++ b/cypress/e2e/case-list/index.cy.ts
@@ -360,5 +360,66 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100310 (2)")
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100322").should("not.exist")
     })
+
+    it("Should only display trigger reason when the triggers are not resolved", () => {
+      cy.task("insertCourtCasesWithFields", [
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Unresolved",
+          exceptionStatus: "Unresolved",
+          errorReason: "",
+          errorReport: ""
+        },
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Resolved",
+          exceptionStatus: "Unresolved",
+          errorReason: "",
+          errorReport: ""
+        }
+      ])
+
+      cy.task("insertTriggers", {
+        caseId: 0,
+        triggers: [
+          {
+            triggerId: 0,
+            triggerCode: TriggerCode.TRPR0001,
+            status: "Unresolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          },
+          {
+            triggerId: 1,
+            triggerCode: TriggerCode.TRPR0002,
+            status: "Resolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          }
+        ]
+      })
+      cy.task("insertTriggers", {
+        caseId: 1,
+        triggers: [
+          {
+            triggerId: 2,
+            triggerCode: TriggerCode.TRPR0003,
+            status: "Unresolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          },
+          {
+            triggerId: 3,
+            triggerCode: TriggerCode.TRPR0004,
+            status: "Resolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          }
+        ]
+      })
+
+      loginAndVisit()
+
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0001")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0002").should("not.exist")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0003")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0004").should("not.exist")
+    })
   })
 })

--- a/cypress/e2e/case-list/index.cy.ts
+++ b/cypress/e2e/case-list/index.cy.ts
@@ -496,4 +496,44 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0002")
     })
   })
+
+  it("Should display triggers only once when resolved exceptions are not displayed", () => {
+    cy.task("insertCourtCasesWithFields", [
+      {
+        orgForPoliceFilter: "011111",
+        errorStatus: "Resolved",
+        triggerStatus: "Unresolved",
+        errorReason: "",
+        errorReport: "",
+        errorResolvedBy: "GeneralHandler",
+        triggerResolvedBy: "GeneralHandler"
+      }
+    ])
+    cy.task("insertTriggers", {
+      caseId: 0,
+      triggers: [
+        {
+          triggerId: 0,
+          triggerCode: TriggerCode.TRPR0001,
+          status: "Unresolved",
+          createdAt: new Date("2022-07-09T10:22:34.000Z")
+        }
+      ]
+    })
+    cy.task("insertTriggers", {
+      caseId: 0,
+      triggers: [
+        {
+          triggerId: 1,
+          triggerCode: TriggerCode.TRPR0002,
+          status: "Unresolved",
+          createdAt: new Date("2022-07-09T10:22:34.000Z")
+        }
+      ]
+    })
+
+    loginAndVisit()
+
+    cy.get("tr").not(":first").get("td:nth-child(7)").find(".trigger-description").should("have.length", 2)
+  })
 })

--- a/cypress/e2e/case-list/index.cy.ts
+++ b/cypress/e2e/case-list/index.cy.ts
@@ -317,5 +317,48 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0010 - Conditional bail")
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0015 - Personal details changed")
     })
+
+    it("Should only display error reason when the exceptions are not resolved", () => {
+      cy.task("insertCourtCasesWithFields", [
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Unresolved",
+          triggerStatus: "Unresolved",
+          errorReason: "",
+          errorReport: ""
+        },
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Resolved",
+          triggerStatus: "Unresolved",
+          errorReason: "",
+          errorReport: ""
+        }
+      ])
+
+      cy.task("insertException", {
+        caseId: 0,
+        exceptionCode: "HO100310",
+        errorReport: "HO100310||ds:OffenceReasonSequence",
+        errorStatus: "Unresolved"
+      })
+      cy.task("insertException", {
+        caseId: 0,
+        exceptionCode: "HO100310",
+        errorReport: "HO100310||ds:OffenceReasonSequence",
+        errorStatus: "Unresolved"
+      })
+      cy.task("insertException", {
+        caseId: 1,
+        exceptionCode: "HO100322",
+        errorReport: "HO100322||ds:OrganisationUnitCode",
+        errorStatus: "Resolved"
+      })
+
+      loginAndVisit()
+
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100310 (2)")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100322").should("not.exist")
+    })
   })
 })

--- a/cypress/e2e/case-list/index.cy.ts
+++ b/cypress/e2e/case-list/index.cy.ts
@@ -318,7 +318,7 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0015 - Personal details changed")
     })
 
-    it("Should only display error reason when the exceptions are not resolved", () => {
+    it("Should only display error reason when the exceptions are not resolved (showing unresolved cases by default)", () => {
       cy.task("insertCourtCasesWithFields", [
         {
           orgForPoliceFilter: "011111",
@@ -420,6 +420,80 @@ describe("Case list", () => {
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0002").should("not.exist")
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0003")
       cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0004").should("not.exist")
+    })
+
+    it("Should display resolved reason when the exceptions are resolved and filtering resolved cases", () => {
+      cy.task("insertCourtCasesWithFields", [
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Resolved",
+          triggerStatus: "Resolved",
+          errorReason: "",
+          errorReport: "",
+          errorResolvedBy: "GeneralHandler",
+          triggerResolvedBy: "GeneralHandler"
+        },
+        {
+          orgForPoliceFilter: "011111",
+          errorStatus: "Resolved",
+          triggerStatus: "Resolved",
+          errorReason: "",
+          errorReport: "",
+          errorResolvedBy: "GeneralHandler",
+          triggerResolvedBy: "GeneralHandler"
+        }
+      ])
+
+      cy.task("insertException", {
+        caseId: 0,
+        exceptionCode: "HO100310",
+        errorReport: "HO100310||ds:OffenceReasonSequence",
+        errorStatus: "Resolved"
+      })
+      cy.task("insertException", {
+        caseId: 0,
+        exceptionCode: "HO100310",
+        errorReport: "HO100310||ds:OffenceReasonSequence",
+        errorStatus: "Resolved"
+      })
+      cy.task("insertException", {
+        caseId: 1,
+        exceptionCode: "HO100322",
+        errorReport: "HO100322||ds:OrganisationUnitCode",
+        errorStatus: "Resolved"
+      })
+
+      cy.task("insertTriggers", {
+        caseId: 0,
+        triggers: [
+          {
+            triggerId: 0,
+            triggerCode: TriggerCode.TRPR0001,
+            status: "Resolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          }
+        ]
+      })
+      cy.task("insertTriggers", {
+        caseId: 1,
+        triggers: [
+          {
+            triggerId: 1,
+            triggerCode: TriggerCode.TRPR0002,
+            status: "Resolved",
+            createdAt: new Date("2022-07-09T10:22:34.000Z")
+          }
+        ]
+      })
+
+      loginAndVisit()
+      cy.get(`label[for="resolved"]`).click()
+      cy.get("button[id=search]").click()
+
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100310 (2)")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("HO100322")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0001")
+      cy.get("tr").not(":first").get("td:nth-child(7)").contains("TRPR0002")
     })
   })
 })

--- a/cypress/e2e/case-list/index.cy.ts
+++ b/cypress/e2e/case-list/index.cy.ts
@@ -1,8 +1,8 @@
 import TriggerCode from "bichard7-next-data-latest/dist/types/TriggerCode"
-import { TestTrigger } from "../../test/utils/manageTriggers"
-import a11yConfig from "../support/a11yConfig"
-import { loginAndVisit } from "../support/helpers"
-import logAccessibilityViolations from "../support/logAccessibilityViolations"
+import { TestTrigger } from "../../../test/utils/manageTriggers"
+import a11yConfig from "../../support/a11yConfig"
+import { loginAndVisit } from "../../support/helpers"
+import logAccessibilityViolations from "../../support/logAccessibilityViolations"
 
 describe("Case list", () => {
   beforeEach(() => {

--- a/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
@@ -26,6 +26,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
 }: Props) => {
   const {
     errorId,
+    errorStatus,
     errorLockedByUsername,
     errorLockedByUserFullName,
     errorReport,
@@ -58,7 +59,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
     const filteredExceptions = Object.fromEntries(
       Object.entries(exceptions).filter(([error]) => query.reasonCodes?.includes(error))
     )
-    exceptionsReasonCell = (
+    exceptionsReasonCell = errorStatus === "Unresolved" && (
       <ExceptionsReasonCell exceptionCounts={query.reasonCodes ? filteredExceptions : exceptions} />
     )
     exceptionsLockTag = (

--- a/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
@@ -52,6 +52,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
 
   const hasTriggers = triggers.length > 0
   const hasExceptions = !!errorReport
+  const displayExceptions = (query.state === "Resolved" && errorStatus === "Resolved") || errorStatus === "Unresolved"
 
   let exceptionsReasonCell, exceptionsLockTag, triggersReasonCell, triggersLockTag
   if (hasExceptions && currentUser.hasAccessTo[Permission.Exceptions]) {
@@ -59,7 +60,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
     const filteredExceptions = Object.fromEntries(
       Object.entries(exceptions).filter(([error]) => query.reasonCodes?.includes(error))
     )
-    exceptionsReasonCell = errorStatus === "Unresolved" && (
+    exceptionsReasonCell = displayExceptions && (
       <ExceptionsReasonCell exceptionCounts={query.reasonCodes ? filteredExceptions : exceptions} />
     )
     exceptionsLockTag = (

--- a/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
+++ b/src/features/CourtCaseList/CourtCaseListEntry/CourtCaseListEntry.tsx
@@ -52,10 +52,10 @@ const CourtCaseListEntry: React.FC<Props> = ({
 
   const hasTriggers = triggers.length > 0
   const hasExceptions = !!errorReport
-  const displayExceptions = (query.state === "Resolved" && errorStatus === "Resolved") || errorStatus === "Unresolved"
 
   let exceptionsReasonCell, exceptionsLockTag, triggersReasonCell, triggersLockTag
   if (hasExceptions && currentUser.hasAccessTo[Permission.Exceptions]) {
+    const displayExceptions = (query.state === "Resolved" && errorStatus === "Resolved") || errorStatus === "Unresolved"
     const exceptions = groupErrorsFromReport(errorReport)
     const filteredExceptions = Object.fromEntries(
       Object.entries(exceptions).filter(([error]) => query.reasonCodes?.includes(error))
@@ -63,7 +63,7 @@ const CourtCaseListEntry: React.FC<Props> = ({
     exceptionsReasonCell = displayExceptions && (
       <ExceptionsReasonCell exceptionCounts={query.reasonCodes ? filteredExceptions : exceptions} />
     )
-    exceptionsLockTag = (
+    exceptionsLockTag = displayExceptions && (
       <ExceptionsLockTag
         errorLockedByUsername={errorLockedByUsername}
         errorLockedByFullName={errorLockedByUserFullName}

--- a/test/utils/manageExceptions.ts
+++ b/test/utils/manageExceptions.ts
@@ -6,11 +6,11 @@ export default async (
   caseId: number,
   exceptionCode: string,
   errorReport?: string,
-  exceptionResolved?: ResolutionStatus,
+  errorStatus?: ResolutionStatus,
   username?: string
 ): Promise<boolean> => {
   const dataSource = await getDataSource()
-
+  const isExceptionResolved = errorStatus === "Resolved"
   await dataSource
     .createQueryBuilder()
     .update(CourtCase)
@@ -21,9 +21,9 @@ export default async (
         errorReport: () =>
           `(CASE WHEN (error_report = '') THEN '${errorReport}' ELSE error_report || ', ' || '${errorReport}' END)`
       }),
-      errorResolvedBy: exceptionResolved === "Resolved" ? username ?? "BichardForce03" : null,
-      errorResolvedTimestamp: exceptionResolved === "Resolved" ? new Date() : null,
-      errorStatus: exceptionResolved ?? "Unresolved"
+      errorResolvedBy: isExceptionResolved ? username ?? "BichardForce03" : null,
+      errorResolvedTimestamp: isExceptionResolved ? new Date() : null,
+      errorStatus: errorStatus ?? "Unresolved"
     })
     .where("errorId = :id", { id: caseId })
     .execute()


### PR DESCRIPTION
### Context
Users found it confusing that exceptions are displayed even when the exception status is resolved. Once the exception is resolved, the exception code should no longer appear anywhere, whether it's in the reason column of the case list or the exceptions panel within the case.

### Changes
- Move cypess tests into relevant folders 
- Display exceptions only when the exceptions are unresolved(by default case list showing unresolved cases)
- Display resolved exceptions in the reason column when the resolved filter is applied