### PR TITLE
Make disposals collapsible 

### DIFF
--- a/cypress/component/PncDetails.cy.tsx
+++ b/cypress/component/PncDetails.cy.tsx
@@ -104,7 +104,7 @@ describe("PNC details", () => {
     cy.get("#disposal-duration").contains("Y999").should("exist")
     cy.get("#disposal-monetary-value").contains("1000").should("exist")
     cy.get("#disposal-units-fined").should("not.exist")
-    cy.get(".disposal-text").click()
+    cy.get("summary").first().click()
     cy.get(".disposal-text").contains("This is a dummy text").should("exist")
   })
 

--- a/cypress/component/PncDetails.cy.tsx
+++ b/cypress/component/PncDetails.cy.tsx
@@ -308,4 +308,89 @@ describe("PNC details", () => {
     cy.get(".pnc-offence").eq(0).should("exist")
     cy.get(".pnc-offence").eq(1).should("not.exist")
   })
+
+  it("Displays message 'No disposals' where disposals have empty array", () => {
+    const pncQueryData = {
+      forceStationCode: "01ZD",
+      checkName: "LEBOWSKI",
+      pncId: "2021/0000006A",
+      courtCases: [
+        {
+          courtCaseReference: "21/2732/000006N",
+          offences: [
+            {
+              offence: {
+                acpoOffenceCode: "5:5:5:1",
+                cjsOffenceCode: "TH68001",
+                title: "Theft from the person of another",
+                sequenceNumber: 1
+              },
+              disposals: []
+            }
+          ],
+          crimeOffenceReference: ""
+        }
+      ]
+    }
+
+    const courtCase = {
+      aho: {
+        PncQuery: pncQueryData,
+        PncQueryDate: "2024-07-10T00:00:00.000Z"
+      }
+    } as unknown as DisplayFullCourtCase
+
+    cy.mount(
+      <CurrentUserContext.Provider value={{ currentUser }}>
+        <CourtCaseContext.Provider value={[{ courtCase, amendments: {}, savedAmendments: {} }, () => {}]}>
+          <PncDetails />
+        </CourtCaseContext.Provider>
+      </CurrentUserContext.Provider>
+    )
+
+    cy.get(".no-disposals-message").should("exist")
+    cy.get(".no-disposals-message").contains("No disposals")
+  })
+
+  it("Displays message 'No disposals' where disposals are undefined", () => {
+    const pncQueryData = {
+      forceStationCode: "01ZD",
+      checkName: "LEBOWSKI",
+      pncId: "2021/0000006A",
+      courtCases: [
+        {
+          courtCaseReference: "21/2732/000006N",
+          offences: [
+            {
+              offence: {
+                acpoOffenceCode: "5:5:5:1",
+                cjsOffenceCode: "TH68001",
+                title: "Theft from the person of another",
+                sequenceNumber: 1
+              }
+            }
+          ],
+          crimeOffenceReference: ""
+        }
+      ]
+    }
+
+    const courtCase = {
+      aho: {
+        PncQuery: pncQueryData,
+        PncQueryDate: "2024-07-10T00:00:00.000Z"
+      }
+    } as unknown as DisplayFullCourtCase
+
+    cy.mount(
+      <CurrentUserContext.Provider value={{ currentUser }}>
+        <CourtCaseContext.Provider value={[{ courtCase, amendments: {}, savedAmendments: {} }, () => {}]}>
+          <PncDetails />
+        </CourtCaseContext.Provider>
+      </CurrentUserContext.Provider>
+    )
+
+    cy.get(".no-disposals-message").should("exist")
+    cy.get(".no-disposals-message").contains("No disposals")
+  })
 })

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.styles.tsx
@@ -1,10 +1,9 @@
+import { Details } from "govuk-react"
 import styled from "styled-components"
-import { gdsLightGrey, textSecondary } from "utils/colours"
+import { textSecondary } from "utils/colours"
 
-const DisposalHeader = styled.div`
-  background-color: ${gdsLightGrey};
-  padding: 5px 0;
-  margin-bottom: 10px;
+const StyledDetails = styled(Details)`
+  margin-bottom: 20px;
 `
 
 const DisposalDetails = styled.div`
@@ -33,4 +32,4 @@ const DisposalText = styled.div`
   }
 `
 
-export { DisposalHeader, DisposalDetails, DisposalText }
+export { DisposalDetails, DisposalText, StyledDetails }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.styles.tsx
@@ -22,6 +22,8 @@ const DisposalDetails = styled.div`
 `
 
 const DisposalText = styled.div`
+  margin-top: 15px;
+
   .disposal-text {
     font-size: 16px;
   }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
@@ -1,8 +1,7 @@
-import { DisposalDetails, DisposalText } from "./Disposal.styles"
-import { Details } from "govuk-react"
+import ConditionalRender from "components/ConditionalRender"
 import { isEmpty } from "lodash"
 import { formatDisplayedDate } from "utils/date/formattedDate"
-import ConditionalRender from "components/ConditionalRender"
+import { DisposalDetails, DisposalText, StyledDetails } from "./Disposal.styles"
 
 interface DisposalProps {
   qtyDate?: string
@@ -17,7 +16,7 @@ interface DisposalProps {
 const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue, qualifiers, text }: DisposalProps) => {
   return (
     <div className="disposal">
-      <Details summary={`Disposal - ${type}`}>
+      <StyledDetails summary={`Disposal - ${type}`}>
         {/* <DisposalHeader className="govuk-heading-s">{`Disposal - ${type}`}</DisposalHeader> */}
         <DisposalDetails>
           <div id={"disposal-date"}>
@@ -56,7 +55,7 @@ const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue,
             // </Details>
           )}
         </DisposalText>
-      </Details>
+      </StyledDetails>
     </div>
   )
 }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
@@ -51,7 +51,7 @@ const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue,
             <span className="disposal-text-absent">{"No disposal text"}</span>
           ) : (
             // <Details className="disposal-text" summary={"Show details"}>
-            <p>{text}</p>
+            <p className="disposal-text">{text}</p>
             // </Details>
           )}
         </DisposalText>

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
@@ -1,4 +1,4 @@
-import { DisposalDetails, DisposalHeader, DisposalText } from "./Disposal.styles"
+import { DisposalDetails, DisposalText } from "./Disposal.styles"
 import { Details } from "govuk-react"
 import { isEmpty } from "lodash"
 import { formatDisplayedDate } from "utils/date/formattedDate"
@@ -17,44 +17,46 @@ interface DisposalProps {
 const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue, qualifiers, text }: DisposalProps) => {
   return (
     <div className="disposal">
-      <DisposalHeader className="govuk-heading-s">{`Disposal - ${type}`}</DisposalHeader>
-      <DisposalDetails>
-        <div id={"disposal-date"}>
-          <b>{"Date"}</b>
-          <div>{formatDisplayedDate(qtyDate ?? "", "dd/MM/yyyy HH:mm") || "-"}</div>
-        </div>
-        <div id={"disposal-qualifiers"}>
-          <b>{"Qualifiers"}</b>
-          <div>{qualifiers || "-"}</div>
-        </div>
-        <ConditionalRender isRendered={!!qtyDuration}>
-          <div id={"disposal-duration"}>
-            <b>{"Duration"}</b>
-            <div>{qtyDuration}</div>
+      <Details summary={`Disposal - ${type}`}>
+        {/* <DisposalHeader className="govuk-heading-s">{`Disposal - ${type}`}</DisposalHeader> */}
+        <DisposalDetails>
+          <div id={"disposal-date"}>
+            <b>{"Date"}</b>
+            <div>{formatDisplayedDate(qtyDate ?? "", "dd/MM/yyyy HH:mm") || "-"}</div>
           </div>
-        </ConditionalRender>
-        <ConditionalRender isRendered={!!qtyMonetaryValue}>
-          <div id={"disposal-monetary-value"}>
-            <b>{"Monetary value"}</b>
-            <div>{qtyMonetaryValue}</div>
+          <div id={"disposal-qualifiers"}>
+            <b>{"Qualifiers"}</b>
+            <div>{qualifiers || "-"}</div>
           </div>
-        </ConditionalRender>
-        <ConditionalRender isRendered={!!qtyUnitsFined}>
-          <div id={"disposal-units-fined"}>
-            <b>{"Units fined"}</b>
-            <div>{qtyUnitsFined}</div>
-          </div>
-        </ConditionalRender>
-      </DisposalDetails>
-      <DisposalText>
-        {isEmpty(text) ? (
-          <span className="disposal-text-absent">{"No disposal text"}</span>
-        ) : (
-          <Details className="disposal-text" summary={"Show details"}>
+          <ConditionalRender isRendered={!!qtyDuration}>
+            <div id={"disposal-duration"}>
+              <b>{"Duration"}</b>
+              <div>{qtyDuration}</div>
+            </div>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!qtyMonetaryValue}>
+            <div id={"disposal-monetary-value"}>
+              <b>{"Monetary value"}</b>
+              <div>{qtyMonetaryValue}</div>
+            </div>
+          </ConditionalRender>
+          <ConditionalRender isRendered={!!qtyUnitsFined}>
+            <div id={"disposal-units-fined"}>
+              <b>{"Units fined"}</b>
+              <div>{qtyUnitsFined}</div>
+            </div>
+          </ConditionalRender>
+        </DisposalDetails>
+        <DisposalText>
+          {isEmpty(text) ? (
+            <span className="disposal-text-absent">{"No disposal text"}</span>
+          ) : (
+            // <Details className="disposal-text" summary={"Show details"}>
             <p>{text}</p>
-          </Details>
-        )}
-      </DisposalText>
+            // </Details>
+          )}
+        </DisposalText>
+      </Details>
     </div>
   )
 }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/Disposal.tsx
@@ -17,7 +17,6 @@ const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue,
   return (
     <div className="disposal">
       <StyledDetails summary={`Disposal - ${type}`}>
-        {/* <DisposalHeader className="govuk-heading-s">{`Disposal - ${type}`}</DisposalHeader> */}
         <DisposalDetails>
           <div id={"disposal-date"}>
             <b>{"Date"}</b>
@@ -50,9 +49,7 @@ const Disposal = ({ qtyDate, qtyDuration, type, qtyUnitsFined, qtyMonetaryValue,
           {isEmpty(text) ? (
             <span className="disposal-text-absent">{"No disposal text"}</span>
           ) : (
-            // <Details className="disposal-text" summary={"Show details"}>
             <p className="disposal-text">{text}</p>
-            // </Details>
           )}
         </DisposalText>
       </StyledDetails>

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
@@ -107,6 +107,10 @@ const Offence = styled.div`
     }
   }
 
+  .no-disposals-message {
+    margin-top: 0;
+  }
+
   .adjudication {
     margin-bottom: 10px;
   }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
@@ -12,6 +12,7 @@ const CourtCaseHeaderContainer = styled.div`
   background-color: ${gdsLightGrey};
   border-bottom: solid 1px ${gdsMidGrey};
 
+  &.expanded,
   &:hover {
     background-color: #dfdfe0;
 
@@ -23,7 +24,6 @@ const CourtCaseHeaderContainer = styled.div`
 `
 const CourtCaseHeader = styled.div`
   width: 100%;
-
   margin: 15px 20px;
 `
 
@@ -97,4 +97,4 @@ const Offence = styled.div`
   }
 `
 
-export { CourtCase, CourtCaseHeaderContainer, CourtCaseHeader, CCR, CrimeOffenceReference, ChevronContainer, Offence }
+export { CCR, ChevronContainer, CourtCase, CourtCaseHeader, CourtCaseHeaderContainer, CrimeOffenceReference, Offence }

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
@@ -4,6 +4,10 @@ import { gdsLightGrey, gdsMidGrey } from "utils/colours"
 const CourtCase = styled.div`
   font-family: var(--default-font-family);
   font-size: var(--default-font-size);
+
+  &:not(:first-of-type) {
+    border-top: solid 1px ${gdsMidGrey};
+  }
 `
 const CourtCaseHeaderContainer = styled.div`
   display: flex;
@@ -60,9 +64,20 @@ const Offence = styled.div`
   display: flex;
   flex-direction: column;
   margin: 20px 20px;
-  padding-bottom: 12px;
   row-gap: 15px;
-  border-bottom: solid 1px ${gdsMidGrey};
+
+  hr {
+    border-top: solid 1px ${gdsMidGrey};
+    border-bottom: 0;
+    margin-left: -20px;
+    margin-right: -20px;
+    margin-top: -15px;
+    margin-bottom: 0;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   .heading {
     display: flex;
@@ -97,4 +112,21 @@ const Offence = styled.div`
   }
 `
 
-export { CCR, ChevronContainer, CourtCase, CourtCaseHeader, CourtCaseHeaderContainer, CrimeOffenceReference, Offence }
+const DisposalHeader = styled.h2`
+  background-color: ${gdsLightGrey};
+  margin: 0 -20px;
+  padding-left: 20px;
+  font-size: 24px;
+  line-height: 32px;
+`
+
+export {
+  CCR,
+  ChevronContainer,
+  CourtCase,
+  CourtCaseHeader,
+  CourtCaseHeaderContainer,
+  CrimeOffenceReference,
+  DisposalHeader,
+  Offence
+}

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.styles.tsx
@@ -8,7 +8,7 @@ const CourtCase = styled.div`
 const CourtCaseHeaderContainer = styled.div`
   display: flex;
   justify-content: space-between;
-
+  cursor: pointer;
   background-color: ${gdsLightGrey};
   border-bottom: solid 1px ${gdsMidGrey};
 

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
@@ -1,4 +1,5 @@
 import type { PncCourtCase } from "@moj-bichard7-developers/bichard7-next-core/core/types/PncQueryResult"
+import ConditionalRender from "components/ConditionalRender"
 import { useState } from "react"
 import Disposal from "./Disposal"
 import {
@@ -8,6 +9,7 @@ import {
   CourtCaseHeader,
   CourtCaseHeaderContainer,
   CrimeOffenceReference,
+  DisposalHeader,
   Offence
 } from "./PncCourtCaseAccordion.styles"
 import PncOffenceDetails from "./PncOffenceDetails"
@@ -53,7 +55,13 @@ const PncCourtCaseAccordion = ({
           {offences?.map(({ offence: details, adjudication, disposals }, i) => (
             <Offence className="pnc-offence" key={`${i}-${details.sequenceNumber}`}>
               <PncOffenceDetails details={details} adjudication={adjudication} />
-              {disposals?.map((d, j) => <Disposal key={`${j}-${d.type}`} {...d} />)}
+              <DisposalHeader>{"Disposals"}</DisposalHeader>
+              <ConditionalRender isRendered={disposals?.length !== undefined && disposals.length > 0}>
+                {disposals?.map((d, j) => <Disposal key={`${j}-${d.type}`} {...d} />)}
+              </ConditionalRender>
+              <ConditionalRender isRendered={offences.length !== i + 1}>
+                <hr />
+              </ConditionalRender>
             </Offence>
           ))}
         </div>

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
@@ -1,16 +1,16 @@
-import { useState } from "react"
 import type { PncCourtCase } from "@moj-bichard7-developers/bichard7-next-core/core/types/PncQueryResult"
+import { useState } from "react"
+import Disposal from "./Disposal"
 import {
   CCR,
+  ChevronContainer,
+  CourtCase,
+  CourtCaseHeader,
   CourtCaseHeaderContainer,
   CrimeOffenceReference,
-  CourtCase,
-  Offence,
-  CourtCaseHeader,
-  ChevronContainer
+  Offence
 } from "./PncCourtCaseAccordion.styles"
 import PncOffenceDetails from "./PncOffenceDetails"
-import Disposal from "./Disposal"
 
 interface PncCourtCaseAccordionProps {
   index: number
@@ -29,7 +29,7 @@ const PncCourtCaseAccordion = ({
   return (
     <CourtCase key={courtCaseReference}>
       <CourtCaseHeaderContainer
-        className="courtcase-toggle"
+        className={`courtcase-toggle ${isContentVisible ? "expanded" : ""}`}
         onClick={toggleContentVisibility}
         aria-expanded={isContentVisible}
         aria-controls={`CCR-${courtCaseReference}-content`}

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncCourtCaseAccordion.tsx
@@ -52,18 +52,25 @@ const PncCourtCaseAccordion = ({
 
       {isContentVisible && (
         <div id={`CCR-${courtCaseReference}-content`}>
-          {offences?.map(({ offence: details, adjudication, disposals }, i) => (
-            <Offence className="pnc-offence" key={`${i}-${details.sequenceNumber}`}>
-              <PncOffenceDetails details={details} adjudication={adjudication} />
-              <DisposalHeader>{"Disposals"}</DisposalHeader>
-              <ConditionalRender isRendered={disposals?.length !== undefined && disposals.length > 0}>
-                {disposals?.map((d, j) => <Disposal key={`${j}-${d.type}`} {...d} />)}
-              </ConditionalRender>
-              <ConditionalRender isRendered={offences.length !== i + 1}>
-                <hr />
-              </ConditionalRender>
-            </Offence>
-          ))}
+          {offences?.map(({ offence: details, adjudication, disposals }, i) => {
+            const hasDisposals = disposals?.length !== undefined && disposals.length > 0
+
+            return (
+              <Offence className="pnc-offence" key={`${i}-${details.sequenceNumber}`}>
+                <PncOffenceDetails details={details} adjudication={adjudication} />
+                <DisposalHeader>{"Disposals"}</DisposalHeader>
+                <ConditionalRender isRendered={!hasDisposals}>
+                  <p className={"no-disposals-message"}>{"No disposals"}</p>
+                </ConditionalRender>
+                <ConditionalRender isRendered={hasDisposals}>
+                  {disposals?.map((d, j) => <Disposal key={`${j}-${d.type}`} {...d} />)}
+                </ConditionalRender>
+                <ConditionalRender isRendered={offences.length !== i + 1}>
+                  <hr />
+                </ConditionalRender>
+              </Offence>
+            )
+          })}
         </div>
       )}
     </CourtCase>

--- a/src/features/CourtCaseDetails/Sidebar/PncDetails/PncDetails.styles.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/PncDetails/PncDetails.styles.tsx
@@ -9,7 +9,7 @@ const UpdatedDate = styled.div`
 `
 
 const PncQueryError = styled.div`
-  padding: 15px 20px;
+  padding: 30px 20px;
 `
 
 const CourtCases = styled.div`
@@ -17,4 +17,4 @@ const CourtCases = styled.div`
   overflow-y: scroll;
 `
 
-export { UpdatedDate, CourtCases, PncQueryError }
+export { CourtCases, PncQueryError, UpdatedDate }

--- a/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -101,13 +101,16 @@ const TriggersList = ({ onNavigate }: Props) => {
           </MarkCompleteGridCol>
         </GridRow>
       </ConditionalRender>
-      <LockStatus>
-        <LockStatusTag
-          isRendered={triggers.length > 0}
-          resolutionStatus={courtCase.triggerStatus}
-          lockName="Triggers"
-        />
-      </LockStatus>
+
+      <ConditionalRender isRendered={hasTriggers}>
+        <LockStatus>
+          <LockStatusTag
+            isRendered={triggers.length > 0}
+            resolutionStatus={courtCase.triggerStatus}
+            lockName="Triggers"
+          />
+        </LockStatus>
+      </ConditionalRender>
     </Form>
   )
 }

--- a/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
+++ b/src/features/CourtCaseDetails/Sidebar/TriggersList.tsx
@@ -71,7 +71,7 @@ const TriggersList = ({ onNavigate }: Props) => {
 
   return (
     <Form method="post" action={resolveTriggerUrl(selectedTriggerIds)} csrfToken={csrfToken}>
-      {triggers.length === 0 && "There are no triggers for this case."}
+      {!hasTriggers && "There are no triggers for this case."}
       <ConditionalRender isRendered={hasUnresolvedTriggers && !triggersLockedByAnotherUser}>
         <SelectAllTriggersGridRow id={"select-all-triggers"}>
           <GridCol>


### PR DESCRIPTION
* Reuse `hasTriggers` 
* Make the cursor a pointer when interacting with the Header of PNC details
* Use consistent white space for Triggers, Exceptions and PNC details when there's no data
* Match the design for PNC details panel
* Added a no disposals message